### PR TITLE
Add support for purging ElasticSearch indexes with Curator

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -20,3 +20,4 @@ azavea.git,0.1.0
 azavea.pgweb,0.1.1
 azavea.elasticsearch,0.1.0
 azavea.java,0.1.1
+azavea.curator,0.1.0

--- a/deployment/ansible/roles/nyc-trees.elasticsearch/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.elasticsearch/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+curator_time_unit: 30

--- a/deployment/ansible/roles/nyc-trees.elasticsearch/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.elasticsearch/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: "azavea.curator" }
+  - { role: "azavea.elasticsearch" }

--- a/deployment/ansible/roles/nyc-trees.elasticsearch/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.elasticsearch/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Delete ElasticSearch indexes order than 30 days
+  cron: name="elasticsearch-curator"
+        special_time=daily
+        job="/usr/local/bin/curator delete --older-than {{ curator_time_unit }}"
+        state=present

--- a/deployment/ansible/roles/nyc-trees.logstash/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.logstash/meta/main.yml
@@ -1,5 +1,5 @@
 ---
 dependencies:
   - { role: "azavea.relp" }
-  - { role: "azavea.elasticsearch" }
+  - { role: "nyc-trees.elasticsearch" }
   - { role: "azavea.logstash" }


### PR DESCRIPTION
This changeset adds support for purging old ElasticSearch/Logstash indexes with Curator. After installing Curator, a cron job is created to delete any indexes that are older than 30 days.

Attempts to resolve #81.
