### PR TITLE
Secure group edit with new decorators

### DIFF
--- a/src/nyc_trees/apps/census_admin/urls.py
+++ b/src/nyc_trees/apps/census_admin/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls import patterns, url
 
 from django_tinsel.decorators import route
 
-from apps.core.decorators import is_census_admin
+from apps.core.decorators import census_admin_do
 from apps.census_admin.views import (start_admin_users_job,
                                      start_admin_surveys_job, admin_edits_page,
                                      admin_edits_partial,
@@ -19,31 +19,31 @@ from apps.census_admin.views import (start_admin_users_job,
 urlpatterns = patterns(
     '',
     url(r'^users-export/$',
-        is_census_admin(route(POST=start_admin_users_job)),
+        census_admin_do(route(POST=start_admin_users_job)),
         name='start_admin_users_job'),
 
     url(r'^surveys-export/$',
-        is_census_admin(route(POST=start_admin_surveys_job)),
+        census_admin_do(route(POST=start_admin_surveys_job)),
         name='start_admin_surveys_job'),
 
     url(r'^edits/$',
-        is_census_admin(route(GET=admin_edits_page)),
+        census_admin_do(route(GET=admin_edits_page)),
         name='admin_edits_page'),
 
     url(r'^edits-partial/$',
-        is_census_admin(route(GET=admin_edits_partial)),
+        census_admin_do(route(GET=admin_edits_partial)),
         name='admin_edits_partial'),
 
     # TODO: Use Django flatpages for training POST/PUT endpoints
 
     url(r'^training/$',
-        is_census_admin(route(GET=admin_training_material_list,
+        census_admin_do(route(GET=admin_training_material_list,
                               # POST=add_training_material
         )),
         name='admin_training_material_list'),
 
     url(r'^training/(?P<training_material_url_name>\w+)/$',
-        is_census_admin(route(GET=admin_training_material,
+        census_admin_do(route(GET=admin_training_material,
                               # PUT=edit_training_material
         )),
         name='admin_training_material'),

--- a/src/nyc_trees/apps/core/decorators.py
+++ b/src/nyc_trees/apps/core/decorators.py
@@ -3,10 +3,63 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from functools import wraps
+from functools import wraps, partial
+
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404
+
+from django_tinsel.utils import decorate as do
+
+from apps.core.helpers import user_is_census_admin, user_is_group_admin
+from apps.core.models import Group
 
 
-def is_census_admin(view_fn):
+def group_request(view_fn):
+    """
+    This decorator consumes the `group_slug` argument of the view
+    function being wrapped, fetches the Group the `group_slug`
+    identifies and sets it on `request.group`.  Any chained view
+    functions downstream from this decorator must not expect a
+    `group_slug` argument. They can access `request.group` directly.
+    """
+    @wraps(view_fn)
+    def wrapper(request, group_slug, *args, **kwargs):
+        request.group = get_object_or_404(Group, slug=group_slug)
+        return view_fn(request, *args, **kwargs)
+    return wrapper
+
+
+def user_must_be_census_admin(view_fn):
+    """
+    Raise PermissionDenied if `request.user` is not a census admin
+    """
+    @wraps(view_fn)
+    def wrapper(request, *args, **kwargs):
+        if user_is_census_admin(request.user):
+            return view_fn(request, *args, **kwargs)
+        else:
+            raise PermissionDenied('%s is not a census administrator'
+                                   % request.user)
+    return wrapper
+
+
+def user_must_be_group_admin(view_fn):
+    """
+    Raise PermissionDenied if `request.user` is not allowed to
+    administer `request.group`.
+    """
+    @wraps(view_fn)
+    def wrapper(request, *args, **kwargs):
+        if user_is_group_admin(request.user, request.group):
+            return view_fn(request, *args, **kwargs)
+        else:
+            raise PermissionDenied('%s is not an administrator of %s'
+                                   % (request.user, request.group))
+    return wrapper
+
+
+def user_must_have_online_training(view_fn):
     # TODO: implement
     @wraps(view_fn)
     def wrapper(request, *args, **kwargs):
@@ -14,7 +67,7 @@ def is_census_admin(view_fn):
     return wrapper
 
 
-def is_group_admin(view_fn):
+def user_must_have_field_training(view_fn):
     # TODO: implement
     @wraps(view_fn)
     def wrapper(request, *args, **kwargs):
@@ -22,17 +75,21 @@ def is_group_admin(view_fn):
     return wrapper
 
 
-def has_training(view_fn):
+def user_must_be_individual_mapper(view_fn):
     # TODO: implement
     @wraps(view_fn)
     def wrapper(request, *args, **kwargs):
         return view_fn(request, *args, **kwargs)
     return wrapper
 
+##############################################################################
+# Composite Route Helpers
 
-def is_individual_mapper(view_fn):
-    # TODO: implement
-    @wraps(view_fn)
-    def wrapper(request, *args, **kwargs):
-        return view_fn(request, *args, **kwargs)
-    return wrapper
+group_admin_do = partial(do,
+                         login_required,
+                         group_request,
+                         user_must_be_group_admin)
+
+census_admin_do = partial(do,
+                          login_required,
+                          user_must_be_census_admin)

--- a/src/nyc_trees/apps/core/helpers.py
+++ b/src/nyc_trees/apps/core/helpers.py
@@ -1,0 +1,23 @@
+from apps.event.models import EventRegistration
+
+
+def user_is_census_admin(user):
+    return user.is_authenticated() and user.is_census_admin
+
+
+def user_is_group_admin(user, group):
+    return user.is_authenticated() and (user.is_census_admin
+                                        or group.admin == user)
+
+
+def user_has_online_training(user):
+    return user.is_authenticated() and user.online_training_complete
+
+
+def user_has_field_training(user):
+    return user.is_authenticated() and EventRegistration.objects.filter(
+        user=user, did_attend=True, event__includes_training=True)
+
+
+def user_is_individual_mapper(user):
+    return user.is_authenticated() and user.individual_mapper

--- a/src/nyc_trees/apps/core/test_utils.py
+++ b/src/nyc_trees/apps/core/test_utils.py
@@ -9,7 +9,8 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 
 
-def make_request(params={}, user=None, method='GET', body=None, file=None):
+def make_request(params={}, user=None, method='GET', body=None, file=None,
+                 group=None, **extra):
     if user is None:
         user = AnonymousUser()
 
@@ -29,5 +30,6 @@ def make_request(params={}, user=None, method='GET', body=None, file=None):
         req.method = method
 
     setattr(req, 'user', user)
+    setattr(req, 'group', group)
 
     return req

--- a/src/nyc_trees/apps/event/routes.py
+++ b/src/nyc_trees/apps/event/routes.py
@@ -9,7 +9,9 @@ from django_tinsel.decorators import route, render_template
 
 from django_tinsel.utils import decorate as do
 
-from apps.core.decorators import is_group_admin, has_training
+from apps.core.decorators import (user_must_be_group_admin,
+                                  user_must_have_online_training,
+                                  group_request, group_admin_do)
 from apps.event import views as v
 
 #####################################
@@ -29,47 +31,45 @@ events_list_feed = route(GET=v.events_list_feed)
 # GROUP ROUTES
 #####################################
 
-events = is_group_admin(route(GET=v.event_dashboard))
+events = group_admin_do(route(GET=v.event_dashboard))
 
-add_event = do(is_group_admin,
-               render_template('event/add_event.html'),
-               route(GET=v.add_event_page,
-                     POST=v.add_event))
+add_event = group_admin_do(render_template('event/add_event.html'),
+                           route(GET=v.add_event_page,
+                                 POST=v.add_event))
 
-event_detail = route(GET=do(render_template('event/event_detail.html'),
-                            v.event_detail),
-                     DELETE=is_group_admin(v.delete_event))
+event_detail = do(group_request,
+                  route(GET=do(render_template('event/event_detail.html'),
+                               v.event_detail),
+                        DELETE=user_must_be_group_admin(v.delete_event)))
 
-event_edit = do(is_group_admin,
-                render_template('event/edit_event.html'),
-                route(GET=v.edit_event_page,
-                      POST=v.edit_event))
+event_edit = group_admin_do(render_template('event/edit_event.html'),
+                            route(GET=v.edit_event_page,
+                            POST=v.edit_event))
 
-event_email = do(
-    is_group_admin,
-    render_template('event/email_rsvps.html'),
-    route(GET=v.event_email_page,
-          POST=v.event_email))
+event_email = group_admin_do(render_template('event/email_rsvps.html'),
+                             route(GET=v.event_email_page,
+                                   POST=v.event_email))
 
-event_popup_partial = route(GET=v.event_popup_partial)
+event_popup_partial = group_request(route(GET=v.event_popup_partial))
 
 event_registration = do(login_required,
-                        has_training,
+                        group_request,
+                        user_must_have_online_training,
                         render_template('event/partials/rsvp.html'),
                         route(POST=v.register_for_event,
                               DELETE=v.cancel_event_registration,
                               GET=v.register_for_event_after_login))
 
-start_event_map_print_job = do(has_training,
+start_event_map_print_job = do(group_request,
+                               user_must_have_online_training,
                                route(POST=v.start_event_map_print_job))
 
-event_check_in_page = do(is_group_admin,
-                         route(GET=do(
-                             render_template('event/admin_checkin.html'),
-                             v.event_check_in_page)))
+event_check_in_page = group_admin_do(
+    route(GET=do(render_template('event/admin_checkin.html'),
+                 v.event_check_in_page)))
 
-event_check_in = is_group_admin(route(POST=v.check_in_user_to_event,
+event_check_in = group_admin_do(route(POST=v.check_in_user_to_event,
                                       DELETE=v.un_check_in_user_to_event))
 
-email_event_registered_users = do(is_group_admin,
-                                  route(POST=v.email_event_registered_users))
+email_event_registered_users = group_admin_do(
+    route(POST=v.email_event_registered_users))

--- a/src/nyc_trees/apps/event/tests.py
+++ b/src/nyc_trees/apps/event/tests.py
@@ -64,9 +64,9 @@ class EventEmailTest(EventTestCase):
         request = make_request({
             'subject': 'Come to the event',
             'body': "It's happening now!"
-        }, self.other_user, 'POST')
+        }, self.other_user, 'POST', group=self.group)
 
-        context = event_email(request, self.group.slug, self.event.slug)
+        context = event_email(request, self.event.slug)
 
         self.assertEqual(mail.outbox[0].subject, "Come to the event")
         self.assertTrue(context['message_sent'])

--- a/src/nyc_trees/apps/survey/urls/blockface.py
+++ b/src/nyc_trees/apps/survey/urls/blockface.py
@@ -7,7 +7,8 @@ from django.conf.urls import patterns, url
 
 from django_tinsel.decorators import route
 
-from apps.core.decorators import is_individual_mapper, has_training
+from apps.core.decorators import (user_must_be_individual_mapper,
+                                  user_must_have_online_training)
 from apps.survey.views import (reserve_blockface_page, cancel_reservation,
                                add_blockface_to_cart,
                                remove_blockface_from_cart, blockface_cart_page,
@@ -20,30 +21,31 @@ from apps.survey.views import (reserve_blockface_page, cancel_reservation,
 urlpatterns = patterns(
     '',
     url(r'^$',
-        is_individual_mapper(route(GET=reserve_blockface_page)),
+        user_must_be_individual_mapper(route(GET=reserve_blockface_page)),
         name='reserve_blockface_page'),
 
     url(r'^(?P<blockface_id>\d+)/cancel-reservation/$',
-        is_individual_mapper(route(POST=cancel_reservation)),
+        user_must_be_individual_mapper(route(POST=cancel_reservation)),
         name='cancel_reservation'),
 
     url(r'^(?P<blockface_id>\d+)/cart/$',
-        is_individual_mapper(route(POST=add_blockface_to_cart,
-                                   DELETE=remove_blockface_from_cart)),
+        user_must_be_individual_mapper(
+            route(POST=add_blockface_to_cart,
+                  DELETE=remove_blockface_from_cart)),
         name='edit_cart_for_blockface'),
 
     url(r'^checkout/$',
-        is_individual_mapper(route(GET=blockface_cart_page,
-                                   POST=reserve_blockfaces)),
+        user_must_be_individual_mapper(route(GET=blockface_cart_page,
+                                             POST=reserve_blockfaces)),
         name='reserve_blockfaces'),
 
     url(r'^checkout-confirmation/$',
-        is_individual_mapper(
+        user_must_be_individual_mapper(
             route(GET=blockface_reservations_confirmation_page)),
         name='blockface_reservations_confirmation_page'),
 
     url(r'^(?P<blockface_id>\d+)/survey/$',
-        has_training(route(GET=start_survey,
-                           POST=submit_survey)),
+        user_must_have_online_training(route(GET=start_survey,
+                                             POST=submit_survey)),
         name='start_survey'),
 )

--- a/src/nyc_trees/apps/survey/urls/census_admin.py
+++ b/src/nyc_trees/apps/survey/urls/census_admin.py
@@ -7,7 +7,7 @@ from django.conf.urls import patterns, url
 
 from django_tinsel.decorators import route
 
-from apps.core.decorators import is_census_admin
+from apps.core.decorators import census_admin_do
 from apps.survey.views import (admin_blockface_page,
                                admin_blockface_partial,
                                admin_blockface_detail_page,
@@ -19,22 +19,23 @@ from apps.survey.views import (admin_blockface_page,
 urlpatterns = patterns(
     '',
     url(r'^blockface/$',
-        is_census_admin(route(GET=admin_blockface_page)),
+        census_admin_do(route(GET=admin_blockface_page)),
         name='admin_blockface_page'),
 
     url(r'^blockface-partial/$',
-        is_census_admin(route(GET=admin_blockface_partial)),
+        census_admin_do(route(GET=admin_blockface_partial)),
         name='admin_blockface_partial'),
 
     url(r'^blockface/(?P<blockface_id>\d+)/$',
-        is_census_admin(route(GET=admin_blockface_detail_page)),
+        census_admin_do(route(GET=admin_blockface_detail_page)),
         name='admin_blockface_detail_page'),
 
     url(r'^blockface/(?P<blockface_id>\d+)/extend-reservation/$',
-        is_census_admin(route(POST=admin_extend_blockface_reservation)),
+        census_admin_do(route(
+            POST=admin_extend_blockface_reservation)),
         name='admin_extend_blockface_reservation'),
 
     url(r'^blockface/(?P<blockface_id>\d+)/set-available/$',
-        is_census_admin(route(POST=admin_blockface_available)),
+        census_admin_do(route(POST=admin_blockface_available)),
         name='admin_blockface_available'),
 )

--- a/src/nyc_trees/apps/survey/urls/survey.py
+++ b/src/nyc_trees/apps/survey/urls/survey.py
@@ -7,7 +7,7 @@ from django.conf.urls import patterns, url
 
 from django_tinsel.decorators import route
 
-from apps.core.decorators import has_training
+from apps.core.decorators import user_must_have_online_training
 from apps.survey.views import choose_blockface_survey_page
 
 
@@ -17,6 +17,7 @@ urlpatterns = patterns(
     # The choose_blockface_survey_page will have a GET parameter of
     # blockface_id, which is used to change the starting map location
     url(r'^$',
-        has_training(route(GET=choose_blockface_survey_page)),
+        user_must_have_online_training(
+            route(GET=choose_blockface_survey_page)),
         name='choose_blockface_survey_page'),
 )

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -8,20 +8,20 @@ from django.contrib.auth.decorators import login_required
 from django_tinsel.decorators import route, render_template
 from django_tinsel.utils import decorate as do
 
-from apps.core.decorators import is_group_admin
+from apps.core.decorators import group_request, group_admin_do
 
 from apps.users.views import group as v
 
 group_list_page = route(GET=do(render_template('groups/list.html'),
                                v.group_list_page))
 
-group_detail = route(GET=do(render_template('groups/detail.html'),
+group_detail = route(GET=do(group_request,
+                            render_template('groups/detail.html'),
                             v.group_detail))
 
-group_edit = do(is_group_admin,
-                render_template('groups/settings.html'),
-                route(GET=v.edit_group,
-                      POST=v.update_group_settings))
+group_edit = group_admin_do(render_template('groups/settings.html'),
+                            route(GET=v.edit_group,
+                                  POST=v.update_group_settings))
 
 follow_group = login_required(route(POST=v.follow_group))
 
@@ -30,7 +30,6 @@ unfollow_group = login_required(route(POST=v.unfollow_group))
 # TODO: should this have group_admin
 start_group_map_print_job = route(POST=v.start_group_map_print_job)
 
-edit_user_mapping_priveleges = do(
-    is_group_admin,
+edit_user_mapping_priveleges = group_admin_do(
     route(PUT=v.give_user_mapping_priveleges,
           DELETE=v.remove_user_mapping_priveleges))

--- a/src/nyc_trees/apps/users/uitests.py
+++ b/src/nyc_trees/apps/users/uitests.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.core.urlresolvers import reverse
+
+from libs.ui_test_helpers import NycTreesSeleniumTestCase
+
+from apps.core.models import User, Group
+
+
+class GroupUITest(NycTreesSeleniumTestCase):
+    def setUp(self):
+        super(GroupUITest, self).setUp()
+        self.public_user = User.objects.create(
+            username='public_user',
+            email='public_user@foo.com'
+        )
+        self.public_user.set_password('password')
+        self.public_user.clean_and_save()
+
+        self.census_admin_user = User.objects.create(
+            username='census_admin_user',
+            email='census_admin_user@foo.com',
+            is_census_admin=True
+        )
+        self.census_admin_user.set_password('password')
+        self.census_admin_user.clean_and_save()
+
+        self.group_admin_user = User.objects.create(
+            username='group_admin_user',
+            email='group_admin_user@foo.com'
+        )
+        self.group_admin_user.set_password('password')
+        self.group_admin_user.clean_and_save()
+
+        self.group = Group.objects.create(
+            name='The Best Group of All',
+            description='Seriously, the best group in town.',
+            slug='the-best-group',
+            contact_info='Jane Best',
+            contact_email='best@group.com',
+            contact_url='https://thebest.nyc',
+            admin=self.group_admin_user
+        )
+
+    @property
+    def group_url(self):
+        return reverse('group_detail', kwargs={
+            'group_slug': self.group.slug
+        })
+
+    @property
+    def group_edit_url(self):
+        return reverse('group_edit', kwargs={
+            'group_slug': self.group.slug
+        })
+
+    def test_anonymous_user_can_see_group_page(self):
+        self.get(self.group_url)
+        self.wait_for_text(self.group.name)
+
+    def test_anonymous_user_redirected_when_getting_group_edit_page(self):
+        self.get(self.group_edit_url)
+        self.wait_for_text('Password:')
+
+    def test_public_user_cannot_see_edit_form(self):
+        self.login(self.public_user.username)
+        self.get(self.group_edit_url)
+        self.wait_for_text('Forbidden')
+
+    def test_group_admin_can_see_edit_form(self):
+        self.login(self.group_admin_user.username)
+        self.get(self.group_edit_url)
+        self.wait_for_element('textarea[name="description"]')
+
+    def test_census_admin_can_see_edit_form(self):
+        self.login(self.census_admin_user.username)
+        self.get(self.group_edit_url)
+        self.wait_for_element('textarea[name="description"]')

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -5,10 +5,8 @@ from __future__ import division
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
 
 from apps.core.models import Group
-
 from apps.users.forms import GroupSettingsForm
 from apps.event.models import Event
 from apps.event.event_list import EventList
@@ -20,64 +18,62 @@ def group_list_page(request):
     }
 
 
-def group_detail(request, group_slug):
-    group = get_object_or_404(Group, slug=group_slug)
-    events = Event.objects.filter(group_id=group.pk, is_private=False)
+def group_detail(request):
+    events = Event.objects.filter(group_id=request.group.pk, is_private=False)
 
     return {
-        'group': group,
+        'group': request.group,
         'event_list': EventList.simple_context(request, events),
         # TODO: check if user is group admin or census admin
         'user_can_edit_group': True,
-        'edit_url': reverse('group_edit', kwargs={'group_slug': group.slug})
+        'edit_url': reverse('group_edit', kwargs={
+            'group_slug': request.group.slug})
     }
 
 
-def edit_group(request, group_slug):
-    group = get_object_or_404(Group, slug=group_slug)
-    form = GroupSettingsForm(instance=group, label_suffix='')
+def edit_group(request):
+    form = GroupSettingsForm(instance=request.group, label_suffix='')
     context = {
         'form': form,
-        'group_slug': group_slug
+        'group_slug': request.group.slug
     }
     return context
 
 
-def update_group_settings(request, group_slug):
-    group = get_object_or_404(Group, slug=group_slug)
-    form = GroupSettingsForm(request.POST, instance=group)
+def update_group_settings(request):
+    form = GroupSettingsForm(request.POST, instance=request.group)
     if form.is_valid():
         form.save()
         return HttpResponseRedirect(
-            reverse('group_detail', kwargs={'group_slug': group_slug}))
+            reverse('group_detail', kwargs={'group_slug': request.group.slug}))
     else:
         context = {
             'form': form,
-            'group_slug': group_slug
+            'group_slug': request.group.slug
         }
         return context
 
 
-def follow_group(request, group_slug):
+def follow_group(request):
     # TODO: implement
     pass
 
 
-def unfollow_group(request, group_slug):
+def unfollow_group(request):
     # TODO: implement
     pass
 
 
-def start_group_map_print_job(request, group_slug):
+def start_group_map_print_job(request):
     # TODO: implement
     pass
 
 
-def give_user_mapping_priveleges(request, group_slug, username):
+def give_user_mapping_priveleges(request, username):
     # TODO: implement
     pass
 
 
-def remove_user_mapping_priveleges(request, group_slug, username):
+def remove_user_mapping_priveleges(request, username):
     # TODO: implement
     pass


### PR DESCRIPTION
This is a large refactor that allows for chainable decorators that decorate the `request` with a group object and enforce editability constraints base on the logged in user.

The `group_request` decorator takes it's cues from the auth context processor. Views wrapped with this decorator will have a `request.group` in addition to `request.user`. This makes for easier composability of decorators and has the side effect of ensuring that the group is only queried once.

I renamed the existing decorators to make them more forceful. For example `is_census_admin` is now `user_must_be_census_admin` which is more suggestive of the fact that a view wrapped with this decorator will return 403 Forbidden if the `request.user` is not an admin.

While working on the decorators, I also clarified the two different types of training, which grant different levels of page access.
