### PR TITLE
Attempt to resolve periodic Gulp/Sass build errors

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/tasks/static-files.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/static-files.yml
@@ -33,7 +33,7 @@
   sudo_user: nyc-trees
 
 - name: Create static files and run collectstatic (staging/production)
-  command: "./node_modules/.bin/gulp build"
+  command: "./node_modules/.bin/gulp"
   args:
     chdir: "{{ app_home }}"
   sudo_user: nyc-trees


### PR DESCRIPTION
There is no clear evidence that these changes resolve the issue, but two sets of changes are being made to try and suppress/isolate errors:
- Only delete and recreate the `node_modules` symlink within the project root if it wasn't already a symlink (that maps to a directory on the virtual machine's file system). The main driver for `node_modules` delete/recreate was to prevent a scenario where someone ran `npm install` manually, which would lead to a `node_modules` directory on the VirtualBox share.

A `node_modules` directory directly on the VirtualBox share is not desirable for Vagrant users on Windows because Windows does not allow regular users to create symlinks (`npm` produces symlinks internally within `node_modules`).
- Bypass `scripts` mechanism in `package.js` because it does not seem to set the `HOME` environmental properly:

``` bash
vagrant@app:/opt/app$ grep "test" package.json
    "test": "sudo -E -u nyc-trees env"
vagrant@app:/opt/app$ npm run test | grep HOME
HOME=/home/vagrant
vagrant@app:/opt/app$ grep "test" package.json
    "test": "sudo -u nyc-trees env"
vagrant@app:/opt/app$ npm run test | grep HOME
HOME=/home/vagrant
```

Instead, use Ansible's `sudo_user`, which outputs `HOME=/var/lib/nyc-trees`.

Example task to test:

``` yaml
- command: "env"
  sudo_user: nyc-trees
  register: xyz

- debug: msg="{{ xyz }}"
```

(Output not provided because there is a lot of it.)

Attempts to resolve #117.
