### PR TITLE
Fix group list expansion styling on profile page

### DIFF
--- a/src/nyc_trees/apps/users/templates/users/partials/profile/groups.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/groups.html
@@ -12,8 +12,9 @@
 {% endfor %}
 
 {% if follows.hidden_count > 0 %}
-<a data-class="user-profile-groups-show-all"
-   href="#">+{{ follows.hidden_count }} more group{{ hidden_count|pluralize }}</a>
+<a data-class="user-profile-groups-show-all" href="javascript:;" class="group block item">
+   <div class="row"><div class="col-xs-12">+{{ follows.hidden_count }} more group{{ follows.hidden_count|pluralize }}</div></div>
+</a>
 {% endif %}
 
 {% endblock section_content %}


### PR DESCRIPTION
I copied the style of the other rows to fix a whitespace problem, and fixed a bug in the pluralization filter.

Before:

![screen shot 2014-12-30 at 2 48 40 pm](https://cloud.githubusercontent.com/assets/17363/5583271/04f0cdc0-9033-11e4-8a12-ff89d9889d2e.png)

After:

![screen shot 2014-12-30 at 2 48 05 pm](https://cloud.githubusercontent.com/assets/17363/5583274/0d3d0bb0-9033-11e4-9058-765f6460d01c.png)

This is the last bit of styling to implement for #158
