### PR TITLE
Add flake8 checks to the test suite

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Run flake8 against the Django codebase and output a known string so that
+# the Jenkins text finder plugin can detect a failed check and mark the build
+# unstable. This command should only fail the build if the `vagrant ssh`
+# command itself fails.
+vagrant ssh app -c "flake8 /opt/app/apps || echo flake8 check failed"
+
+# Run the Django test suite with --noinput flag.
+vagrant ssh app -c "cd /opt/app && envdir /etc/nyc-trees.d/env ./manage.py test --noinput"

--- a/src/nyc_trees/requirements/test.txt
+++ b/src/nyc_trees/requirements/test.txt
@@ -1,3 +1,4 @@
 -r base.txt
 
 coverage==3.6
+flake8==2.2.5


### PR DESCRIPTION
This changeset adds `flake8` to the project test dependencies and executes checks before the Django test suite. A failed `flake8` run emits a known string ("flake8 check failed") so that the Jenkins text finder plugin can mark the build unstable.

Attempts to resolve #70.
