### PR TITLE
Add PostgreSQL command line client

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -10,3 +10,6 @@ graphite_port: 2003
 statsite_port: 8125
 apache_port: 8080
 graphite_web_port: "{{ apache_port }}"
+
+postgresql_version: "9.3"
+postgresql_package_version: "9.3.5-1.pgdg14.04+1"

--- a/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
@@ -6,6 +6,9 @@
     - libproj-dev=4.8.0-2ubuntu2
     - gdal-bin=1.10.1+dfsg-5ubuntu1
 
+- name: Install PostgreSQL client
+  apt: pkg=postgresql-client-{{ postgresql_version }}={{ postgresql_package_version }}
+
 - name: Install application dependencies for development and test
   pip: chdir={{ app_home }}/requirements requirements={{ item }}.txt
   with_items:


### PR DESCRIPTION
This changeset installs the PostgreSQL command line client on the application server so that it can be used to interact with the database.

```
vagrant@app:~$ envdir /etc/nyc-trees.d/env/ /opt/app/manage.py dbshell
Password for user nyc_trees:
psql (9.3.5)
SSL connection (cipher: DHE-RSA-AES256-SHA, bits: 256)
Type "help" for help.

nyc_trees=#
```

Attempts to resolve #72.
