### PR TITLE
Add `pre_tasks` for updating the APT cache

### DIFF
--- a/deployment/ansible/app-servers.yml
+++ b/deployment/ansible/app-servers.yml
@@ -2,6 +2,10 @@
 - hosts: app-servers
   sudo: True
 
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "nyc-trees.common" }
 

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -2,6 +2,10 @@
 - hosts: services
   sudo: True
 
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "nyc-trees.common" }
 

--- a/deployment/ansible/tile-servers.yml
+++ b/deployment/ansible/tile-servers.yml
@@ -2,6 +2,10 @@
 - hosts: tile-servers
   sudo: True
 
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "nyc-trees.common" }
 


### PR DESCRIPTION
In order to prevent inconsistencies with package versions, try to start provisioning with a fresh APT cache.
