### PR TITLE
Remove use of collectd_hostname

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -14,3 +14,4 @@ azavea.unzip,0.1.0
 azavea.graphite,0.2.0
 azavea.statsite,0.1.0
 azavea.daemontools,0.1.0
+azavea.collectd,0.1.1

--- a/deployment/ansible/roles/nyc-trees.collectd/vars/main.yml
+++ b/deployment/ansible/roles/nyc-trees.collectd/vars/main.yml
@@ -8,4 +8,3 @@ collectd_load_plugins:
   - memory
   - processes
   - write_graphite
-collectd_hostname: "{{ ansible_hostname }}"

--- a/deployment/ansible/roles/nyc-trees.graphite/vars/main.yml
+++ b/deployment/ansible/roles/nyc-trees.graphite/vars/main.yml
@@ -14,4 +14,3 @@ collectd_load_plugins:
   - swap
   - tail
   - write_graphite
-collectd_hostname: "{{ ansible_hostname }}"


### PR DESCRIPTION
`collectd_hostname` was being used to populate the Collectd configuration file's `Hostname` setting. If omitted, Collectd uses the `gethostname(2)` system call to automatically set `Hostname`. This behavior is much more desirable for EC2.

See also: https://github.com/azavea/ansible-collectd/pull/1
