### PR TITLE
Add simple shell script for running manage.py commands

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -3,4 +3,11 @@
 set -e
 set -x
 
-vagrant ssh app -c "envdir /etc/nyc-trees.d/env /opt/app/manage.py $*"
+ARGS=$*
+
+# Sane defaults for runserver
+if [[ $# -eq 1 ]] && [[ $1 == "runserver" ]]; then
+    ARGS="runserver 0.0.0.0:8000"
+fi
+
+vagrant ssh app -c "envdir /etc/nyc-trees.d/env /opt/app/manage.py $ARGS"


### PR DESCRIPTION
All arguments are passed through, so you can do:
`./manage.sh runserver`
or
`./manage.py migrate core`
or any other management command, from your host, without having to SSH into the VM and wrap your call with `envdir`
