### PR TITLE
Add test provisioning path

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,12 @@ if [ "up", "provision" ].include?(ARGV.first)
   install_dependent_roles
 end
 
-ANSIBLE_INVENTORY_PATH = "deployment/ansible/inventory"
+ANSIBLE_INVENTORY_PATH = if !ENV["VAGRANT_ENV"].nil? && ENV["VAGRANT_ENV"] == "TEST"
+  "deployment/ansible/inventory/test"
+else
+  "deployment/ansible/inventory/development"
+end
+
 VAGRANT_PROXYCONF_ENDPOINT = ENV["VAGRANT_PROXYCONF_ENDPOINT"]
 VAGRANTFILE_API_VERSION = "2"
 

--- a/deployment/ansible/app-servers.yml
+++ b/deployment/ansible/app-servers.yml
@@ -8,5 +8,6 @@
 
   roles:
     - { role: "nyc-trees.common" }
-    - { role: "nyc-trees.collectd" }
+    - { role: "nyc-trees.monitoring", when: not_testing }
+
     - { role: "nyc-trees.app" }

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,4 +1,7 @@
 ---
+not_testing: "'test' not in group_names"
+developing_or_testing: "'development' in group_names or 'test' in group_names"
+
 redis_port: 6379
 
 postgresql_port: 5432

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -1,0 +1,11 @@
+---
+redis_bind_address: "0.0.0.0"
+redis_host: "33.33.33.30"
+
+postgresql_listen_addresses: "*"
+postgresql_host: "33.33.33.30"
+postgresql_username: nyc_trees
+postgresql_password: nyc_trees
+postgresql_database: nyc_trees
+postgresql_hba_mapping:
+  - { type: "host", database: "all", user: "all", address: "33.33.33.1/24", method: "md5" }

--- a/deployment/ansible/inventory/test
+++ b/deployment/ansible/inventory/test
@@ -1,0 +1,17 @@
+app ansible_ssh_host=33.33.33.10
+tiler ansible_ssh_host=33.33.33.20
+services ansible_ssh_host=33.33.33.30
+
+[app-servers]
+app
+
+[tile-servers]
+tiler
+
+[services]
+services
+
+[test:children]
+app-servers
+tile-servers
+services

--- a/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
@@ -11,7 +11,7 @@
         append=yes
         group=nyc-trees
         state=present
-  when: "'development' in group_names"
+  when: developing_or_testing
 
 - name: Create configuration file directory
   file: path={{ app_config_home }}
@@ -40,4 +40,4 @@
   with_items:
     - development
     - test
-  when: "'development' in group_names"
+  when: developing_or_testing

--- a/deployment/ansible/roles/nyc-trees.common/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.common/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
   - { role: "azavea.ntp" }
-  - { role: "azavea.relp" }

--- a/deployment/ansible/roles/nyc-trees.common/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.common/tasks/main.yml
@@ -2,25 +2,23 @@
 - name: Check if Puppet service definition exists
   stat: path=/etc/init.d/puppet
   register: puppet_installed
-  when: "'development' in group_names"
 
 - name: Stop Puppet service
   service: name=puppet state=stopped
-  when: puppet_installed.stat.exists and 'development' in group_names
+  when: puppet_installed.stat.exists and developing_or_testing
 
 - name: Remove Puppet service
   file: path=/etc/init.d/puppet state=absent
-  when: puppet_installed.stat.exists and 'development' in group_names
+  when: puppet_installed.stat.exists and developing_or_testing
 
 - name: Check if Chef service definition exists
   stat: path=/etc/init.d/chef-client
   register: chef_installed
-  when: "'development' in group_names"
 
 - name: Stop Chef service
   service: name=chef-client state=stopped
-  when: chef_installed.stat.exists and 'development' in group_names
+  when: chef_installed.stat.exists and developing_or_testing
 
 - name: Remove Chef service
   file: path=/etc/init.d/chef-client state=absent
-  when: chef_installed.stat.exists and 'development' in group_names
+  when: chef_installed.stat.exists and developing_or_testing

--- a/deployment/ansible/roles/nyc-trees.monitoring/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.monitoring/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: "azavea.relp" }
+  - { role: "nyc-trees.collectd" }

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -8,9 +8,10 @@
 
   roles:
     - { role: "nyc-trees.common" }
-    - { role: "nyc-trees.postgresql", when: "'development' in group_names" }
 
-    - { role: "azavea.redis", when: "'development' in group_names" }
-    - { role: "azavea.kibana" }
-    - { role: "nyc-trees.logstash" }
-    - { role: "nyc-trees.graphite" }
+    - { role: "nyc-trees.postgresql", when: developing_or_testing }
+    - { role: "azavea.redis", when: developing_or_testing }
+
+    - { role: "azavea.kibana", when: not_testing }
+    - { role: "nyc-trees.logstash", when: not_testing }
+    - { role: "nyc-trees.graphite", when: not_testing }

--- a/deployment/ansible/tile-servers.yml
+++ b/deployment/ansible/tile-servers.yml
@@ -8,7 +8,7 @@
 
   roles:
     - { role: "nyc-trees.common" }
-    - { role: "nyc-trees.collectd" }
+    - { role: "nyc-trees.monitoring", when: not_testing }
 
     - { role: "azavea.nodejs" }
     - { role: "azavea.mapnik" }


### PR DESCRIPTION
This changeset introduces an alternate provisioning path for testing environments. The majority of the differences in a test provisioning path are associated with the omission of monitoring (Collectd, RELP, Logstash). There is a new `nyc-trees.monitoring` role that attempts to encapsulate monitoring tasks associated with a metrics/logs producer.

The environmental variable `VAGRANT_ENV` is used to determine which provisioning path is taken. Inside of Jenkins, `VAGRANT_ENV` will be set to `TEST`, which will adjust the Ansible inventory used.
