### PR TITLE
Fix collapsing section behavior on profile

### DIFF
--- a/src/nyc_trees/apps/users/templates/users/partials/profile/section.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/section.html
@@ -4,7 +4,7 @@
    </a>
 </h4>
 
-<div id="{{ section_id }}">
+<div id="{{ section_id }}" class="collapse in">
     {% block section_content %}
     {% endblock section_content %}
 </div>


### PR DESCRIPTION
Adding this class informs the Bootstrap widget that the sections are expanded when they are first rendered.

Fixes #157 
