### PR TITLE
User privacy controls

### DIFF
--- a/src/nyc_trees/apps/users/forms.py
+++ b/src/nyc_trees/apps/users/forms.py
@@ -16,6 +16,13 @@ class ProfileSettingsForm(ModelForm):
             'first_name',
             'last_name',
             'opt_in_stewardship_info',
+        ]
+
+
+class PrivacySettingsForm(ModelForm):
+    class Meta:
+        model = User
+        fields = [
             'profile_is_public',
             'real_name_is_public',
             'group_follows_are_public',
@@ -23,8 +30,10 @@ class ProfileSettingsForm(ModelForm):
             'achievements_are_public',
         ]
 
+
 EventRegistrationFormSet = inlineformset_factory(
     User, EventRegistration, fields=['opt_in_emails'], extra=0)
+
 
 class GroupSettingsForm(ModelForm):
     class Meta:

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -13,7 +13,7 @@ from apps.core.decorators import is_group_admin
 from apps.users.views import group as v
 
 group_list_page = route(GET=do(render_template('groups/list.html'),
-                                v.group_list_page))
+                               v.group_list_page))
 
 group_detail = route(GET=do(render_template('groups/detail.html'),
                             v.group_detail))

--- a/src/nyc_trees/apps/users/routes/user.py
+++ b/src/nyc_trees/apps/users/routes/user.py
@@ -11,16 +11,16 @@ from django_tinsel.utils import decorate as do
 from apps.users.views import user as v
 
 render_user_template = render_template('users/profile.html')
+render_settings_template = render_template('users/settings.html')
 
 user_detail_redirect = do(login_required,
                           route(GET=v.user_detail_redirect))
 
 user_profile_settings = do(
     login_required,
-    route(GET=do(render_template('users/settings.html'),
-                 v.profile_settings),
-          POST=do(render_user_template,
-                  v.update_profile_settings)))
+    render_settings_template,
+    route(GET=v.profile_settings,
+          POST=v.update_profile_settings))
 
 achievements = do(login_required,
                   route(GET=do(render_template('users/achievement.html'),
@@ -30,7 +30,9 @@ training = do(login_required,
               route(GET=do(render_template('users/training.html'),
                            v.training_page)))
 
-user_detail = route(GET=do(render_user_template, v.user_detail))
+user_detail = route(
+    GET=do(render_user_template, v.user_detail),
+    POST=do(login_required, render_user_template, v.set_privacy))
 
 request_individual_mapper_status = do(
     login_required,

--- a/src/nyc_trees/apps/users/templates/users/partials/privacy_controls.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/privacy_controls.html
@@ -8,15 +8,17 @@
     {% for category in privacy_categories %}
         <tr>
             <td>
-                {# TODO: use locked/unlocked icons instead of text#}
-                {% if category.is_public %}(public){% endif %}
-                {{ category.form_field.as_hidden }}
+                {# TODO: use locked icon instead of text#}
+                <span class="lock-icon">Private&nbsp;&nbsp;&nbsp;</span>
+                {{ category.title }}
             </td>
-            <td>{{ category.title }}</td>
             <td>
-                <a href="javascript:;">
-                    {% if category.is_public %}Public{% else %}Private{% endif %}
+                <a class="privacy-toggler" href="javascript:;"
+                   data-privacy-field-name="{{ category.field_name }}"
+                   data-is-public="{{ category.is_public }}">
+                    (Text set client-side)
                 </a>
+                {{ category.form_field.as_hidden }}
             </td>
         </tr>
     {% endfor %}

--- a/src/nyc_trees/apps/users/templates/users/profile.html
+++ b/src/nyc_trees/apps/users/templates/users/profile.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block content %}
 
@@ -28,7 +29,7 @@
                             {% if user.profile_is_public %}Public{% else %}Private{% endif %} Profile
                         </div>
                         <div class="col-xs-6 text-right">
-                            <a class="btn btn-primary">Privacy</a>
+                            <a class="btn btn-primary" href="#privacy-popup" data-toggle="modal">Privacy</a>
                         </div>
                     </div>
                 </div>
@@ -78,7 +79,8 @@
                 {% if viewing_own_profile and not user.profile_is_public%}
                     <div class="block highlight">
                         <h5>Tip:</h5>
-                        Want to share your progress and information with the tree mapping community? <a>Make your profile public!</a>
+                        Want to share your progress and information with the tree mapping community?
+                        <a data-toggle="modal" href="#privacy-popup">Make your profile public!</a>
                     </div>
                 {% endif %}
 
@@ -86,6 +88,36 @@
         </div>
     </div>
 
+    {% if viewing_own_profile %}
+        <div class="modal fade" id="privacy-popup" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal">
+                            <span aria-hidden="true">&times;</span>
+                            <span class="sr-only">Close</span>
+                        </button>
+                        <h4 class="modal-title" id="myModalLabel">Privacy</h4>
+                    </div>
+                    <form id="privacy-form" method="POST">
+                        {% csrf_token %}
+                        <div class="modal-body">
+                            {% include 'users/partials/privacy_controls.html' %}
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default js-cancel" data-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
 </div>
 
 {% endblock %}
+
+{% block page_js %}
+    <script type="text/javascript" src="{{ "js/userProfile.js"|static_url }}"></script>
+{% endblock page_js %}

--- a/src/nyc_trees/apps/users/templates/users/settings.html
+++ b/src/nyc_trees/apps/users/templates/users/settings.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block content %}
     <ul class="nav nav-tabs">
@@ -13,19 +14,19 @@
         </li>
     </ul>
 
-    <form method="POST">
+    <form id="form" method="POST">
         <fieldset>
             {% csrf_token %}
 
             <div class="tab-content">
                 <div class="tab-pane active" id="account-pane">
                     <div class="fieldWrapper">
-                        {{ form.first_name.label_tag }}
-                        {{ form.first_name }}
+                        {{ profile_form.first_name.label_tag }}
+                        {{ profile_form.first_name }}
                     </div>
                     <div class="fieldWrapper">
-                        {{ form.last_name.label_tag }}
-                        {{ form.last_name }}
+                        {{ profile_form.last_name.label_tag }}
+                        {{ profile_form.last_name }}
                     </div>
                 </div>
 
@@ -33,8 +34,8 @@
                     <h3>NYC Parks</h3>
                     <div>I am interested in receiving additional information on stewardship opportunities available through NYC Parks.</div>
                     <div class="fieldWrapper">
-                        {{ form.opt_in_stewardship_info }}
-                        {{ form.opt_in_stewardship_info.label_tag }}
+                        {{ profile_form.opt_in_stewardship_info }}
+                        {{ profile_form.opt_in_stewardship_info.label_tag }}
                     </div>
                     <div>I want to receive emails for these events:</div>
                     <table>
@@ -68,12 +69,16 @@
 
             </div>
 
-            <div style="float:right;">
+            <div class="pull-right">
                 <input type="submit" class="btn" value="Save" />
             </div>
-            <a class="btn" href="{% url 'user_detail' username=username %}">Cancel</a>
+            <a class="btn" href="{% url 'user_profile_settings' %}">Cancel</a>
 
         </fieldset>
     </form>
 
 {% endblock %}
+
+{% block page_js %}
+    <script type="text/javascript" src="{{ "js/userSettings.js"|static_url }}"></script>
+{% endblock page_js %}

--- a/src/nyc_trees/apps/users/tests.py
+++ b/src/nyc_trees/apps/users/tests.py
@@ -55,20 +55,20 @@ class ProfileTemplateTests(UsersTestCase):
         request = make_request(user=viewer)
         return user_detail_route(request, self.user.username)
 
-    def _assert_profile_contains(self, text, its_me=True):
+    def _assert_profile_contains(self, text, its_me=True, count=1):
         response = self._render_profile(its_me)
-        self.assertContains(response, text, count=1)
+        self.assertContains(response, text, count=count)
 
     def _assert_profile_does_not_contain(self, text, its_me=True):
         response = self._render_profile(its_me)
         self.assertContains(response, text, count=0)
 
-    def _assert_visible_to_all(self, text):
-        self._assert_profile_contains(text)
-        self._assert_profile_contains(text, its_me=False)
+    def _assert_visible_to_all(self, text, me_count=1, them_count=1):
+        self._assert_profile_contains(text, count=me_count)
+        self._assert_profile_contains(text, its_me=False, count=them_count)
 
-    def _assert_visible_only_to_me(self, text):
-        self._assert_profile_contains(text)
+    def _assert_visible_only_to_me(self, text, count=1):
+        self._assert_profile_contains(text, count=count)
         self._assert_profile_does_not_contain(text, its_me=False)
 
     def test_private_profile_404_if_not_me(self):
@@ -89,12 +89,12 @@ class ProfileTemplateTests(UsersTestCase):
         self._assert_visible_to_all('Tree Mapper')
 
     def test_privacy_link_visible_only_to_me(self):
-        self._assert_visible_only_to_me('Privacy')
+        self._assert_visible_only_to_me('Privacy', count=2)
 
     def test_groups_section_visibility(self):
-        self._assert_visible_only_to_me('Groups')
+        self._assert_visible_only_to_me('Groups', count=2)
         self._update_user(group_follows_are_public=True)
-        self._assert_visible_to_all('Groups')
+        self._assert_visible_to_all('Groups', me_count=2, them_count=1)
 
     def test_groups_section_contents(self):
         self._assert_visible_only_to_me(self.group.name)
@@ -102,9 +102,9 @@ class ProfileTemplateTests(UsersTestCase):
         self._assert_visible_to_all(self.group.name)
 
     def test_achievements_section_visibility(self):
-        self._assert_visible_only_to_me('Achievements')
+        self._assert_visible_only_to_me('Achievements', count=2)
         self._update_user(achievements_are_public=True)
-        self._assert_visible_to_all('Achievements')
+        self._assert_visible_to_all('Achievements', me_count=2, them_count=1)
 
     def test_achievements_section_contents(self):
         self._assert_visible_only_to_me(
@@ -114,9 +114,9 @@ class ProfileTemplateTests(UsersTestCase):
             achievements[AchievementDefinition.FINISH_TRAINING].name)
 
     def test_contributions_section_visibility(self):
-        self._assert_visible_only_to_me('Contributions')
+        self._assert_visible_only_to_me('Contributions', count=2)
         self._update_user(contributions_are_public=True)
-        self._assert_visible_to_all('Contributions')
+        self._assert_visible_to_all('Contributions', me_count=2, them_count=1)
 
     def test_contributions_section_contents(self):
         blockface = Blockface.objects.create(

--- a/src/nyc_trees/apps/users/views/user.py
+++ b/src/nyc_trees/apps/users/views/user.py
@@ -12,7 +12,8 @@ from django.utils import timezone
 from apps.core.models import User
 from apps.event.models import EventRegistration
 from apps.users.models import achievements
-from apps.users.forms import ProfileSettingsForm, EventRegistrationFormSet
+from apps.users.forms import ProfileSettingsForm, EventRegistrationFormSet, \
+    PrivacySettingsForm
 from apps.survey.models import Tree
 
 
@@ -34,6 +35,7 @@ def user_detail(request, username):
 
 
 def _user_profile_context(request, user, its_me):
+    privacy_form = PrivacySettingsForm(instance=user)
     follows = user.follow_set.select_related('group').order_by('created_at')
     user_achievements = set(user.achievement_set
                             .order_by('created_at')
@@ -59,6 +61,7 @@ def _user_profile_context(request, user, its_me):
         'show_groups': its_me or user.group_follows_are_public,
         'show_individual_mapper': (user.individual_mapper and
                                    (its_me or user.profile_is_public)),
+        'privacy_categories': _get_privacy_categories(privacy_form),
         'follows': follows,
         'counts': {
             'block': block_count,
@@ -73,8 +76,9 @@ def _user_profile_context(request, user, its_me):
 
 def profile_settings(request):
     user = request.user
-    form = ProfileSettingsForm(instance=user, label_suffix='')
-    form.fields['opt_in_stewardship_info'].label = ''
+    privacy_form = PrivacySettingsForm(instance=user)
+    profile_form = ProfileSettingsForm(instance=user, label_suffix='')
+    profile_form.fields['opt_in_stewardship_info'].label = ''
 
     a_week_ago = timezone.now().date() - timedelta(days=7)
     events = EventRegistration.objects \
@@ -84,9 +88,10 @@ def profile_settings(request):
         instance=user, queryset=events)
 
     context = {
-        'form': form,
+        'profile_form': profile_form,
+        'privacy_form': privacy_form,
         'event_formset': event_formset,
-        'privacy_categories': _get_privacy_categories(form),
+        'privacy_categories': _get_privacy_categories(privacy_form),
         'username': request.user.username,
     }
     return context
@@ -94,42 +99,44 @@ def profile_settings(request):
 
 def _get_privacy_categories(form):
     user = form.instance
-    return [
-        {
-            'title': 'Profile',
-            'is_public': user.profile_is_public,
-            'form_field': form['profile_is_public']
-        }, {
-            'title': 'Name',
-            'is_public': user.real_name_is_public,
-            'form_field': form['real_name_is_public']
-        }, {
-            'title': 'Groups',
-            'is_public': user.group_follows_are_public,
-            'form_field': form['group_follows_are_public']
-        }, {
-            'title': 'Contributions',
-            'is_public': user.contributions_are_public,
-            'form_field': form['contributions_are_public']
-        }, {
-            'title': 'Achievements',
-            'is_public': user.achievements_are_public,
-            'form_field': form['achievements_are_public']
+
+    def make_category(title, field_name):
+        return {
+            'title': title,
+            'field_name': field_name,
+            'is_public': getattr(user, field_name),
+            'form_field': form[field_name]
         }
+
+    return [
+        make_category('Profile', 'profile_is_public'),
+        make_category('Name', 'real_name_is_public'),
+        make_category('Groups', 'group_follows_are_public'),
+        make_category('Contributions', 'contributions_are_public'),
+        make_category('Achievements', 'achievements_are_public'),
     ]
 
 
 def update_profile_settings(request):
     user = request.user
     profile_form = ProfileSettingsForm(request.POST, instance=user)
+    privacy_form = PrivacySettingsForm(request.POST, instance=user)
     event_formset = EventRegistrationFormSet(request.POST, instance=user)
 
     # It's not possible to create invalid data with this form,
     # so don't check form.is_valid()
     profile_form.save()
+    privacy_form.save()
     event_formset.save()
 
-    return _user_profile_context(request, request.user, its_me=True)
+    return profile_settings(request)
+
+
+def set_privacy(request, username):
+    user = request.user
+    privacy_form = PrivacySettingsForm(request.POST, instance=user)
+    privacy_form.save()
+    return user_detail(request, username)
 
 
 def update_user(request, username):

--- a/src/nyc_trees/gulpfile.js
+++ b/src/nyc_trees/gulpfile.js
@@ -38,7 +38,9 @@ var args = minimist(process.argv.slice(2),
         'event_list_page.js',
         'forgot_username.js',
         'group_detail.js',
-        'group_list.js'
+        'group_list.js',
+        'userProfile.js',
+        'userSettings.js',
     ],
     entryFiles = entries.map(function(file) { return './js/src/' + file; }),
 

--- a/src/nyc_trees/js/src/privacySettings.js
+++ b/src/nyc_trees/js/src/privacySettings.js
@@ -1,0 +1,87 @@
+"use strict";
+
+// Manage toggle buttons for a set of privacy categories.
+// Toggle state is kept in a DOM data attribute on each button.
+// prepareForSave() copies that state to corresponding hidden form fields.
+// revert() loads state from the hidden form fields.
+
+var $ = require('jquery'),
+    dom = {
+        row: 'tr',
+        privacyTogglers: '.privacy-toggler',
+        lockIcon: '.lock-icon'
+    };
+
+module.exports = {
+    prepareForSave: loadDomStateFromHiddenFields,
+    revert: loadHiddenFieldsFromDomState
+};
+
+loadHiddenFieldsFromDomState();
+updateUI();
+$(dom.privacyTogglers).on('click', togglePrivacy);
+
+function togglePrivacy(e) {
+    var $toggler = $(e.target),
+        $row = $toggler.closest(dom.row);
+    if (!$row.hasClass('disabled')) {
+        var iAmNowPublic = !isPublic($toggler),
+            $togglers = $(dom.privacyTogglers),
+            isFirst = ($toggler[0] === $togglers[0]);
+        setIsPublic($toggler, iAmNowPublic);
+        if (isFirst && !iAmNowPublic) {
+            // Making first row private makes all rows private
+            setIsPublic($togglers, false);
+        }
+        updateUI();
+    }
+}
+
+function updateUI() {
+    var $togglers = $(dom.privacyTogglers),
+        disable = ! isPublic($togglers.first());
+    $togglers.each(function (i, toggler) {
+        var $toggler = $(toggler),
+            iAmPublic = isPublic($toggler),
+            $row = $toggler.closest(dom.row),
+            $lockIcon = $row.find(dom.lockIcon);
+        $toggler.html(iAmPublic ? 'Public' : 'Private');
+        $lockIcon.toggle(!iAmPublic);  // hide lock icon when public
+        if (i > 0) {
+            $row.toggleClass('disabled', disable);
+        }
+    });
+}
+
+function loadDomStateFromHiddenFields() {
+        $(dom.privacyTogglers).each(function () {
+        var $toggler = $(this),
+            iAmPublic = isPublic($toggler),
+            $hidden = getHiddenForToggler($toggler);
+        $hidden.val(iAmPublic ? 'True' : 'False');
+    });
+}
+
+function loadHiddenFieldsFromDomState() {
+    $(dom.privacyTogglers).each(function () {
+        var $toggler = $(this),
+            $hidden = getHiddenForToggler($toggler),
+            iAmPublic = ($hidden.val() == 'True');
+        setIsPublic($toggler, iAmPublic);
+    });
+    updateUI();
+}
+
+function isPublic($toggler) {
+    return $toggler.data('is-public');
+}
+
+function setIsPublic($toggler, isPublic) {
+    $toggler.data('is-public', isPublic);
+}
+
+function getHiddenForToggler($toggler) {
+    var fieldName = $toggler.data('privacy-field-name'),
+        $hidden = $('input[name=' + fieldName + ']');
+    return $hidden;
+}

--- a/src/nyc_trees/js/src/userProfile.js
+++ b/src/nyc_trees/js/src/userProfile.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var $ = require('jquery'),
+    privacySettings = require('./privacySettings.js'),
+
+    dom = {
+        privacyForm: '#privacy-form',
+        cancelButton: '.js-cancel'
+    };
+
+$(dom.privacyForm).on('submit', function () {
+    privacySettings.prepareForSave();
+    // Note: postback rather than ajax update because changing privacy settings
+    // may affect how the user profile template is rendered.
+});
+
+$(dom.cancelButton).on('click', function () {
+    privacySettings.revert();
+});

--- a/src/nyc_trees/js/src/userSettings.js
+++ b/src/nyc_trees/js/src/userSettings.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var $ = require('jquery'),
+    privacySettings = require('./privacySettings.js'),
+
+    dom = {
+        form: '#form'
+    };
+
+$(dom.form).on('submit', function () {
+    privacySettings.prepareForSave();
+});
+
+// Note that "Cancel" is handled by reloading the page so we don't need to do anything


### PR DESCRIPTION
Back end:
- Separate `PrivacySettingsForm` from `ProfileSettingsForm`
- User settings page: stay on page after save or cancel (per JeffF)
- Postback to user profile updates privacy settings

Front end:
- Add bootstrap modal to show privacy settings on profile page
- Module `privacySettings.js` controls toggling and display of privacy settings
- Used in both user profile and settings pages, each with their own save and cancel buttons
