### PR TITLE
Wire up the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Use the following command to bring up a local development environment:
 $ vagrant up
 ```
 
+After provisioning is complete, you can bring up the Django `runserver` from within the `app` virtual machine with the following commands:
+
+```bash
+$ vagrant ssh app
+vagrant@app:~$ envdir /etc/nyc-trees.d/env /opt/app/manage.py runserver
+```
+
+**Note**: If you get an error that resembles the following, try logging into the `app` virtual machine again for the group permissions changes to take effect:
+
+```
+envdir: fatal: unable to switch to directory /etc/nyc-trees.d/env: access denied
+```
+
 ### Caching
 
 In order to speed up things up, you may want to consider using a local caching proxy. The `VAGRANT_PROXYCONF_ENDPOINT` environmental variable provides a way to supply a caching proxy endpoint for the virtual machines to use:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,9 +50,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Graphite Web
     services.vm.network "forwarded_port", guest: 8080, host: 8082
     # PortgreSQL
-    services.vm.network "forwarded_port", guest: 5432, host: 5432
+    services.vm.network "forwarded_port", guest: 5432, host: 15432
     # Redis
-    services.vm.network "forwarded_port", guest: 6379, host: 6379
+    services.vm.network "forwarded_port", guest: 6379, host: 16379
 
     services.vm.provider "virtualbox" do |v|
       v.memory = 1024
@@ -85,8 +85,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.vm.synced_folder ".", "/vagrant", disabled: true
     app.vm.synced_folder "src/nyc_trees", "/opt/app/"
 
-    # Django application
-    app.vm.network "forwarded_port", guest: 80, host: 8080
+    # Django runserver
+    app.vm.network "forwarded_port", guest: 8000, host: 8000
 
     app.vm.provision "ansible" do |ansible|
       ansible.playbook = "deployment/ansible/app-servers.yml"

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -4,6 +4,9 @@ redis_host: "33.33.33.30"
 
 postgresql_listen_addresses: "*"
 postgresql_host: "33.33.33.30"
+postgresql_username: nyc_trees
+postgresql_password: nyc_trees
+postgresql_database: nyc_trees
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "33.33.33.1/24", method: "md5" }
 

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -13,3 +13,4 @@ azavea.kibana,0.1.0
 azavea.unzip,0.1.0
 azavea.graphite,0.2.0
 azavea.statsite,0.1.0
+azavea.daemontools,0.1.0

--- a/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
@@ -1,2 +1,9 @@
 ---
 app_home: /opt/app
+app_config_home: /etc/nyc-trees.d/env
+app_config:
+  - { file: "NYC_TREES_DB_NAME", content: "{{ postgresql_database }}" }
+  - { file: "NYC_TREES_DB_USER", content: "{{ postgresql_username }}" }
+  - { file: "NYC_TREES_DB_PASSWORD", content: "{{ postgresql_password }}" }
+  - { file: "NYC_TREES_DB_HOST", content: "{{ postgresql_host }}" }
+  - { file: "NYC_TREES_DB_PORT", content: "{{ postgresql_port }}" }

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
   - { role: "azavea.python", python_development: True }
   - { role: "azavea.pip" }
   - { role: "azavea.postgresql-support" }
+  - { role: "azavea.daemontools" }

--- a/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
@@ -1,4 +1,43 @@
 ---
-- name: Install application dependencies for development
-  pip: chdir={{ app_home }}/requirements requirements=development.txt
+- name: Create service account for application
+  user: name=nyc-trees
+        system=yes
+        createhome=no
+        shell=/bin/false
+        state=present
+
+- name: Add Vagrant user to the nyc-trees group
+  user: name=vagrant
+        append=yes
+        group=nyc-trees
+        state=present
+  when: "'development' in group_names"
+
+- name: Create configuration file directory
+  file: path={{ app_config_home }}
+        owner=root
+        group=nyc-trees
+        mode=0750
+        state=directory
+
+- name: Configure application
+  copy: content={{ item.content }}
+        dest={{ app_config_home }}/{{ item.file }}
+        owner=root
+        group=nyc-trees
+        mode=0750
+  with_items: app_config
+
+- name: Install Geospatial libraries
+  apt: pkg={{ item }} state=present
+  with_items:
+    - binutils=2.24-5ubuntu3
+    - libproj-dev=4.8.0-2ubuntu2
+    - gdal-bin=1.10.1+dfsg-5ubuntu1
+
+- name: Install application dependencies for development and test
+  pip: chdir={{ app_home }}/requirements requirements={{ item }}.txt
+  with_items:
+    - development
+    - test
   when: "'development' in group_names"

--- a/deployment/ansible/roles/nyc-trees.postgresql/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.postgresql/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - { role: "azavea.postgresql-support" }
+  - { role: "azavea.postgresql" }
+  - { role: "azavea.postgis" }

--- a/deployment/ansible/roles/nyc-trees.postgresql/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.postgresql/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Create PostgreSQL super user
+  sudo_user: postgres
+  postgresql_user: name="{{ postgresql_username }}"
+                   password="{{ postgresql_password }}"
+                   role_attr_flags=SUPERUSER
+                   state=present
+
+- name: Create PostgreSQL database
+  sudo_user: postgres
+  postgresql_db: name="{{ postgresql_database }}"
+                 owner="{{ postgresql_username }}"
+
+- name: Add PostGIS extension
+  sudo_user: postgres
+  command: psql {{ postgresql_database }} -c "CREATE EXTENSION postgis"
+  register: psql_result
+  failed_when: >
+    psql_result.rc != 0 and ("already exists" not in psql_result.stderr)
+  changed_when: "psql_result.rc == 0"

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -8,10 +8,9 @@
 
   roles:
     - { role: "nyc-trees.common" }
+    - { role: "nyc-trees.postgresql", when: "'development' in group_names" }
 
-    - { role: "azavea.postgresql" }
-    - { role: "azavea.postgis" }
-    - { role: "azavea.redis" }
+    - { role: "azavea.redis", when: "'development' in group_names" }
     - { role: "azavea.kibana" }
     - { role: "nyc-trees.logstash" }
     - { role: "nyc-trees.graphite" }

--- a/src/nyc_trees/nyc_trees/settings/development.py
+++ b/src/nyc_trees/nyc_trees/settings/development.py
@@ -1,6 +1,7 @@
 """Development settings and globals."""
 
 
+from os import environ
 from os.path import join, normpath
 
 from base import *
@@ -26,11 +27,11 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME': 'nyc',
-        'USER': 'nyc',
-        'PASSWORD': 'nyc',
-        'HOST': '33.33.33.30',
-        'PORT': '5432',
+        'NAME': environ.get('NYC_TREES_DB_NAME', 'nyc_trees'),
+        'USER': environ.get('NYC_TREES_DB_USER', 'nyc_trees'),
+        'PASSWORD': environ.get('NYC_TREES_DB_PASSWORD', 'nyc_trees'),
+        'HOST': environ.get('NYC_TREES_DB_HOST', 'localhost'),
+        'PORT': environ.get('NYC_TREES_DB_PORT', 5432)
     }
 }
 # END DATABASE CONFIGURATION


### PR DESCRIPTION
This changeset connects the Django application (running on `app`) to the PostgreSQL database (running on `services`). The Django application is setup to pull database settings in from the environment and `envdir` is used to populate the environment.

Example usage:

``` bash
$ vagrant ssh app
vagrant@app:~$ envdir /etc/nyc-trees.d/env /opt/app/manage.py runserver
```

Attempts to resolve the following issues:
- https://github.com/azavea/nyc-trees/issues/31
- https://github.com/azavea/nyc-trees/issues/35
- https://github.com/azavea/nyc-trees/issues/36
