### PR TITLE
Add CloudFormation support via Troposphere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ target/
 deployment/ansible/roles/*
 !deployment/ansible/roles/nyc-trees.*
 
+# Troposphere
+deployment/troposphere/*.json
+
 # NodeJS / Browserify stuff
 node_modules/
 npm-debug.log

--- a/deployment/troposphere/Makefile
+++ b/deployment/troposphere/Makefile
@@ -1,0 +1,8 @@
+.DEFAULT: build
+.PHONY: build clean
+
+build:
+	@find . -name "*.py" | grep -v "utils" | xargs -I{} python {}
+
+clean:
+	@rm *.json

--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -1,0 +1,106 @@
+from troposphere import Template, Parameter, Ref
+from os.path import basename
+
+import template_utils as utils
+import troposphere.autoscaling as asg
+
+t = Template()
+
+t.add_version('2010-09-09')
+t.add_description('An application server stack for the nyc-trees project.')
+
+#
+# Parameters
+#
+keyname_param = t.add_parameter(Parameter(
+    'KeyName', Type='String', Default='nyc-trees-test',
+    Description='Name of an existing EC2 key pair'
+))
+
+notification_arn_param = t.add_parameter(Parameter(
+    'GlobalNotificationsARN', Type='String',
+    Description='Physical resource ID of an AWS::SNS::Topic for notifications'
+))
+
+app_server_ami_param = t.add_parameter(Parameter(
+    'AppServerAMI', Type='String', Default='ami-d87dc6b0',
+    Description='Application server AMI'
+))
+
+app_server_instance_profile_param = t.add_parameter(Parameter(
+    'AppServerInstanceProfile', Type='String',
+    Default=
+    'arn:aws:iam::900325299081:instance-profile/AppServerInstanceProfile',
+    Description='Physical resource ID of an AWS::IAM::Role for the '
+                'application servers'
+))
+
+app_server_instance_type_param = t.add_parameter(Parameter(
+    'AppServerInstanceType', Type='String', Default='t2.micro',
+    Description='Application server EC2 instance type',
+    AllowedValues=utils.EC2_INSTANCE_TYPES,
+    ConstraintDescription='must be a valid EC2 instance type.'
+))
+
+app_server_load_balancer = t.add_parameter(Parameter(
+    'elbAppServer', Type='String',
+    Description='Name of an AWS::ElasticLoadBalancing::LoadBalancer'
+))
+
+app_server_security_group = t.add_parameter(Parameter(
+    'sgAppServer', Type='String',
+    Description='Physical resource ID of an AWS::EC2::SecurityGroup'
+))
+
+app_server_subnets_param = t.add_parameter(Parameter(
+    'AppServerSubnets', Type='CommaDelimitedList',
+    Description='A list of subnets to associate with the application server '
+                'load balancer'
+))
+
+#
+# Resources
+#
+app_server_launch_config = t.add_resource(asg.LaunchConfiguration(
+    'lcAppServer',
+    ImageId=Ref(app_server_ami_param),
+    IamInstanceProfile=Ref(app_server_instance_profile_param),
+    InstanceType=Ref(app_server_instance_type_param),
+    KeyName=Ref(keyname_param),
+    SecurityGroups=[Ref(app_server_security_group)]
+))
+
+app_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
+    'asgAppServer',
+    AvailabilityZones=map(lambda x: 'us-east-1%s' % x,
+                          utils.EC2_AVAILABILITY_ZONES),
+    Cooldown=300,
+    DesiredCapacity=2,
+    HealthCheckGracePeriod=600,
+    HealthCheckType='ELB',
+    LaunchConfigurationName=Ref(app_server_launch_config),
+    LoadBalancerNames=[Ref(app_server_load_balancer)],
+    MaxSize=2,
+    MinSize=2,
+    NotificationConfiguration=asg.NotificationConfiguration(
+        TopicARN=Ref(notification_arn_param),
+        NotificationTypes=[
+            asg.EC2_INSTANCE_LAUNCH,
+            asg.EC2_INSTANCE_LAUNCH_ERROR,
+            asg.EC2_INSTANCE_TERMINATE,
+            asg.EC2_INSTANCE_TERMINATE_ERROR
+        ]
+    ),
+    VPCZoneIdentifier=Ref(app_server_subnets_param),
+    Tags=[asg.Tag('Name', 'AppServer', True)]
+))
+
+if __name__ == '__main__':
+    utils.validate_cloudformation_template(t.to_json())
+
+    file_name = basename(__file__).replace('.py', '.json')
+
+    with open(file_name, 'w') as f:
+        f.write(t.to_json())
+
+    print('Template validated and written to %s' % file_name)

--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -1,0 +1,150 @@
+from troposphere import Template, Parameter, Ref, Tags, Output, Join, GetAtt
+from os.path import basename
+
+import template_utils as utils
+import troposphere.rds as rds
+import troposphere.elasticache as ec
+
+t = Template()
+
+t.add_version('2010-09-09')
+t.add_description('A data store server stack for the nyc-trees project.')
+
+#
+# Parameters
+#
+keyname_param = t.add_parameter(Parameter(
+    'KeyName', Type='String', Default='nyc-trees-test',
+    Description='Name of an existing EC2 key pair'
+))
+
+notification_arn_param = t.add_parameter(Parameter(
+    'GlobalNotificationsARN', Type='String',
+    Description='Physical resource ID of an AWS::SNS::Topic for notifications'
+))
+
+database_server_instance_type_param = t.add_parameter(Parameter(
+    'DatabaseServerInstanceType', Type='String', Default='db.t2.micro',
+    Description='Database server RDS instance type',
+    AllowedValues=utils.RDS_INSTANCE_TYPES,
+    ConstraintDescription='must be a valid RDS instance type.'
+))
+
+database_server_master_username_param = t.add_parameter(Parameter(
+    'DatabaseServerMasterUsername', Type='String', Default='nyctrees',
+    Description='Database server master username'
+))
+
+database_server_master_password_param = t.add_parameter(Parameter(
+    'DatabaseServerMasterPassword', Type='String', Default='nyctrees',
+    NoEcho=True, Description='Database server master password'
+))
+
+cache_cluster_instance_type_param = t.add_parameter(Parameter(
+    'CacheClusterInstanceType', Type='String', Default='cache.m1.small',
+    Description='Cache cluster ElastiCache instances type',
+    AllowedValues=utils.ELASTICACHE_INSTANCE_TYPES,
+    ConstraintDescription='must be a valid ElastiCache instance type.'
+))
+
+database_server_security_group = t.add_parameter(Parameter(
+    'sgDatabaseServer', Type='String',
+    Description='Physical resource ID of an AWS::EC2::SecurityGroup'
+))
+
+cache_cluster_security_group = t.add_parameter(Parameter(
+    'sgCacheCluster', Type='String',
+    Description='Physical resource ID of an AWS::EC2::SecurityGroup'
+))
+
+
+data_store_server_subnets_param = t.add_parameter(Parameter(
+    'DataStoreServerSubnets', Type='CommaDelimitedList',
+    Description='A list of subnets to associate with the data store servers'
+))
+
+#
+# Resources
+#
+database_server_subnet_group = t.add_resource(rds.DBSubnetGroup(
+    "dbsngDatabaseServer",
+    DBSubnetGroupDescription='Private subnets for the RDS instances',
+    SubnetIds=Ref(data_store_server_subnets_param),
+    Tags=Tags(Name='dbsngDatabaseServer')
+))
+
+database_server_instance = t.add_resource(rds.DBInstance(
+    "DatabaseServer",
+    AllocatedStorage=20,
+    AllowMajorVersionUpgrade=False,
+    AutoMinorVersionUpgrade=True,
+    BackupRetentionPeriod=30,
+    DBInstanceClass=Ref(database_server_instance_type_param),
+    DBInstanceIdentifier='nyctrees-nyc-trees-database-server',
+    DBName='nyc_trees',
+    DBSubnetGroupName=Ref(database_server_subnet_group),
+    Engine='postgres',
+    EngineVersion='9.3.3',
+    MasterUsername=Ref(database_server_master_username_param),
+    MasterUserPassword=Ref(database_server_master_password_param),
+    MultiAZ=True,
+    PreferredBackupWindow='01:00-01:30',
+    PreferredMaintenanceWindow='mon:01:00-mon:01:30',  # 9PM ET
+    VPCSecurityGroups=[Ref(database_server_security_group)],
+    Tags=Tags(Name='DatabaseServer')
+))
+
+cache_cluster_subnet_group = t.add_resource(ec.SubnetGroup(
+    "ecsngCacheCluster",
+    Description='Private subnets for the ElastiCache instances',
+    SubnetIds=Ref(data_store_server_subnets_param)
+))
+
+cache_cluster_parameter_group = t.add_resource(ec.ParameterGroup(
+    'ecpgCacheCluster',
+    CacheParameterGroupFamily='redis2.8',
+    Description='Parameter group for the ElastiCache instances',
+    Properties={
+        "appendonly": "yes"
+    }
+))
+
+cache_cluster = t.add_resource(ec.CacheCluster(
+    'CacheCluster',
+    AutoMinorVersionUpgrade=True,
+    CacheNodeType=Ref(cache_cluster_instance_type_param),
+    CacheParameterGroupName=Ref(cache_cluster_parameter_group),
+    CacheSubnetGroupName=Ref(cache_cluster_subnet_group),
+    ClusterName='nyctrees',
+    Engine='redis',
+    EngineVersion='2.8.6',
+    NotificationTopicArn=Ref(notification_arn_param),
+    NumCacheNodes=1,
+    PreferredMaintenanceWindow='mon:01:00-mon:01:30',  # 9PM ET
+    VpcSecurityGroupIds=[Ref(cache_cluster_security_group)]
+))
+
+#
+# Outputs
+#
+t.add_output([
+    Output(
+        'DatabaseServerEndpoint',
+        Description='Database server endpoint',
+        Value=Join(':', [
+            GetAtt('DatabaseServer', 'Endpoint.Address'),
+            GetAtt('DatabaseServer', 'Endpoint.Port')
+        ])
+    ),
+    # CacheCluster endpoint output is not supported for Redis. :(
+])
+
+if __name__ == '__main__':
+    utils.validate_cloudformation_template(t.to_json())
+
+    file_name = basename(__file__).replace('.py', '.json')
+
+    with open(file_name, 'w') as f:
+        f.write(t.to_json())
+
+    print('Template validated and written to %s' % file_name)

--- a/deployment/troposphere/parameters/staging_app.json
+++ b/deployment/troposphere/parameters/staging_app.json
@@ -1,0 +1,34 @@
+[
+  {
+    "ParameterKey": "KeyName",
+    "ParameterValue": "nyc-trees-test"
+  },
+  {
+    "ParameterKey": "GlobalNotificationsARN",
+    "ParameterValue": "arn:aws:sns:us-east-1:900325299081:topicGlobalNotifications"
+  },
+  {
+    "ParameterKey": "AppServerAMI",
+    "ParameterValue": "ami-d87dc6b0"
+  },
+  {
+    "ParameterKey": "AppServerInstanceProfile",
+    "ParameterValue": "arn:aws:iam::900325299081:instance-profile/AppServerInstanceProfile"
+  },
+  {
+    "ParameterKey": "AppServerInstanceType",
+    "ParameterValue": "t2.micro"
+  },
+  {
+    "ParameterKey": "elbAppServer",
+    "ParameterValue": "elbAppServer"
+  },
+  {
+    "ParameterKey": "sgAppServer",
+    "ParameterValue": "sg-9fb5b6fa"
+  },
+  {
+    "ParameterKey": "AppServerSubnets",
+    "ParameterValue": "subnet-c6fb5bb1,subnet-c8ee2d91"
+  }
+]

--- a/deployment/troposphere/parameters/staging_data_store.json
+++ b/deployment/troposphere/parameters/staging_data_store.json
@@ -1,0 +1,38 @@
+[
+  {
+    "ParameterKey": "KeyName",
+    "ParameterValue": "nyc-trees-test"
+  },
+  {
+    "ParameterKey": "GlobalNotificationsARN",
+    "ParameterValue": "arn:aws:sns:us-east-1:900325299081:topicGlobalNotifications"
+  },
+  {
+    "ParameterKey": "DatabaseServerInstanceType",
+    "ParameterValue": "db.t2.micro"
+  },
+  {
+    "ParameterKey": "DatabaseServerMasterUsername",
+    "ParameterValue": "nyctrees"
+  },
+  {
+    "ParameterKey": "DatabaseServerMasterPassword",
+    "ParameterValue": "nyctrees"
+  },
+  {
+    "ParameterKey": "CacheClusterInstanceType",
+    "ParameterValue": "cache.m1.small"
+  },
+  {
+    "ParameterKey": "sgDatabaseServer",
+    "ParameterValue": "sg-c4dad8a1"
+  },
+  {
+    "ParameterKey": "sgCacheCluster",
+    "ParameterValue": "sg-c5dad8a0"
+  },
+  {
+    "ParameterKey": "DataStoreServerSubnets",
+    "ParameterValue": "subnet-c6fb5bb1,subnet-c8ee2d91"
+  }
+]

--- a/deployment/troposphere/parameters/staging_tiler.json
+++ b/deployment/troposphere/parameters/staging_tiler.json
@@ -1,0 +1,34 @@
+[
+  {
+    "ParameterKey": "KeyName",
+    "ParameterValue": "nyc-trees-test"
+  },
+  {
+    "ParameterKey": "GlobalNotificationsARN",
+    "ParameterValue": "arn:aws:sns:us-east-1:900325299081:topicGlobalNotifications"
+  },
+  {
+    "ParameterKey": "TileServerAMI",
+    "ParameterValue": "ami-d87dc6b0"
+  },
+  {
+    "ParameterKey": "TileServerInstanceProfile",
+    "ParameterValue": "arn:aws:iam::900325299081:instance-profile/TileServerInstanceProfile"
+  },
+  {
+    "ParameterKey": "TileServerInstanceType",
+    "ParameterValue": "t2.micro"
+  },
+  {
+    "ParameterKey": "elbTileServer",
+    "ParameterValue": "elbTileServer"
+  },
+  {
+    "ParameterKey": "sgTileServer",
+    "ParameterValue": "sg-9db5b6f8"
+  },
+  {
+    "ParameterKey": "TileServerSubnets",
+    "ParameterValue": "subnet-c6fb5bb1,subnet-c8ee2d91"
+  }
+]

--- a/deployment/troposphere/parameters/staging_vpc.json
+++ b/deployment/troposphere/parameters/staging_vpc.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey": "NotificationEmailAddress",
+    "ParameterValue": "hcastro@azavea.com"
+  },
+  {
+    "ParameterKey": "KeyName",
+    "ParameterValue": "nyc-trees-test"
+  },
+  {
+    "ParameterKey": "OfficeCIDR",
+    "ParameterValue": "216.158.51.82/32"
+  },
+  {
+    "ParameterKey": "NATInstanceType",
+    "ParameterValue": "t1.micro"
+  },
+  {
+    "ParameterKey": "BastionInstanceType",
+    "ParameterValue": "t2.micro"
+  },
+  {
+    "ParameterKey": "BastionHostAMI",
+    "ParameterValue": "ami-d87dc6b0"
+  }
+]

--- a/deployment/troposphere/requirements.txt
+++ b/deployment/troposphere/requirements.txt
@@ -1,0 +1,4 @@
+awscli==1.5.2
+boto==2.32.1
+requests==2.4.1
+troposphere==0.6.2

--- a/deployment/troposphere/template_utils.py
+++ b/deployment/troposphere/template_utils.py
@@ -1,0 +1,172 @@
+import csv
+import requests
+import boto
+import datetime
+
+from troposphere import Ref, Tags, ec2
+
+VPC_CIDR = '10.0.0.0/16'
+ALLOW_ALL_CIDR = '0.0.0.0/0'
+
+EC2_REGIONS = [
+    'us-east-1'
+]
+EC2_AVAILABILITY_ZONES = [
+    'a',
+    'b'
+]
+EC2_INSTANCE_TYPES = [
+    't1.micro',
+    't2.micro',
+    'm3.medium'
+]
+RDS_INSTANCE_TYPES = [
+    'db.t2.micro',
+    'db.m3.large'
+]
+ELASTICACHE_INSTANCE_TYPES = [
+    'cache.m1.small'
+]
+
+
+def get_ubuntu_daily_ami_mapping(arch='amd64', root_store='ebs',
+                                 virtualization='hvm'):
+    """Retrieves yesterday's daily Ubuntu AMI ID for each EC2_REGIONS
+
+    Arguments
+    :param arch: Architecture preference for the AMI
+    :param root_store: Root store preference for the AMI
+    :param virtualization: Virtualization type preference for the AMI
+    """
+    response = requests.get(
+        'http://cloud-images.ubuntu.com/query/trusty/server/daily.txt'
+    )
+
+    if response.status_code != 200:
+        raise Exception('Ubuntu Image ID Data not found.')
+
+    csv_data = response.text.strip().split('\n')
+    yesterdays_date = (datetime.datetime.now() -
+                       datetime.timedelta(days=1)).strftime("%Y%m%d")
+
+    def get_image_id(region):
+        for row in csv.reader(csv_data, delimiter='\t'):
+            criteria = [
+                region in row,
+                arch in row,
+                root_store in row,
+                virtualization in row,
+                yesterdays_date in row
+            ]
+
+            if all(criteria):
+                return row[7]
+
+        raise Exception('Could not find image ID for %s' % region)
+
+    return {region: {'AMI': get_image_id(region)} for region in EC2_REGIONS}
+
+
+def get_nat_ami_mapping():
+    """Retrieves the most recent NAT AMI ID for each EC2_REGIONS"""
+    def get_image_id(region):
+        c = boto.connect_ec2()
+        all_images = c.get_all_images(owners='amazon', filters={
+            'name': '*ami-vpc-nat*'
+        })
+
+        images = [i for i in all_images if 'beta' not in i.name]
+
+        return sorted(images, key=lambda i: i.name, reverse=True)[0].id
+
+    return {region: {'AMI': get_image_id(region)} for region in EC2_REGIONS}
+
+
+def create_route_table(template, name, vpc, **attrs):
+    """Creates a route table as part of an existing VPC
+
+    Arguments
+    :param template: An instance of troposphere.Template
+    :param name: A name for the route table
+    :param vpc: An instance of troposphere.ec2.VPC
+    :param **attrs: Additional arguments for troposphere.ec2.RouteTable
+    """
+    return template.add_resource(ec2.RouteTable(
+        name,
+        VpcId=Ref(vpc),
+        Tags=Tags(Name=name),
+        **attrs
+    ))
+
+
+def create_subnet(template, name, vpc, cidr_block, availability_zone):
+    """Creates a subnet as part of an existing VPC
+
+    Arguments
+    :param template: An instance of troposphere.Template
+    :param name: A name for the subnet
+    :param cidr_block: A CIDR block for the subnet
+    :param availability_zone: An availability zone for the subnet
+    """
+    return template.add_resource(ec2.Subnet(
+        name,
+        VpcId=Ref(vpc),
+        CidrBlock=cidr_block,
+        AvailabilityZone=availability_zone,
+        Tags=Tags(Name=name)
+    ))
+
+
+def create_route(template, name, route_table, cidr_block=None, **attrs):
+    """Creates a route as part of an existing route table
+
+    Arguments
+    :param template: An instance of troposphere.Template
+    :param name: A name for the route
+    :param route_table: An instance of troposphere.ec2.RouteTable
+    :param cidr_block: A CIDR block for the route
+    :param **attrs: Additional arguments for troposphere.ec2.route
+    """
+    cidr_block = cidr_block or ALLOW_ALL_CIDR
+    return template.add_resource(ec2.Route(
+        name,
+        RouteTableId=Ref(route_table),
+        DestinationCidrBlock=cidr_block,
+        **attrs
+    ))
+
+
+def create_security_group(template, name, description, vpc, ingress,
+                          egress, **attrs):
+    """Creates a security group
+
+    Arguments
+    :param template: An instance of troposphere.Template
+    :param name: A name for the security group
+    :param description: A description for the security group
+    :param vpc: An instance of troposphere.ec2.VPC
+    :param ingress: An array of troposphere.ec2.SecurityGroupRules
+    :param egress: An array of troposphere.ec2.SecurityGroupRules
+    :param **attrs: Additional arguments for troposphere.ec2.SecurityGroup
+    """
+    return template.add_resource(ec2.SecurityGroup(
+        name,
+        GroupDescription=description,
+        VpcId=Ref(vpc),
+        SecurityGroupIngress=ingress,
+        SecurityGroupEgress=egress,
+        Tags=Tags(Name=name),
+        **attrs
+    ))
+
+
+def validate_cloudformation_template(template_body):
+    """Validates the JSON of a CloudFormation template produced by Troposphere
+
+    Arguments
+    :param template_body: The string representation of CloudFormation template
+                          JSON
+    """
+    c = boto.connect_cloudformation()
+
+    return c.validate_template(template_body=template_body)

--- a/deployment/troposphere/tiler_template.py
+++ b/deployment/troposphere/tiler_template.py
@@ -1,0 +1,106 @@
+from troposphere import Template, Parameter, Ref
+from os.path import basename
+
+import template_utils as utils
+import troposphere.autoscaling as asg
+
+t = Template()
+
+t.add_version('2010-09-09')
+t.add_description('A tiler stack for the nyc-trees project.')
+
+#
+# Parameters
+#
+keyname_param = t.add_parameter(Parameter(
+    'KeyName', Type='String', Default='nyc-trees-test',
+    Description='Name of an existing EC2 key pair'
+))
+
+notification_arn_param = t.add_parameter(Parameter(
+    'GlobalNotificationsARN', Type='String',
+    Description='Physical resource ID of an AWS::SNS::Topic for notifications'
+))
+
+tile_server_ami_param = t.add_parameter(Parameter(
+    'TileServerAMI', Type='String', Default='ami-d87dc6b0',
+    Description='Tile server AMI'
+))
+
+tile_server_instance_profile_param = t.add_parameter(Parameter(
+    'TileServerInstanceProfile', Type='String',
+    Default=
+    'arn:aws:iam::900325299081:instance-profile/TileServerInstanceProfile',
+    Description='Physical resource ID of an AWS::IAM::Role for the '
+                'tile servers'
+))
+
+tile_server_instance_type_param = t.add_parameter(Parameter(
+    'TileServerInstanceType', Type='String', Default='t2.micro',
+    Description='Tile server EC2 instance type',
+    AllowedValues=utils.EC2_INSTANCE_TYPES,
+    ConstraintDescription='must be a valid EC2 instance type.'
+))
+
+tile_server_load_balancer = t.add_parameter(Parameter(
+    'elbTileServer', Type='String',
+    Description='Name of an AWS::ElasticLoadBalancing::LoadBalancer'
+))
+
+tile_server_security_group = t.add_parameter(Parameter(
+    'sgTileServer', Type='String',
+    Description='Physical resource ID of an AWS::EC2::SecurityGroup'
+))
+
+tile_server_subnets_param = t.add_parameter(Parameter(
+    'TileServerSubnets', Type='CommaDelimitedList',
+    Description='A list of subnets to associate with the tile server '
+                'load balancer'
+))
+
+#
+# Resources
+#
+tile_server_launch_config = t.add_resource(asg.LaunchConfiguration(
+    'lcTileServer',
+    ImageId=Ref(tile_server_ami_param),
+    IamInstanceProfile=Ref(tile_server_instance_profile_param),
+    InstanceType=Ref(tile_server_instance_type_param),
+    KeyName=Ref(keyname_param),
+    SecurityGroups=[Ref(tile_server_security_group)]
+))
+
+tile_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
+    'asgTileServer',
+    AvailabilityZones=map(lambda x: 'us-east-1%s' % x,
+                          utils.EC2_AVAILABILITY_ZONES),
+    Cooldown=300,
+    DesiredCapacity=2,
+    HealthCheckGracePeriod=600,
+    HealthCheckType='ELB',
+    LaunchConfigurationName=Ref(tile_server_launch_config),
+    LoadBalancerNames=[Ref(tile_server_load_balancer)],
+    MaxSize=2,
+    MinSize=2,
+    NotificationConfiguration=asg.NotificationConfiguration(
+        TopicARN=Ref(notification_arn_param),
+        NotificationTypes=[
+            asg.EC2_INSTANCE_LAUNCH,
+            asg.EC2_INSTANCE_LAUNCH_ERROR,
+            asg.EC2_INSTANCE_TERMINATE,
+            asg.EC2_INSTANCE_TERMINATE_ERROR
+        ]
+    ),
+    VPCZoneIdentifier=Ref(tile_server_subnets_param),
+    Tags=[asg.Tag('Name', 'TileServer', True)]
+))
+
+if __name__ == '__main__':
+    utils.validate_cloudformation_template(t.to_json())
+
+    file_name = basename(__file__).replace('.py', '.json')
+
+    with open(file_name, 'w') as f:
+        f.write(t.to_json())
+
+    print('Template validated and written to %s' % file_name)

--- a/deployment/troposphere/vpc_template.py
+++ b/deployment/troposphere/vpc_template.py
@@ -1,0 +1,479 @@
+from troposphere import Template, Parameter, Ref, FindInMap, Output, GetAtt, \
+    Join, Tags, ec2
+from os.path import basename
+
+import template_utils as utils
+import troposphere.sns as sns
+import troposphere.elasticloadbalancing as elb
+
+t = Template()
+
+t.add_version('2010-09-09')
+t.add_description('A VPC stack for the nyc-trees project.')
+
+#
+# Parameters
+#
+notificaiton_email = t.add_parameter(Parameter(
+    'NotificationEmailAddress', Type='String', Default='hcastro@azavea.com',
+    Description='Email address for global notifications'
+))
+
+keyname_param = t.add_parameter(Parameter(
+    'KeyName', Type='String', Default='nyc-trees-test',
+    Description='Name of an existing EC2 key pair'
+))
+
+office_cidr_param = t.add_parameter(Parameter(
+    'OfficeCIDR', Type='String', Default='216.158.51.82/32',
+    Description='CIDR notation of office IP addresses'
+))
+
+nat_instance_type_param = t.add_parameter(Parameter(
+    'NATInstanceType', Type='String', Default='t1.micro',
+    Description='NAT EC2 instance type',
+    AllowedValues=utils.EC2_INSTANCE_TYPES,
+    ConstraintDescription='must be a valid EC2 instance type.'
+))
+
+bastion_instance_type_param = t.add_parameter(Parameter(
+    'BastionInstanceType', Type='String', Default='t2.micro',
+    Description='Bastion EC2 instance type',
+    AllowedValues=utils.EC2_INSTANCE_TYPES,
+    ConstraintDescription='must be a valid EC2 instance type.'
+))
+
+bastion_host_ami_param = t.add_parameter(Parameter(
+    'BastionHostAMI', Type='String', Default='ami-d87dc6b0',
+    Description='Bastion host AMI'
+))
+
+#
+# Mappings
+#
+t.add_mapping('NATAMIMap', utils.get_nat_ami_mapping())
+
+#
+# VPC Resources
+#
+vpc = t.add_resource(ec2.VPC(
+    'NYCTreesVPC', CidrBlock=utils.VPC_CIDR, EnableDnsSupport=True,
+    EnableDnsHostnames=True,
+    Tags=Tags(Name='NYCTreesVPC')
+))
+
+gateway = t.add_resource(ec2.InternetGateway(
+    'InternetGateway', Tags=Tags(Name='InternetGateway')
+))
+
+gateway_attachment = t.add_resource(ec2.VPCGatewayAttachment(
+    'VPCGatewayAttachment', VpcId=Ref(vpc), InternetGatewayId=Ref(gateway)
+))
+
+public_route_table = utils.create_route_table(t, 'PublicRouteTable', vpc)
+
+utils.create_route(
+    t, 'PublicRoute', public_route_table, DependsOn=gateway_attachment.title,
+    GatewayId=Ref(gateway)
+)
+
+nat_security_group = utils.create_security_group(
+    t, 'sgNAT', 'Enables access to the NAT devices', vpc,
+    ingress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.ALLOW_ALL_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [22, 80, 443]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.ALLOW_ALL_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [80, 443]
+    ]
+)
+
+notification_topic = t.add_resource(sns.Topic(
+    'topicGlobalNotifications',
+    Subscription=[sns.Subscription(
+        Endpoint=Ref(notificaiton_email),
+        Protocol='email'
+    )],
+    TopicName='topicGlobalNotifications'
+))
+
+public_subnets = []
+private_subnets = []
+
+for index, availability_zone in enumerate(utils.EC2_AVAILABILITY_ZONES):
+    if index == 1:
+        index = 2
+
+    public_subnet = utils.create_subnet(
+        t, 'USEast1%sPublicSubnet' % availability_zone.upper(), vpc,
+        '10.0.%s.0/24' % index, 'us-east-1%s' % availability_zone
+    )
+
+    t.add_resource(ec2.SubnetRouteTableAssociation(
+        '%sPublicRouteTableAssociation' % public_subnet.title,
+        SubnetId=Ref(public_subnet),
+        RouteTableId=Ref(public_route_table)
+    ))
+
+    nat_device = t.add_resource(ec2.Instance(
+        'USEast1%sNATDevice' % availability_zone.upper(),
+        InstanceType=Ref(nat_instance_type_param),
+        KeyName=Ref(keyname_param),
+        SourceDestCheck=False,
+        ImageId=FindInMap('NATAMIMap', Ref('AWS::Region'), 'AMI'),
+        NetworkInterfaces=[
+            ec2.NetworkInterfaceProperty(
+                Description='ENI for NATDevice',
+                GroupSet=[Ref(nat_security_group)],
+                SubnetId=Ref(public_subnet),
+                AssociatePublicIpAddress=True,
+                DeviceIndex=0,
+                DeleteOnTermination=True,
+            )
+        ],
+        Tags=Tags(Name='USEast1%sNATInstance' % availability_zone.upper())
+    ))
+
+    private_subnet = utils.create_subnet(
+        t, 'USEast1%sPrivateSubnet' % availability_zone.upper(), vpc,
+        '10.0.%s.0/24' % (index + 1), 'us-east-1%s' % availability_zone
+    )
+
+    private_route_table = utils.create_route_table(
+        t, 'USEast1%sPrivateRouteTable' % availability_zone.upper(), vpc)
+
+    private_route = utils.create_route(
+        t, 'USEast1%sPrivateRoute' % availability_zone.upper(),
+        private_route_table, InstanceId=Ref(nat_device))
+
+    t.add_resource(ec2.SubnetRouteTableAssociation(
+        '%sPrivateSubnetRouteTableAssociation' % private_subnet.title,
+        SubnetId=Ref(private_subnet),
+        RouteTableId=Ref(private_route_table)
+    ))
+
+    public_subnets.append(public_subnet)
+    private_subnets.append(private_subnet)
+
+bastion_security_group = utils.create_security_group(
+    t, 'sgBastion', 'Enables access to the BastionHost', vpc,
+    ingress=[
+        ec2.SecurityGroupRule(IpProtocol='tcp', CidrIp=Ref(office_cidr_param),
+                              FromPort=p, ToPort=p)
+        for p in [22, 8081, 8082]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [22, 5432, 6379]
+    ] + [
+        ec2.SecurityGroupRule(IpProtocol='tcp', CidrIp=utils.ALLOW_ALL_CIDR,
+                              FromPort=p, ToPort=p)
+        for p in [80, 443]
+    ]
+)
+
+bastion_host = t.add_resource(ec2.Instance(
+    'BastionHost',
+    InstanceType=Ref(bastion_instance_type_param),
+    KeyName=Ref(keyname_param),
+    ImageId=Ref(bastion_host_ami_param),
+    NetworkInterfaces=[
+        ec2.NetworkInterfaceProperty(
+            Description='ENI for BastionHost',
+            GroupSet=[Ref(bastion_security_group)],
+            SubnetId=Ref(public_subnets[0]),
+            AssociatePublicIpAddress=True,
+            DeviceIndex=0,
+            DeleteOnTermination=True
+        )
+    ],
+    Tags=Tags(Name='BastionHost')
+))
+
+#
+# Security Group Resources
+#
+app_server_load_balancer_security_group = utils.create_security_group(
+    t, 'sgAppServerLoadBalancer',
+    'Enables access to application servers via a load balancer',
+    vpc,
+    ingress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.ALLOW_ALL_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [80]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [80]
+    ]
+)
+
+tile_server_load_balancer_security_group = utils.create_security_group(
+    t, 'sgTileServerLoadBalancer',
+    'Enables access to tile servers via a load balancer',
+    vpc,
+    ingress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.ALLOW_ALL_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [80]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [80]
+    ]
+)
+
+app_server_security_group = utils.create_security_group(
+    t, 'sgAppServer',
+    'Enables access to application servers', vpc,
+    ingress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', SourceSecurityGroupId=Ref(sg),
+            FromPort=22, ToPort=22
+        )
+        for sg in [bastion_security_group]
+    ] + [
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', SourceSecurityGroupId=Ref(sg),
+            FromPort=80, ToPort=80
+        )
+        for sg in [app_server_load_balancer_security_group,
+                   bastion_security_group]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [80, 2003, 5432, 6379, 8125]
+    ] + [
+        ec2.SecurityGroupRule(
+            IpProtocol='udp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [8125]
+    ]
+)
+
+tile_server_security_group = utils.create_security_group(
+    t, 'sgTileServer',
+    'Enables access to tile servers', vpc,
+    ingress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', SourceSecurityGroupId=Ref(sg),
+            FromPort=22, ToPort=22
+        )
+        for sg in [bastion_security_group]
+    ] + [
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', SourceSecurityGroupId=Ref(sg),
+            FromPort=80, ToPort=80
+        )
+        for sg in [tile_server_load_balancer_security_group,
+                   bastion_security_group]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [80, 2003, 5432, 6379, 8125]
+    ] + [
+        ec2.SecurityGroupRule(
+            IpProtocol='udp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [8125]
+    ]
+)
+
+database_server_security_group = utils.create_security_group(
+    t, 'sgDatabaseServer', 'Enables access to database servers', vpc,
+    ingress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', SourceSecurityGroupId=Ref(sg),
+            FromPort=5432, ToPort=5432
+        )
+        for sg in [bastion_security_group,
+                   app_server_security_group,
+                   tile_server_security_group]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [5432]
+    ]
+)
+
+cache_cluster_security_group = utils.create_security_group(
+    t, 'sgCacheCluster', 'Enables access to the cache cluster', vpc,
+    ingress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', SourceSecurityGroupId=Ref(sg),
+            FromPort=6379, ToPort=6379
+        )
+        for sg in [bastion_security_group,
+                   app_server_security_group,
+                   tile_server_security_group]
+    ],
+    egress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=p, ToPort=p
+        )
+        for p in [6379]
+    ]
+)
+
+#
+# ELB Resources
+#
+app_server_load_balancer = t.add_resource(elb.LoadBalancer(
+    'elbAppServer',
+    LoadBalancerName='elbAppServer',
+    # TODO: Create an S3 bucket automatically and enable logging.
+    ConnectionDrainingPolicy=elb.ConnectionDrainingPolicy(
+        Enabled=True,
+        Timeout=300,
+    ),
+    CrossZone=True,
+    SecurityGroups=[Ref(app_server_security_group)],
+    Listeners=[
+        elb.Listener(
+            LoadBalancerPort='80',
+            InstancePort='80',
+            Protocol='HTTP',
+        ),
+    ],
+    HealthCheck=elb.HealthCheck(
+        Target="HTTP:80/",
+        HealthyThreshold="3",
+        UnhealthyThreshold="2",
+        Interval="30",
+        Timeout="5",
+    ),
+    Subnets=[Ref(s)
+             for s in public_subnets],
+    Tags=Tags(Name='elbAppServer')
+))
+
+tile_server_load_balancer = t.add_resource(elb.LoadBalancer(
+    'elbTileServer',
+    LoadBalancerName='elbTileServer',
+    # TODO: Create an S3 bucket automatically and enable logging.
+    ConnectionDrainingPolicy=elb.ConnectionDrainingPolicy(
+        Enabled=True,
+        Timeout=300,
+    ),
+    CrossZone=True,
+    SecurityGroups=[Ref(tile_server_security_group)],
+    Listeners=[
+        elb.Listener(
+            LoadBalancerPort='80',
+            InstancePort='80',
+            Protocol='HTTP',
+        ),
+    ],
+    HealthCheck=elb.HealthCheck(
+        Target="HTTP:80/",
+        HealthyThreshold="3",
+        UnhealthyThreshold="2",
+        Interval="30",
+        Timeout="5",
+    ),
+    Subnets=[Ref(s)
+             for s in public_subnets],
+    Tags=Tags(Name='elbTileServer')
+))
+
+#
+# Outputs
+#
+t.add_output([
+    Output(
+        'BastionIPAddress',
+        Description='IP address of the BastionHost',
+        Value=GetAtt(bastion_host.title, 'PublicIp')
+    ),
+    Output(
+        'GlobalNotificationsARN',
+        Description='Physical resource ID of an AWS::SNS::Topic for '
+                    'notifications',
+        Value=Ref(notification_topic)
+    ),
+    Output(
+        'AppServerSubnets',
+        Description='A list of subnets to associate with the application '
+                    'servers',
+        Value=Join(',', [
+            Ref(s)
+            for s in private_subnets
+        ])
+    ),
+    Output(
+        'TileServerSubnets',
+        Description='A list of subnets to associate with the tile servers',
+        Value=Join(',', [
+            Ref(s)
+            for s in private_subnets
+        ])
+    ),
+    Output(
+        'DataStoreServerSubnets',
+        Description='A list of subnets to associate with the data store '
+                    'servers',
+        Value=Join(',', [
+            Ref(s)
+            for s in private_subnets
+        ])
+    ),
+    Output(
+        'sgAppServer',
+        Description='Application server security group',
+        Value=Ref(app_server_security_group)
+    ),
+    Output(
+        'sgTileServer',
+        Description='Tile server security group',
+        Value=Ref(tile_server_security_group)
+    ),
+    Output(
+        'sgDatabaseServer',
+        Description='Database server security group',
+        Value=Ref(database_server_security_group)
+    ),
+    Output(
+        'sgCacheCluster',
+        Description='Cache cluster security group',
+        Value=Ref(cache_cluster_security_group)
+    ),
+    Output(
+        'AppServerLoadBalancerEndpoint',
+        Description='Application servers endpoint',
+        Value=GetAtt(app_server_load_balancer, 'DNSName')
+    ),
+    Output(
+        'TileServerLoadBalancerEndpoint',
+        Description='Tile servers endpoint',
+        Value=GetAtt(tile_server_load_balancer, 'DNSName')
+    )
+])
+
+if __name__ == '__main__':
+    utils.validate_cloudformation_template(t.to_json())
+
+    file_name = basename(__file__).replace('.py', '.json')
+
+    with open(file_name, 'w') as f:
+        f.write(t.to_json())
+
+    print('Template validated and written to %s' % file_name)


### PR DESCRIPTION
This changeset adds support for Amazon Web Services CloudFormation via [Troposphere](https://github.com/cloudtools/troposphere), a Python library for describing CloudFormation stacks.

There are currently 4 stacks:
- VPC

The VPC consists of 4 subnets, 2 public and 2 private. The subnets are spread across 2 availability zones. There is a NAT instance for each availability zone, and one bastion instance for the entire VPC.
- Data store (contains database and cache)

The data stores consist of a PostgreSQL RDS instance setup across multiple availability zones and a Redis ElastiCache instance. The RDS instance creates a default database (`nyc_trees`) automatically. The ElastiCache Redis instance has AOF enabled. Both live inside the private subnets.
- App servers

The application servers live within a vanilla Auto Scaling Group (ASG) that is associated with an Elastic Load Balancer (ELB). Health checks run by the ELB trigger changes in the ASG. All application servers live inside the private subnets, but are fronted by their own ELB.
- Tile servers

The tile servers live within a vanilla Auto Scaling Group (ASG) that is associated with an Elastic Load Balancer (ELB) as well. Health checks run by the ELB trigger changes in the ASG. All tile servers live inside the private subnets, but are fronted by their own ELB.

Additional AWS deployment details are housed in the `README`.

Resolves #24.
