### PR TITLE
Remove SNS topic from VPC CloudFormation stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Deployment is driven by the [Amazon Web Services CLI](http://aws.amazon.com/cli/
 - An EC2 key pair
 - Access keys to sign API requests
 - An IAM role for the application and tile servers
+- An SNS topic for global notifications
 
 In order to get started, install the deployment dependencies:
 
@@ -90,7 +91,7 @@ $ aws cloudformation create-stack --profile nyc-trees-test --stack-name NYCTrees
 
 First, update the following parameters for the CloudFormation data store stack in `deployment/troposphere/parameters/staging_data_store.json`:
 
-- `GlobalNotificationsARN`: Created by the VPC stack
+- `GlobalNotificationsARN`: One of the prerequisites listed above
 - `sgDatabaseServer`: Created by the VPC stack
 - `sgCacheCluster`: Created by the VPC stack
 - `DataStoreServerSubnets`: Created by the VPC stack (private subnets)
@@ -107,8 +108,8 @@ $ aws cloudformation create-stack --profile nyc-trees-test --stack-name NYCTrees
 
 First, update the following parameters for the CloudFormation application stack in `deployment/troposphere/parameters/staging_app.json`:
 
-- `GlobalNotificationsARN`: Created by the VPC stack
-- `AppServerInstanceProfile`: One the prerequisites listed above
+- `GlobalNotificationsARN`: One of the prerequisites listed above
+- `AppServerInstanceProfile`: One of the prerequisites listed above
 - `elbAppServer` - Created by the VPC stack
 - `sgAppServer` - Created by the VPC stack
 - `AppServerSubnets`: Created by the VPC stack (public subnets)
@@ -125,8 +126,8 @@ $ aws cloudformation create-stack --profile nyc-trees-test --stack-name NYCTrees
 
 First, update the following parameters for the CloudFormation tiler stack in `deployment/troposphere/parameters/staging_tiler.json`:
 
-- `GlobalNotificationsARN`: Created by the VPC stack
-- `TileServerInstanceProfile`: One the prerequisites listed above
+- `GlobalNotificationsARN`: One of the prerequisites listed above
+- `TileServerInstanceProfile`: One of the prerequisites listed above
 - `elbTileServer` - Created by the VPC stack
 - `sgTileServer` - Created by the VPC stack
 - `TileServerSubnets`: Created by the VPC stack (public subnets)

--- a/deployment/troposphere/parameters/staging_vpc.json
+++ b/deployment/troposphere/parameters/staging_vpc.json
@@ -1,9 +1,5 @@
 [
   {
-    "ParameterKey": "NotificationEmailAddress",
-    "ParameterValue": "hcastro@azavea.com"
-  },
-  {
     "ParameterKey": "KeyName",
     "ParameterValue": "nyc-trees-test"
   },

--- a/deployment/troposphere/vpc_template.py
+++ b/deployment/troposphere/vpc_template.py
@@ -3,7 +3,6 @@ from troposphere import Template, Parameter, Ref, FindInMap, Output, GetAtt, \
 from os.path import basename
 
 import template_utils as utils
-import troposphere.sns as sns
 import troposphere.elasticloadbalancing as elb
 
 t = Template()
@@ -14,11 +13,6 @@ t.add_description('A VPC stack for the nyc-trees project.')
 #
 # Parameters
 #
-notificaiton_email = t.add_parameter(Parameter(
-    'NotificationEmailAddress', Type='String', Default='hcastro@azavea.com',
-    Description='Email address for global notifications'
-))
-
 keyname_param = t.add_parameter(Parameter(
     'KeyName', Type='String', Default='nyc-trees-test',
     Description='Name of an existing EC2 key pair'
@@ -92,15 +86,6 @@ nat_security_group = utils.create_security_group(
         for p in [80, 443]
     ]
 )
-
-notification_topic = t.add_resource(sns.Topic(
-    'topicGlobalNotifications',
-    Subscription=[sns.Subscription(
-        Endpoint=Ref(notificaiton_email),
-        Protocol='email'
-    )],
-    TopicName='topicGlobalNotifications'
-))
 
 public_subnets = []
 private_subnets = []
@@ -403,12 +388,6 @@ t.add_output([
         'BastionIPAddress',
         Description='IP address of the BastionHost',
         Value=GetAtt(bastion_host.title, 'PublicIp')
-    ),
-    Output(
-        'GlobalNotificationsARN',
-        Description='Physical resource ID of an AWS::SNS::Topic for '
-                    'notifications',
-        Value=Ref(notification_topic)
     ),
     Output(
         'AppServerSubnets',


### PR DESCRIPTION
Instead of creating the SNS topic used for global stack notifications inside of the VPC stack, it seems better to create it outside of CloudFormation so that we can associate it with all other CloudFormation stacks. This will allow us to get notifications more easily when stacks are modified.
