### PR TITLE
Make events on group detail page clickable

### DIFF
--- a/src/nyc_trees/apps/event/models.py
+++ b/src/nyc_trees/apps/event/models.py
@@ -6,6 +6,7 @@ from __future__ import division
 import shortuuid
 
 from django.contrib.gis.db import models
+from django.core.urlresolvers import reverse
 from django.utils.text import slugify
 
 from apps.core.models import User, Group
@@ -55,6 +56,10 @@ class Event(NycModel, models.Model):
     @property
     def has_space_available(self):
         return self.eventregistration_set.count() < self.max_attendees
+
+    def get_absolute_url(self):
+        return reverse('event_detail', kwargs={'group_slug': self.group.slug,
+                                               'event_slug': self.slug})
 
     class Meta:
         unique_together = (("group", "slug"), ("group", "title"))

--- a/src/nyc_trees/apps/event/templates/event/partials/event_section.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/event_section.html
@@ -1,6 +1,7 @@
 {% with event=info.event %}
 
-<a href="#" class="event block item">
+{# If the user can edit the group, there will be a popover menu. Should not show "rightarrow" #}
+<a href="{{ event.get_absolute_url }}" class="event block item {% if not user_can_edit_group %} rightarrow{% endif %}">
     <div class="row">
         <div class="event-date col-xs-3">
             <div class="event-month">{{ event.begins_at.date|date:"M" }}</div>

--- a/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
@@ -1,6 +1,7 @@
 {% extends 'event/partials/event_section.html' %}
 
 {% block extra_markup %}
+{% if user_can_edit_group %}
 <div class="dropdown text-right">
     <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-expanded="true">
         <span class="caret"></span>
@@ -33,4 +34,5 @@
         </li>
     </ul>
 </div>
+{% endif %}
 {% endblock extra_markup %}


### PR DESCRIPTION
This follows the design from the wireframes. Group admins see a dropdown menu and everyone else sees a right-facing chevron. For all users, tapping on the event row navigates to the event detail page.

(Note: This reimplements 9a9d77b1 and I plan to rebase this pull once that commit has been merged into develop)

Fixes #191 
