### PR TITLE
Remove TEST_RUNNER setting

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -221,5 +221,3 @@ LOGGING = {
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#wsgi-application
 WSGI_APPLICATION = '%s.wsgi.application' % SITE_NAME
 # END WSGI CONFIGURATION
-
-TEST_RUNNER = 'discover_runner.DiscoverRunner'


### PR DESCRIPTION
Fixes #46

Running `manage.py test` was throwing "ImportError: No module named discover_runner."

The Django 1.7 docs say: "By default, TEST_RUNNER points to 'django.test.runner.DiscoverRunner'"
