### PR TITLE
Allow all virtual machines to communicate with PostgreSQL

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -4,6 +4,8 @@ redis_host: "33.33.33.30"
 
 postgresql_listen_addresses: "*"
 postgresql_host: "33.33.33.30"
+postgresql_hba_mapping:
+  - { type: "host", database: "all", user: "all", address: "33.33.33.1/24", method: "md5" }
 
 relp_host: "33.33.33.30"
 

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,7 +1,7 @@
 azavea.ntp,0.1.0
 azavea.pip,0.1.0
 azavea.nodejs,0.1.1
-azavea.postgresql,0.1.1
+azavea.postgresql,0.2.0
 azavea.postgis,0.1.1
 azavea.redis,0.1.0
 azavea.nginx,0.1.1


### PR DESCRIPTION
This changeset overrides the PostgreSQL host-based authentication settings to allow all virtual machines in the Vagrant mutli-VM setup to communicate with PostgreSQL.

Attempts to resolve: #26 
