### PR TITLE
Use .galaxy_install_info to trigger role installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,15 +3,37 @@
 
 Vagrant.require_version ">= 1.5"
 
-# Wipe azavea.* roles and download them using ansible-galaxy
+# Deserialize Ansible Galaxy installation metadata for a role
+def galaxy_install_info(role_name)
+  role_path = File.join("deployment", "ansible", "roles", role_name)
+  galaxy_install_info = File.join(role_path, "meta", ".galaxy_install_info")
+
+  if File.directory?(role_path) && File.exists?(galaxy_install_info)
+    YAML.load_file(galaxy_install_info)
+  else
+    { install_date: "", version: "0.0.0" }.to_yaml
+  end
+end
+
+# Uses the contents of roles.txt to ensure that ansible-galaxy is run
+# if any dependencies are missing
 def install_dependent_roles
-  ansible_path = File.join("deployment", "ansible")
+  ansible_directory = File.join("deployment", "ansible")
+  ansible_roles_txt = File.join(ansible_directory, "roles.txt")
 
-  FileUtils.rm_rf(Dir.glob(File.join("deployment", "ansible", "roles", "azavea.*")))
+  File.foreach(ansible_roles_txt) do |line|
+    role_name, role_version = line.split(",")
+    role_path = File.join(ansible_directory, "roles", role_name)
+    galaxy_metadata = galaxy_install_info(role_name)
 
-  unless system("ansible-galaxy install -f -r #{File.join(ansible_path, "roles.txt")} -p #{File.join(ansible_path, "roles")}")
-    $stderr.puts "\nERROR: An attempt to install Ansible role dependencies failed."
-    exit(1)
+    if galaxy_metadata["version"] != role_version.strip
+      unless system("ansible-galaxy install -f -r #{ansible_roles_txt} -p #{File.dirname(role_path)}")
+        $stderr.puts "\nERROR: An attempt to install Ansible role dependencies failed."
+        exit(1)
+      end
+
+      break
+    end
   end
 end
 


### PR DESCRIPTION
The `ansible-galaxy` command is nice enough to leave behind a bit of metadata associated with role installation (`role_name/meta/.galaxy_install_info`). The `Vagrantfile` now attempts to determine the version of an installed role based off of the metadata in that file. If the versions don't match, an install of all role dependencies occurs.

I'm not in love with this solution, but I think that it is better than force reinstalling all role dependencies every time (~10 seconds on every provision).
