### PR TITLE
Add support for Graphite/Statsite

### DIFF
--- a/deployment/ansible/app-servers.yml
+++ b/deployment/ansible/app-servers.yml
@@ -8,5 +8,6 @@
 
   roles:
     - { role: "nyc-trees.common" }
+    - { role: "nyc-trees.collectd" }
 
     - { role: "azavea.pip" }

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,3 +4,11 @@ redis_port: 6379
 postgresql_port: 5432
 
 relp_port: 20514
+
+graphite_port: 2003
+
+statsite_port: 8125
+
+apache_port: 8080
+
+graphite_web_port: 8080

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -8,3 +8,7 @@ postgresql_host: "33.33.33.30"
 relp_host: "33.33.33.30"
 
 kibana_port: 8081
+
+graphite_host: "33.33.33.30"
+
+statsite_host: "33.33.33.30"

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -9,3 +9,5 @@ azavea.logstash,0.1.0
 azavea.relp,0.1.1
 azavea.kibana,0.1.0
 azavea.unzip,0.1.0
+azavea.graphite,0.2.0
+azavea.statsite,0.1.0

--- a/deployment/ansible/roles/nyc-trees.collectd/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.collectd/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.collectd" }

--- a/deployment/ansible/roles/nyc-trees.collectd/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.collectd/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Configure Collectd plugins
+  template: src={{ item }}.conf.j2 dest=/etc/collectd/collectd.conf.d/{{ item }}.conf
+  with_items:
+    - df
+    - syslog
+    - write_graphite
+  notify:
+    - Restart Collectd

--- a/deployment/ansible/roles/nyc-trees.collectd/templates/df.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.collectd/templates/df.conf.j2
@@ -1,0 +1,4 @@
+<Plugin df>
+	Device "/dev/sda1"
+	ReportInodes true
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.collectd/templates/syslog.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.collectd/templates/syslog.conf.j2
@@ -1,0 +1,3 @@
+<Plugin syslog>
+	LogLevel info
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.collectd/templates/write_graphite.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.collectd/templates/write_graphite.conf.j2
@@ -1,0 +1,8 @@
+<Plugin write_graphite>
+	<Carbon>
+		Host "{{ graphite_host }}"
+		Port "{{ graphite_port }}"
+		Prefix "collectd."
+		Protocol "tcp"
+	</Carbon>
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.collectd/vars/main.yml
+++ b/deployment/ansible/roles/nyc-trees.collectd/vars/main.yml
@@ -1,0 +1,11 @@
+collectd_load_plugins:
+  - syslog
+  - cpu
+  - df
+  - disk
+  - interface
+  - load
+  - memory
+  - processes
+  - write_graphite
+collectd_hostname: "{{ ansible_hostname }}"

--- a/deployment/ansible/roles/nyc-trees.graphite/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.graphite/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+- { role: "azavea.graphite", graphite_web_secret_key: "d41d8cd98f00b204e9800998ecf8gj23" }
+- { role: "azavea.statsite" }

--- a/deployment/ansible/roles/nyc-trees.graphite/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.graphite/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Configure Collectd plugins
+  template: src={{ item }}.conf.j2 dest=/etc/collectd/collectd.conf.d/{{ item }}.conf
+  with_items:
+    - apache
+    - df
+    - filecount
+    - memcached
+    - syslog
+    - tail
+    - write_graphite
+  notify:
+    - Restart Collectd

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/apache.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/apache.conf.j2
@@ -1,0 +1,7 @@
+<Plugin apache>
+	<Instance "graphite-web">
+		URL "http://127.0.0.1/server-status?auto"
+		VerifyPeer false
+		VerifyHost false
+	</Instance>
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/df.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/df.conf.j2
@@ -1,0 +1,4 @@
+<Plugin df>
+	Device "/dev/sda1"
+	ReportInodes true
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/filecount.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/filecount.conf.j2
@@ -1,0 +1,6 @@
+<Plugin filecount>
+	<Directory "/opt/graphite/storage/whisper">
+		Instance "whisper"
+		Name "*.wsp"
+	</Directory>
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/memcached.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/memcached.conf.j2
@@ -1,0 +1,4 @@
+<Plugin memcached>
+	Host "127.0.0.1"
+	Port "11211"
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/syslog.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/syslog.conf.j2
@@ -1,0 +1,3 @@
+<Plugin syslog>
+	LogLevel info
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/tail.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/tail.conf.j2
@@ -1,0 +1,209 @@
+<Plugin "tail">
+	# cache performance
+	<File "/opt/graphite/storage/log/webapp/cache.log">
+		Instance "graphite_web"
+		<Match>
+			Regex "Request-Cache hit "
+			DSType "CounterInc"
+			Type "counter"
+			Instance "request_cache_hit"
+		</Match>
+		<Match>
+			Regex "Request-Cache miss "
+			DSType "CounterInc"
+			Type "counter"
+			Instance "request_cache_miss"
+		</Match>
+		<Match>
+			Regex "CarbonLink creating a new socket "
+			DSType "CounterInc"
+			Type "counter"
+			Instance "socket_create_count"
+		</Match>
+		<Match>
+			Regex "CarbonLink cache-query request "
+			DSType "CounterInc"
+			Type "counter"
+			Instance "query_count"
+		</Match>
+		<Match>
+			Regex "CarbonLink set-metadata request "
+			DSType "CounterInc"
+			Type "counter"
+			Instance "set-metadata_count"
+		</Match>
+		<Match>
+			Regex "Data-Cache hit "
+			DSType "CounterInc"
+			Type "counter"
+			Instance "data_cache_hit"
+		</Match>
+		<Match>
+			Regex "Data-Cache miss "
+			DSType "CounterInc"
+			Type "counter"
+			Instance "data_cache_miss"
+		</Match>
+	</File>
+
+	# rendering performance
+	<File "/opt/graphite/storage/log/webapp/rendering.log">
+		Instance "graphite_web"
+
+		# PNG's
+		<Match>
+			Regex "Rendered PNG in ([0-9\.]+) seconds"
+			DSType "CounterInc"
+			Type "requests"
+			Instance "render_png_count"
+		</Match>
+		<Match>
+			Regex "Rendered PNG in ([0-9\.]+) seconds"
+			DSType "GaugeMin"
+			Type "response_time"
+			Instance "render_png_time_min"
+		</Match>
+		<Match>
+			Regex "Rendered PNG in ([0-9\.]+) seconds"
+			DSType "GaugeMax"
+			Type "response_time"
+			Instance "render_png_time_max"
+		</Match>
+		<Match>
+			Regex "Rendered PNG in ([0-9\.]+) seconds"
+			DSType "GaugeAverage"
+			Type "response_time"
+			Instance "render_png_time_avg"
+		</Match>
+
+		# pickle (carbonlink)
+		<Match>
+			Regex "Total pickle rendering time ([0-9\.]+)"
+			DSType "CounterInc"
+			Type "counter"
+			Instance "render_pickle_count"
+		</Match>
+		<Match>
+			Regex "Total pickle rendering time ([0-9\.]+)"
+			DSType "GaugeMin"
+			Type "response_time"
+			Instance "render_pickle_time_min"
+		</Match>
+		<Match>
+			Regex "Total pickle rendering time ([0-9\.]+)"
+			DSType "GaugeMax"
+			Type "response_time"
+			Instance "render_pickle_time_max"
+		</Match>
+		<Match>
+			Regex "Total pickle rendering time ([0-9\.]+)"
+			DSType "GaugeAverage"
+			Type "response_time"
+			Instance "render_pickle_time_avg"
+		</Match>
+
+		# rawData (json, csv, etc)
+		<Match>
+			Regex "Total rawData rendering time ([0-9\.]+)"
+			DSType "CounterInc"
+			Type "counter"
+			Instance "render_rawdata_count"
+		</Match>
+		<Match>
+			Regex "Total rawData rendering time ([0-9\.]+)"
+			DSType "GaugeMin"
+			Type "response_time"
+			Instance "render_rawdata_time_min"
+		</Match>
+		<Match>
+			Regex "Total rawData rendering time ([0-9\.]+)"
+			DSType "GaugeMax"
+			Type "response_time"
+			Instance "render_rawdata_time_max"
+		</Match>
+		<Match>
+			Regex "Total rawData rendering time ([0-9\.]+)"
+			DSType "GaugeAverage"
+			Type "response_time"
+			Instance "render_rawdata_time_avg"
+		</Match>
+
+		# total render time
+		<Match>
+			Regex "Total rendering time ([0-9\.]+) seconds"
+			DSType "CounterInc"
+			Type "counter"
+			Instance "total_render_count"
+		</Match>
+		<Match>
+			Regex "Total rendering time ([0-9\.]+) seconds"
+			DSType "GaugeMin"
+			Type "response_time"
+			Instance "total_render_time_min"
+		</Match>
+		<Match>
+			Regex "Total rendering time ([0-9\.]+) seconds"
+			DSType "GaugeMax"
+			Type "response_time"
+			Instance "total_render_time_max"
+		</Match>
+		<Match>
+			Regex "Total rendering time ([0-9\.]+) seconds"
+			DSType "GaugeAverage"
+			Type "response_time"
+			Instance "total_render_time_avg"
+		</Match>
+
+		# cached response time
+		<Match>
+			Regex "Returned cached response in ([0-9\.]+) seconds"
+			DSType "CounterInc"
+			Type "counter"
+			Instance "cached_response_time_count"
+		</Match>
+		<Match>
+			Regex "Returned cached response in ([0-9\.]+) seconds"
+			DSType "GaugeMin"
+			Type "response_time"
+			Instance "cached_response_time_min"
+		</Match>
+		<Match>
+			Regex "Returned cached response in ([0-9\.]+) seconds"
+			DSType "GaugeMax"
+			Type "response_time"
+			Instance "cached_response_time_max"
+		</Match>
+		<Match>
+			Regex "Returned cached response in ([0-9\.]+) seconds"
+			DSType "GaugeAverage"
+			Type "response_time"
+			Instance "cached_response_time_avg"
+		</Match>
+
+		# data retrieval time
+		<Match>
+			Regex "Retrieval of [^ ]+ took ([0-9\.]+)"
+			DSType "CounterInc"
+			Type "counter"
+			Instance "retrieval_count"
+		</Match>
+		<Match>
+			Regex "Retrieval of [^ ]+ took ([0-9\.]+)"
+			DSType "GaugeMin"
+			Type "response_time"
+			Instance "retrieval_time_min"
+		</Match>
+		<Match>
+			Regex "Retrieval of [^ ]+ took ([0-9\.]+)"
+			DSType "GaugeMax"
+			Type "response_time"
+			Instance "retrieval_time_max"
+		</Match>
+		<Match>
+			Regex "Retrieval of [^ ]+ took ([0-9\.]+)"
+			DSType "GaugeAverage"
+			Type "response_time"
+			Instance "retrieval_time_avg"
+		</Match>
+	</File>
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/write_graphite.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/write_graphite.conf.j2
@@ -1,0 +1,8 @@
+<Plugin write_graphite>
+	<Carbon>
+		Host "localhost"
+		Port "2003"
+		Prefix "collectd."
+		Protocol "tcp"
+	</Carbon>
+</Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/vars/main.yml
+++ b/deployment/ansible/roles/nyc-trees.graphite/vars/main.yml
@@ -1,0 +1,17 @@
+collectd_load_plugins:
+  - syslog
+  - apache
+  - cpu
+  - df
+  - disk
+  - entropy
+  - filecount
+  - interface
+  - load
+  - memcached
+  - memory
+  - processes
+  - swap
+  - tail
+  - write_graphite
+collectd_hostname: "{{ ansible_hostname }}"

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -13,3 +13,4 @@
     - { role: "azavea.redis" }
     - { role: "azavea.kibana" }
     - { role: "nyc-trees.logstash" }
+    - { role: "nyc-trees.graphite" }

--- a/deployment/ansible/tile-servers.yml
+++ b/deployment/ansible/tile-servers.yml
@@ -8,6 +8,7 @@
 
   roles:
     - { role: "nyc-trees.common" }
+    - { role: "nyc-trees.collectd" }
 
     - { role: "azavea.nodejs" }
     - { role: "azavea.mapnik" }


### PR DESCRIPTION
This changeset adds support for three different metrics collection tools:
- Collectd

Collectd is a lightweight system metrics (disk, memory, CPU) collection agent.
- Graphite

Graphite is made up of several things, but in general it is a time-series data store with dynamic graph generation capabilities.
- Statsite

Statsite is an implementation of StatsD in C. It aggregates incoming statistics and flushes them to a backend time-series data store (Graphite in this case).

All of these things are being added to the environment in order to accomplish something like this:

http://codeascraft.com/2011/02/15/measure-anything-measure-everything/

In order to view the Graphite Web UI, navigate to `http://localhost:8082` on the VM host. Also, standby for @jwalgran to determine what client will be used to feed Statsite/Graphite from Python.
