### PR TITLE
Add support to PostgreSQL for PostGIS

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -2,6 +2,7 @@ azavea.ntp,0.1.0
 azavea.pip,0.1.0
 azavea.nodejs,0.1.1
 azavea.postgresql,0.1.1
+azavea.postgis,0.1.1
 azavea.redis,0.1.0
 azavea.nginx,0.1.1
 azavea.mapnik,0.1.0

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -10,6 +10,7 @@
     - { role: "nyc-trees.common" }
 
     - { role: "azavea.postgresql" }
+    - { role: "azavea.postgis" }
     - { role: "azavea.redis" }
     - { role: "azavea.kibana" }
     - { role: "nyc-trees.logstash" }


### PR DESCRIPTION
This changeset installs PostGIS via the PostgreSQL APT repository. See https://github.com/azavea/ansible-postgis for details.

Attempts to resolve: #27 
