### PR TITLE
Add support for installing project dependencies in development

### DIFF
--- a/deployment/ansible/app-servers.yml
+++ b/deployment/ansible/app-servers.yml
@@ -9,5 +9,4 @@
   roles:
     - { role: "nyc-trees.common" }
     - { role: "nyc-trees.collectd" }
-
-    - { role: "azavea.pip" }
+    - { role: "nyc-trees.app" }

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -2,6 +2,7 @@ azavea.ntp,0.1.0
 azavea.pip,0.1.0
 azavea.nodejs,0.1.1
 azavea.postgresql,0.2.0
+azavea.postgresql-support,0.1.1
 azavea.postgis,0.1.1
 azavea.redis,0.1.0
 azavea.nginx,0.1.1

--- a/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+app_home: /opt/app

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - { role: "azavea.python", python_development: True }
+  - { role: "azavea.pip" }
+  - { role: "azavea.postgresql-support" }

--- a/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Install application dependencies for development
+  pip: chdir={{ app_home }}/requirements requirements=development.txt
+  when: "'development' in group_names"


### PR DESCRIPTION
This changeset adds the `nyc-trees.app` role to capture tasks directly tied to the nyc-trees Django application. The first step is installing the project's requirements file, and any system dependencies it may have.

Attempts to resolve #28.
