### PR TITLE
Add custom password reset form accepting username

### DIFF
--- a/src/nyc_trees/apps/login/forms.py
+++ b/src/nyc_trees/apps/login/forms.py
@@ -3,7 +3,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.contrib.sites.shortcuts import get_current_site
+from django.db.models import Q
 from django.forms import Form, BooleanField, CheckboxInput, EmailField
+from django.template import loader
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 from registration.forms import RegistrationFormUniqueEmail
 
@@ -25,3 +33,66 @@ class NycRegistrationForm(RegistrationFormUniqueEmail):
         label='I am over 13 years old',
         required=False
     )
+
+
+class UsernameOrEmailPasswordResetForm(forms.Form):
+    '''
+    Django 1.8 will expose an overridable ``get_users`` method
+    that separates the filtering logic from the email sending
+    logic. This is not available in 1.7, so the ``save`` method in
+    this form was copied from
+    https://github.com/django/django/blob/59fec1ca9b3c426466f0c613a5ecf2badb992460/django/contrib/auth/forms.py#L230-L276
+    and slighly modified.
+    '''
+    email_or_username = forms.CharField(label="Email or Username",
+                                        max_length=254)
+
+    def save(self, domain_override=None,
+             subject_template_name='registration/password_reset_subject.txt',
+             email_template_name='registration/password_reset_email.html',
+             use_https=False, token_generator=default_token_generator,
+             from_email=None, request=None, html_email_template_name=None):
+        """
+        Generates a one-use only link for resetting password and sends to the
+        user.
+        """
+        from django.core.mail import send_mail
+        email_or_username = self.cleaned_data["email_or_username"]
+        for user in self.get_users(email_or_username):
+            if not domain_override:
+                current_site = get_current_site(request)
+                site_name = current_site.name
+                domain = current_site.domain
+            else:
+                site_name = domain = domain_override
+            context = {
+                'email': user.email,
+                'domain': domain,
+                'site_name': site_name,
+                'uid': urlsafe_base64_encode(force_bytes(user.pk)),
+                'user': user,
+                'token': token_generator.make_token(user),
+                'protocol': 'https' if use_https else 'http',
+            }
+            subject = loader.render_to_string(subject_template_name, context)
+            # Email subject *must not* contain newlines
+            subject = ''.join(subject.splitlines())
+            email = loader.render_to_string(email_template_name, context)
+
+            if html_email_template_name:
+                html_email = loader.render_to_string(html_email_template_name,
+                                                     context)
+            else:
+                html_email = None
+            send_mail(subject, email, from_email, [user.email],
+                      html_message=html_email)
+
+    def get_users(self, email_or_username):
+        matched_username_or_email_q = Q(email__iexact=email_or_username) | \
+            Q(username__iexact=email_or_username)
+        matched_and_active_q = Q(is_active=True) & matched_username_or_email_q
+
+        active_users = get_user_model()._default_manager\
+                                       .filter(matched_and_active_q)
+
+        return (u for u in active_users if u.has_usable_password())

--- a/src/nyc_trees/apps/login/urls/accounts.py
+++ b/src/nyc_trees/apps/login/urls/accounts.py
@@ -6,9 +6,19 @@ from __future__ import division
 from django.conf.urls import patterns, url, include
 
 from apps.login.backends import NycRegistrationView
+from apps.login.views import password_reset
 
 urlpatterns = patterns(
     '',
+    # /accounts/password/reset/ is purposefully shadowing an endpoint and must
+    # come before the registration and auth urls are imported
+    url(r'^password/reset/$', password_reset, name='password_reset'),
+    # TODO: resolve this duplicate mapping Both
+    # /accounts/password/reset/ and /accounts/password_reset/ are
+    # mapped to views via library code. We need to find a long term
+    # solution to this ambiguity but for now I am ensuring that both
+    # password reset URLs are mapped to the customized view.
+    url(r'^password_reset/$', password_reset, name='password_reset_alt'),
     # accounts/register/ is purposefully shadowing an endpoint in the default
     # registration backend.  It must come before it
     url(r'^register/$',

--- a/src/nyc_trees/apps/login/views.py
+++ b/src/nyc_trees/apps/login/views.py
@@ -5,6 +5,8 @@ from __future__ import division
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.contrib.auth.views import password_reset \
+    as contrib_auth_password_reset
 from django.template.loader import render_to_string
 
 from django_tinsel.decorators import render_template
@@ -12,7 +14,14 @@ from django_tinsel.utils import decorate as do
 
 from apps.core.models import User
 
-from apps.login.forms import ForgotUsernameForm
+from apps.login.forms import (ForgotUsernameForm,
+                              UsernameOrEmailPasswordResetForm)
+
+
+def password_reset(request):
+    return contrib_auth_password_reset(
+        request,
+        password_reset_form=UsernameOrEmailPasswordResetForm)
 
 
 def forgot_username_page(request):

--- a/src/nyc_trees/templates/registration/password_reset_form.html
+++ b/src/nyc_trees/templates/registration/password_reset_form.html
@@ -6,7 +6,7 @@
 {% block content %}
 <p>
     {% blocktrans %}
-    Forgot your password?  Enter your email in the form below and we'll send you instructions for creating a new one.
+    Forgot your password?  Enter your email address or username in the form below and we'll send you instructions for creating a new one.
     {% endblocktrans %}
 </p>
 <form method="post" action="">


### PR DESCRIPTION
The contrib.auth password reset workflow is hard coded to only accept an email address, so I had to reimplement the view logic in addition to tweaking the form.

Fixes #168 
