### PR TITLE
On Windows, don't rsync the `apps` folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.vm.synced_folder ".", "/vagrant", disabled: true
 
     if Vagrant::Util::Platform.windows? || Vagrant::Util::Platform.cygwin?
-      app.vm.synced_folder "src/nyc_trees", "/opt/app/", type: "rsync", rsync__exclude: "node_modules/"
+      app.vm.synced_folder "src/nyc_trees", "/opt/app/", type: "rsync", rsync__exclude: ["node_modules/", "apps/"]
+      app.vm.synced_folder "src/nyc_trees/apps", "/opt/app/apps"
     else
       app.vm.synced_folder "src/nyc_trees", "/opt/app/"
     end


### PR DESCRIPTION
Make `apps` a true shared folder, and have the rsync ignore it.

Otherwise, when you do "makemigrations" the migration files are created on your VM. You have to copy them out manually before your next rsync or they will be clobbered.
