### PR TITLE
Add allows_individual_mappers to Group

### DIFF
--- a/src/nyc_trees/apps/core/migrations/0006_group_allows_individual_mappers.py
+++ b/src/nyc_trees/apps/core/migrations/0006_group_allows_individual_mappers.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0005_remove_user_opt_in_events_info'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='group',
+            name='allows_individual_mappers',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -60,6 +60,7 @@ class Group(NycModel, models.Model):
     admin = models.ForeignKey(User, on_delete=models.PROTECT)
     image = models.ImageField(null=True)
     is_active = models.BooleanField(default=True)
+    allows_individual_mappers = models.BooleanField(default=False)
 
     def __unicode__(self):
         return self.name

--- a/src/nyc_trees/apps/users/forms.py
+++ b/src/nyc_trees/apps/users/forms.py
@@ -43,5 +43,11 @@ class GroupSettingsForm(ModelForm):
             'contact_info',
             'contact_email',
             'contact_url',
-            'image'
+            'image',
+            'allows_individual_mappers'
         ]
+
+    def __init__(self, *args, **kwargs):
+        super(GroupSettingsForm, self).__init__(*args, **kwargs)
+        self.fields['allows_individual_mappers'].label =\
+            "I want to allow individual mappers in my group's area"

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -91,11 +91,13 @@
                         {% endfor %}
                     </div>
                 </section>
+                {% if show_mapper_request %}
                 <section>
                     <h4 class="section-heading">Individual Mapping</h4>
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu congue lorem, id feugiat tortor. Aliquam ante elit, sodales eget porttitor vel, commodo et felis.</p>
                     <button class="btn btn-primary btn-mobile--max">Request Individual Mapper Status</button>
                 </section>
+                {% endif %}
             </main>
         </div>
     </div>

--- a/src/nyc_trees/apps/users/templates/groups/settings.html
+++ b/src/nyc_trees/apps/users/templates/groups/settings.html
@@ -73,6 +73,14 @@
                                         {{ form.image }}
                                     </div>
 
+                                    {% comment %}
+                                    The form is repeated on two different tabs, with a different set
+                                    of fields on each tab. The Django forms system expects to see
+                                    every field on every postback, so fields that aren't on the tab
+                                    need to be included as hidden input elements.
+                                    {% endcomment %}
+                                    {{ form.allows_individual_mappers.as_hidden }}
+
                                     <div class="main-footer">
                                         <div class="pull-right">
                                             <input type="submit" class="btn" value="Save group details" />
@@ -207,17 +215,32 @@
                         <div class="tab-pane" id="mappers">
                             <div class="block">
                                 <div class="mappers-option">
-                                    <div class="mappers-option-overview">
-                                        Enabled (<a href="#">Edit</a>)
-                                        <!-- .mappers-option-edit should be displayed and .mappers-option-overview should be hidden when someone clicks on the above "Edit" link. Clicking save should update and display .mappers-options-overview and hide .mappers-option-edit. -->
-                                    </div>
-                                    <div class="mappers-option-edit ">
-                                        <div class="row block">
-                                            <div class="col-xs-9">I want to allow individual mappers for my group.</div>
-                                            <div class="col-xs-3 text-right"><input type="checkbox"></div>
+                                    <form method="POST">
+                                        {% csrf_token %}
+
+                                        <div class="block-item">
+                                            {{ form.allows_individual_mappers.errors }}
+                                            {{ form.allows_individual_mappers.label_tag }}
+                                            {{ form.allows_individual_mappers }}
                                         </div>
-                                        <button class="btn btn-primary">Save</button>
-                                    </div>
+
+                                        {% comment %}
+                                        The form is repeated on two different tabs, with a different set
+                                        of fields on each tab. The Django forms system expects to see
+                                        every field on every postback, so fields that aren't on the tab
+                                        need to be included as hidden input elements.
+                                        {% endcomment %}
+                                        {{ form.description.as_hidden }}
+                                        {{ form.contact_info.as_hidden }}
+                                        {{ form.contact_email.as_hidden }}
+                                        {{ form.contact_url.as_hidden }}
+                                        {{ form.image.as_hidden }}
+
+                                        <div class="pull-right">
+                                          <input id="submit-individual-mappers-form" type="submit" class="btn" value="Save" />
+                                        </div>
+                                        <a class="btn btn-link" href="{% url 'group_detail' group_slug=group_slug %}">Cancel</a>
+                                    </form>
                                 </div>
                                 <hr>
                             </div>

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -31,6 +31,9 @@ def group_detail(request):
     events = Event.objects.filter(group_id=request.group.pk, is_private=False)
     user_is_following = Follow.objects.filter(user_id=request.user.id,
                                               group=request.group).exists()
+    show_mapper_request = request.group.allows_individual_mappers and \
+        not user_is_group_admin(request.user, request.group)
+
     return {
         'group': request.group,
         'event_list': EventList.simple_context(request, events),
@@ -38,7 +41,8 @@ def group_detail(request):
                                                    request.group),
         'user_is_following': user_is_following,
         'edit_url': reverse('group_edit', kwargs={
-            'group_slug': request.group.slug})
+            'group_slug': request.group.slug}),
+        'show_mapper_request': show_mapper_request
     }
 
 

--- a/src/nyc_trees/libs/ui_test_helpers.py
+++ b/src/nyc_trees/libs/ui_test_helpers.py
@@ -21,3 +21,13 @@ class NycTreesSeleniumTestCase(SeleniumTestCase):
         self.click('form input[type="submit"]')
 
         self.wait_for_text('Contributions')
+
+    def assert_text_in_body(self, text):
+        body = self.sel.find_element_by_css_selector('body').text
+        self.assertTrue(text in body,
+                        'Expected to find %s in %s' % (text, body))
+
+    def assert_text_not_in_body(self, text):
+        body = self.sel.find_element_by_css_selector('body').text
+        self.assertTrue(text not in body,
+                        'Did not expect to find %s in %s' % (text, body))


### PR DESCRIPTION
This commit also sets up a copy of the form on the group settings page to allow setting this attribute, and hides the button to request individual mapper status if the group does not allow it (or the person viewing the group detail page is already an admin)

Fixes #177
