### PR TITLE
Add support for selenium UI tests.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,6 +116,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Django via Nginx/Gunicorn
     app.vm.network "forwarded_port", guest: 80, host: 8000
 
+    app.ssh.forward_x11 = true
+
     app.vm.provision "ansible" do |ansible|
       ansible.playbook = "deployment/ansible/app-servers.yml"
       ansible.inventory_path = ANSIBLE_INVENTORY_PATH

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -16,3 +16,4 @@ azavea.graphite,0.2.0
 azavea.statsite,0.1.0
 azavea.daemontools,0.1.0
 azavea.collectd,0.1.1
+azavea.git,0.1.0

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -2,6 +2,7 @@
 dependencies:
   - { role: "azavea.python", python_development: True }
   - { role: "azavea.pip" }
+  - { role: "azavea.git", when: developing_or_testing }
   - { role: "azavea.postgresql-support" }
   - { role: "azavea.daemontools" }
   - { role: "azavea.nginx", nginx_delete_default_site: True }

--- a/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
@@ -12,3 +12,9 @@
     - development
     - test
   when: developing_or_testing
+
+- name: Install Firefox and Xvfb for headless UI tests
+  apt: pkg={{ item }} state=present
+  with_items:
+      - firefox=33.0+build2-0ubuntu0.14.04.1
+  when: developing_or_testing

--- a/src/nyc_trees/apps/core/uitests.py
+++ b/src/nyc_trees/apps/core/uitests.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from libs.ui_test_helpers import NycTreesSeleniumTestCase
+
+from apps.core.models import User
+
+
+class LoginUITest(NycTreesSeleniumTestCase):
+    def setUp(self):
+        super(LoginUITest, self).setUp()
+        self.user = User(username='guy', email='guy@guy.co.uk')
+        self.user.set_password('password')
+        self.user.save()
+
+    def test_login(self):
+        self.get('/accounts/login/')
+
+        self.wait_for_textbox_then_type('[name="username"]',
+                                        self.user.username)
+        self.wait_for_textbox_then_type('[name="password"]', 'password')
+
+        self.click('form input[type="submit"]')

--- a/src/nyc_trees/libs/ui_test_helpers.py
+++ b/src/nyc_trees/libs/ui_test_helpers.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from sbo_selenium import SeleniumTestCase
+
+
+class NycTreesSeleniumTestCase(SeleniumTestCase):
+    def wait_for_textbox_then_type(self, selector, text):
+        return self.wait_for_element(selector).send_keys(text)

--- a/src/nyc_trees/manage.py
+++ b/src/nyc_trees/manage.py
@@ -3,7 +3,14 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nyc_trees.settings.development")
+    # Default to development settings if there is nothing in the environment
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE",
+                          "nyc_trees.settings.development")
+
+    # We *always* want to use the test settings for test commands,
+    # regardless of what is in the environment
+    if 'test' in sys.argv or 'selenium' in sys.argv:
+        os.environ["DJANGO_SETTINGS_MODULE"] = "nyc_trees.settings.test"
 
     from django.core.management import execute_from_command_line
 

--- a/src/nyc_trees/nyc_trees/settings/test.py
+++ b/src/nyc_trees/nyc_trees/settings/test.py
@@ -1,6 +1,11 @@
-from base import *
+from base import *  # NOQA
 
 # TEST SETTINGS
 PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )
+
+SELENIUM_DEFAULT_BROWSER = 'firefox'
+SELENIUM_TEST_COMMAND_OPTIONS = {'pattern': 'uitest*.py'}
+
+INSTALLED_APPS += ('sbo_selenium',)

--- a/src/nyc_trees/requirements/test.txt
+++ b/src/nyc_trees/requirements/test.txt
@@ -1,3 +1,7 @@
 -r base.txt
 
 coverage==3.6
+selenium==2.44
+# There is a PR for these changes at:
+# https://github.com/safarijv/sbo-selenium/pull/5
+git+https://github.com/azavea/sbo-selenium.git@67bb63ac3687


### PR DESCRIPTION
UI tests must be in a file matching the pattern `uitest*.py`.
They can be run by using the `selenium` management command.

The tests are not headless, so they require a local X server to be running on the host (Xvfb is not on the Vagrant VM).

We intend to use Sauce Labs for CI, so this shouldn't be an issue for CI builds.
