### PR TITLE
Switch back to console based emails for development

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/development.py
+++ b/src/nyc_trees/nyc_trees/settings/development.py
@@ -14,8 +14,7 @@ TEMPLATE_DEBUG = DEBUG
 
 # EMAIL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
-EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
-EMAIL_FILE_PATH = '/opt/django-emails'
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # END EMAIL CONFIGURATION
 
 


### PR DESCRIPTION
Fixes #99

Since debugserver.sh gives console output, this is probably a better
development experience than file-based emails anyways
