### PR TITLE
Add icon-lock class when toggling privacy settings

### DIFF
--- a/src/nyc_trees/apps/users/templates/users/partials/privacy_controls.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/privacy_controls.html
@@ -7,7 +7,8 @@
     {% for category in privacy_categories %}
         <div class="privacy-item block item">
             <div class="row">
-                <div class="col-xs-8{% if category.is_public %} icon-lock{% endif %}">
+                <div data-privacy-toggle-target="{{ category.field_name }}"
+                     class="col-xs-8{% if not category.is_public %} icon-lock{% endif %}">
                     {{ category.title }}
                 </div>
                 <div class="col-xs-4 text-right">

--- a/src/nyc_trees/js/src/privacySettings.js
+++ b/src/nyc_trees/js/src/privacySettings.js
@@ -9,7 +9,7 @@ var $ = require('jquery'),
     dom = {
         row: 'tr',
         privacyTogglers: '.privacy-toggler',
-        lockIcon: '.lock-icon'
+        lockIconClass: 'icon-lock'
     };
 
 module.exports = {
@@ -42,11 +42,13 @@ function updateUI() {
         disable = ! isPublic($togglers.first());
     $togglers.each(function (i, toggler) {
         var $toggler = $(toggler),
+            fieldName = $toggler.data('privacy-field-name'),
+            $target = $('[data-privacy-toggle-target="' + fieldName + '"]'),
             iAmPublic = isPublic($toggler),
             $row = $toggler.closest(dom.row),
             $lockIcon = $row.find(dom.lockIcon);
         $toggler.html(iAmPublic ? 'Public' : 'Private');
-        $lockIcon.toggle(!iAmPublic);  // hide lock icon when public
+        $target.toggleClass(dom.lockIconClass, !iAmPublic);  // hide lock icon when public
         if (i > 0) {
             $row.toggleClass('disabled', disable);
         }


### PR DESCRIPTION
The design uses icons applied with CSS classes rather than toggling the visibility of a separate lock element.

Fixes #193 
