### PR TITLE
Update PostgreSQL roles due to package version changes

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -16,6 +16,7 @@ apache_port: 8080
 graphite_web_port: "{{ apache_port }}"
 
 postgresql_version: "9.3"
-postgresql_package_version: "9.3.5-1.pgdg14.04+1"
+postgresql_package_version: "9.3.5-2.pgdg14.04+1"
+postgresql_support_repository_channel: "9.3"
 
 elasticsearch_cluster_name: "logstash"

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -2,8 +2,8 @@ azavea.apache2,0.2.1
 azavea.ntp,0.1.0
 azavea.pip,0.1.0
 azavea.nodejs,0.2.0
-azavea.postgresql,0.2.0
-azavea.postgresql-support,0.1.1
+azavea.postgresql,0.2.1
+azavea.postgresql-support,0.2.0
 azavea.postgis,0.1.1
 azavea.redis,0.1.0
 azavea.nginx,0.2.0

--- a/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
@@ -6,6 +6,10 @@
     - libproj-dev=4.8.0-2ubuntu2
     - gdal-bin=1.10.1+dfsg-5ubuntu1
 
+- name: Configure the main PostgreSQL APT repository
+  apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release}}-pgdg main"
+                  state=present
+
 - name: Install PostgreSQL client
   apt: pkg=postgresql-client-{{ postgresql_version }}={{ postgresql_package_version }}
 


### PR DESCRIPTION
This changeset updates the versions of PostgreSQL roles we use because new packages were cut for `libpq-dev` and `postgresql-9.3`. These changes will prevent errors when fresh provisions are attempted.
