### PR TITLE
Add missing import to settings/base.py

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -1,6 +1,6 @@
 """Common settings and globals."""
 
-
+from os import environ
 from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 


### PR DESCRIPTION
In 791faa94 I moved the database config to base.py but did not import the required `environ` function.
