### PR TITLE
Fix Apache and Nginx race condition with /var/www/html

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,3 +1,4 @@
+azavea.apache,0.2.1
 azavea.ntp,0.1.0
 azavea.pip,0.1.0
 azavea.nodejs,0.2.0

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -12,6 +12,8 @@
     - { role: "nyc-trees.postgresql", when: developing_or_testing }
     - { role: "azavea.redis", when: developing_or_testing }
 
+    # Keep nyc-trees.graphite ahead of nyc-trees.logstash because the
+    # apache2 package clobbers whatever exists in /var/www/html
+    - { role: "nyc-trees.graphite", when: not_testing }
     - { role: "azavea.kibana", when: not_testing }
     - { role: "nyc-trees.logstash", when: not_testing }
-    - { role: "nyc-trees.graphite", when: not_testing }


### PR DESCRIPTION
Kibana uses `/var/www/html` as its web root and Nginx attempts to serve its static assets from there. Later, Apache is installed for the Graphite Web interface, and the Apache package dumps a test site into `/var/www/html`. Unfortunately, this overwrites the static assets that Kibana and Apache's test site have in common (`index.html`).

This changeset makes the Graphite installation go first, followed by Kibana. In addition, the Apache installation also removes the test site _if_ `apache_delete_default_site` is `True`.

See also: https://github.com/azavea/ansible-apache2/pull/2
