### PR TITLE
Enable contrib.gis to allow OpenLayers forms on the Django Admin site

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -190,6 +190,7 @@ DJANGO_APPS = (
     # Default Django apps:
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.gis',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',


### PR DESCRIPTION
Needed for editing things like Events which contain geospatial data.
