### PR TITLE
Prevent minors from making public profiles

### DIFF
--- a/src/nyc_trees/apps/core/tests.py
+++ b/src/nyc_trees/apps/core/tests.py
@@ -24,6 +24,40 @@ class UserModelTest(TestCase):
         self.assertIn('email', ec.exception.error_dict)
 
 
+class UserPrivacyTest(TestCase):
+    def assert_clean_raises_validation_error(self, model, field):
+        try:
+            model.clean()
+            self.fail('Expected clean to raise a ValidationError')
+        except ValidationError as ve:
+            self.assertTrue(field in ve.message_dict,
+                            'Expected the message_dict of the ValidationError '
+                            'to contain %s' % field)
+
+    def test_minor_cant_make_profile_public(self):
+        kid = User(is_minor=True, profile_is_public=True)
+        self.assert_clean_raises_validation_error(kid, 'profile_is_public')
+
+    def test_minor_cant_make_real_name_public(self):
+        kid = User(is_minor=True, real_name_is_public=True)
+        self.assert_clean_raises_validation_error(kid, 'real_name_is_public')
+
+    def test_minor_cant_make_group_follows_public(self):
+        kid = User(is_minor=True, group_follows_are_public=True)
+        self.assert_clean_raises_validation_error(kid,
+                                                  'group_follows_are_public')
+
+    def test_minor_cant_make_contributions_public(self):
+        kid = User(is_minor=True, contributions_are_public=True)
+        self.assert_clean_raises_validation_error(kid,
+                                                  'contributions_are_public')
+
+    def test_minor_cant_make_achievements_public(self):
+        kid = User(is_minor=True, achievements_are_public=True)
+        self.assert_clean_raises_validation_error(kid,
+                                                  'achievements_are_public')
+
+
 class GroupModelTest(TestCase):
     def test_slugification(self):
         user = User.objects.create(username='hfarnesworth',

--- a/src/nyc_trees/apps/users/templates/users/profile.html
+++ b/src/nyc_trees/apps/users/templates/users/profile.html
@@ -30,9 +30,12 @@
                         <div class="col-xs-6">
                             {% if user.profile_is_public %}Public{% else %}Private{% endif %} Profile
                         </div>
+                        {# A minor's profile is always private #}
+                        {% if not user.is_minor %}
                         <div class="col-xs-6 text-right">
                             <a class="btn btn-primary" href="#privacy-popup" data-toggle="modal">Privacy</a>
                         </div>
+                        {% endif %}
                     </div>
                 </div>
                 {% endif %}
@@ -63,7 +66,7 @@
                 </section>
                 {% endif %}
 
-                {% if viewing_own_profile and not user.profile_is_public%}
+                {% if viewing_own_profile and not user.profile_is_public and not user.is_minor %}
                     <div class="block highlight">
                         <h5>Tip:</h5>
                         Want to share your progress and information with the tree mapping community?

--- a/src/nyc_trees/apps/users/templates/users/settings.html
+++ b/src/nyc_trees/apps/users/templates/users/settings.html
@@ -25,9 +25,12 @@
                         <li>
                             <a href="#emails-pane" data-toggle="tab">Emails</a>
                         </li>
+                        {# A minor's profile is always private #}
+                        {% if not request.user.is_minor %}
                         <li>
                             <a href="#privacy-pane" data-toggle="tab">Privacy</a>
                         </li>
+                        {% endif %}
                     </ul>
                 </div>
 
@@ -67,9 +70,12 @@
                                 {{ event_formset.management_form }}
                             </div>
 
+                            {# A minor's profile is always private #}
+                            {% if not request.user.is_minor %}
                             <div class="tab-pane" id="privacy-pane">
                                 {% include 'users/partials/privacy_controls.html' %}
                             </div>
+                            {% endif %}
 
                             <hr>
 

--- a/src/nyc_trees/apps/users/uitests.py
+++ b/src/nyc_trees/apps/users/uitests.py
@@ -150,3 +150,50 @@ class FollowGroupUITest(BaseGroupUITest):
         self._click_follow()
         self._click_unfollow()
         self._click_follow()
+
+
+class UserPrivacyUITest(NycTreesSeleniumTestCase):
+    def setUp(self):
+        super(UserPrivacyUITest, self).setUp()
+        self.minor_user = User(username='kid', email='kid@cool.com',
+                               is_minor=True)
+        self.minor_user.set_password('password')
+        self.minor_user.save()
+
+        self.adult_user = User(username='adult', email='adult@business.biz')
+        self.adult_user.set_password('password')
+        self.adult_user.save()
+
+    def test_adult_can_see_privacy_button_on_profile(self):
+        self.login(self.adult_user.username)
+        self.get(self.adult_user.get_absolute_url())
+        self.wait_for_text(self.adult_user.username)
+        self.wait_for_element('a[href="#privacy-popup"]')
+
+    def test_minor_cannot_see_privacy_button_on_profile(self):
+        self.login(self.minor_user.username)
+        self.get(self.minor_user.get_absolute_url())
+        self.wait_for_text(self.minor_user.username)
+        self.assert_text_not_in_body("Privacy")
+
+    def test_adult_can_see_privacy_tab_on_settings(self):
+        self.login(self.adult_user.username)
+        self.get(reverse('user_profile_settings'))
+        self.wait_for_text(self.adult_user.username)
+        self.wait_for_element('#privacy-pane')
+
+    def test_minor_cannot_see_privacy_tab_on_settings(self):
+        self.login(self.minor_user.username)
+        self.get(reverse('user_profile_settings'))
+        self.wait_for_text(self.minor_user.username)
+        self.assert_text_not_in_body("Privacy")
+
+    def test_adult_sees_privacy_invitation_on_profile(self):
+        self.login(self.adult_user.username)
+        self.get(self.adult_user.get_absolute_url())
+        self.wait_for_text('Make your profile public')
+
+    def test_minor_does_not_see_privacy_invitation_on_profile(self):
+        self.login(self.minor_user.username)
+        self.get(self.minor_user.get_absolute_url())
+        self.assert_text_not_in_body('Make your profile public')


### PR DESCRIPTION
To prevent exposing personally identifiable information about a minor to the internet, we are preventing under age users from making their profile public. This pull implements validations to prevent setting any of the privacy flags to `True` if `is_minor` is `True` and also hides the privacy sections of the UI from under age users, preventing them from even attempting to change the settings.

Fixes #214
