### PR TITLE
Include image file data when editing group

### DIFF
--- a/src/nyc_trees/apps/users/templates/groups/settings.html
+++ b/src/nyc_trees/apps/users/templates/groups/settings.html
@@ -41,7 +41,7 @@
                     <div class="tab-content">
                         <div class="tab-pane active" id="details">
 
-                            <form method="POST">
+                            <form method="POST" enctype="multipart/form-data">
                               {% csrf_token %}
 
                                 <fieldset>

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -64,7 +64,8 @@ def edit_group(request):
 
 
 def update_group_settings(request):
-    form = GroupSettingsForm(request.POST, instance=request.group)
+    form = GroupSettingsForm(request.POST, request.FILES,
+                             instance=request.group)
     if form.is_valid():
         form.save()
         return HttpResponseRedirect(request.group.get_absolute_url())


### PR DESCRIPTION
This was mistakenly omitted from the initial implementation of the group edit form.

Fixes #170
