### PR TITLE
Fix pgweb Upstart start on stanza

### DIFF
--- a/deployment/ansible/roles/nyc-trees.pgweb/templates/pgweb.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.pgweb/templates/pgweb.conf.j2
@@ -1,6 +1,6 @@
 description	"pgweb"
 
-start on vagrant-mounted
+start on (local-filesystems and net-device-up IFACE!=lo)
 stop on shutdown
 
 respawn


### PR DESCRIPTION
There are no shared folders on the `services` virtual machine, so using `vagrant-mounted` isn't a great option.
