### PR TITLE
Add support for pgweb in development

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,6 +79,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     services.vm.network "forwarded_port", guest: 8081, host: ENV.fetch("NYC_TREES_PORT_8081", 8081)
     # PortgreSQL
     services.vm.network "forwarded_port", guest: 5432, host: ENV.fetch("NYC_TREES_PORT_5432", 15432)
+    # Pgweb
+    services.vm.network "forwarded_port", guest: 5433, host: ENV.fetch("NYC_TREES_PORT_5433", 15433)
     # Redis
     services.vm.network "forwarded_port", guest: 6379, host: ENV.fetch("NYC_TREES_PORT_6379", 16379)
 

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -17,3 +17,4 @@ azavea.statsite,0.1.0
 azavea.daemontools,0.1.0
 azavea.collectd,0.1.1
 azavea.git,0.1.0
+azavea.pgweb,0.1.0

--- a/deployment/ansible/roles/nyc-trees.pgweb/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.pgweb/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+pgweb_log: /var/log/pgweb.log
+pgweb_log_rotate_count: 5
+pgweb_log_rotate_interval: daily

--- a/deployment/ansible/roles/nyc-trees.pgweb/handlers/main.yml
+++ b/deployment/ansible/roles/nyc-trees.pgweb/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart pgweb
+  service: name=pgweb state=restarted

--- a/deployment/ansible/roles/nyc-trees.pgweb/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.pgweb/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.pgweb" }

--- a/deployment/ansible/roles/nyc-trees.pgweb/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.pgweb/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Create service account for pgweb
+  user: name=pgweb
+        system=yes
+        home=/var/lib/pgweb
+        shell=/bin/false
+        state=present
+
+- name: Configure pgweb service definition
+  template: src=pgweb.conf.j2 dest=/etc/init/pgweb.conf
+  notify:
+    - Restart pgweb
+
+- name: Touch log file if it does not exist
+  command: touch {{ pgweb_log }}
+           creates={{ pgweb_log }}
+
+- name: Set log file permissions
+  file: path={{ pgweb_log }} owner=pgweb group=pgweb mode=0644
+
+- name: Configure pgweb log rotation
+  template: src=logrotate_pgweb.j2 dest=/etc/logrotate.d/pgweb

--- a/deployment/ansible/roles/nyc-trees.pgweb/templates/logrotate_pgweb.j2
+++ b/deployment/ansible/roles/nyc-trees.pgweb/templates/logrotate_pgweb.j2
@@ -1,0 +1,7 @@
+{{ pgweb_log }} {
+  rotate {{ pgweb_log_rotate_count }}
+  {{ pgweb_log_rotate_interval }}
+  compress
+  missingok
+  notifempty
+}

--- a/deployment/ansible/roles/nyc-trees.pgweb/templates/pgweb.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.pgweb/templates/pgweb.conf.j2
@@ -1,0 +1,18 @@
+description	"pgweb"
+
+start on vagrant-mounted
+stop on shutdown
+
+respawn
+setuid pgweb
+chdir /var/lib/pgweb
+
+exec /usr/local/bin/pgweb \
+	--skip-open \
+	--host localhost \
+	--port {{ postgresql_port }} \
+	--user {{ postgresql_username }} \
+	--pass {{ postgresql_password }} \
+	--db {{ postgresql_database }} \
+	--bind 0.0.0.0 \
+	--listen 5433 >> {{ pgweb_log }} 2>&1

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -10,6 +10,7 @@
     - { role: "nyc-trees.common" }
 
     - { role: "nyc-trees.postgresql", when: developing_or_testing }
+    - { role: "nyc-trees.pgweb", when: developing_or_testing }
     - { role: "azavea.redis", when: developing_or_testing }
 
 - hosts: monitoring-servers


### PR DESCRIPTION
This changeset adds support for `pgweb` by installing the executable and running it as a service. `pgweb` binds to `5433` within the VM and is exposed to the Vagrant virtual machine host via `15433`.

Attempts to resolve #69.
