### PR TITLE
Add support for running Vagrant environments in parallel

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,33 +95,32 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     services.vm.hostname = "services"
     services.vm.network "private_network", ip: SERVICES_IP
 
-
     services.vm.synced_folder ".", "/vagrant", disabled: true
 
     # Graphite Web
     services.vm.network "forwarded_port", {
       guest: 8080,
-      host: ENV.fetch("NYC_TREES_PORT_8080", 8080)
+      host: 8080
     }.merge(VAGRANT_NETWORK_OPTIONS)
     # Kibana
     services.vm.network "forwarded_port", {
       guest: 5601,
-      host: ENV.fetch("NYC_TREES_PORT_5601", 15601),
+      host: 15601
     }.merge(VAGRANT_NETWORK_OPTIONS)
     # PostgreSQL
     services.vm.network "forwarded_port", {
       guest: 5432,
-      host: ENV.fetch("NYC_TREES_PORT_5432", 15432)
+      host: 15432
     }.merge(VAGRANT_NETWORK_OPTIONS)
     # Pgweb
     services.vm.network "forwarded_port", {
       guest: 5433,
-      host: ENV.fetch("NYC_TREES_PORT_5433", 15433)
+      host: 15433
     }.merge(VAGRANT_NETWORK_OPTIONS)
     # Redis
     services.vm.network "forwarded_port", {
       guest: 6379,
-      host: ENV.fetch("NYC_TREES_PORT_6379", 16379)
+      host: 16379
     }.merge(VAGRANT_NETWORK_OPTIONS)
 
     services.vm.provider "virtualbox" do |v|
@@ -152,7 +151,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "app" do |app|
     app.vm.hostname = "app"
-    app.vm.network "private_network", ip: ENV.fetch("NYC_TREES_APP_IP", "33.33.33.10")
+    app.vm.network "private_network", type: "dhcp", ip: "33.33.33.10"
 
     app.vm.synced_folder ".", "/vagrant", disabled: true
 
@@ -166,7 +165,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Django via Nginx/Gunicorn
     app.vm.network "forwarded_port", {
       guest: 80,
-      host: ENV.fetch("NYC_TREES_PORT_8000", 8000)
+      host: 8000
     }.merge(VAGRANT_NETWORK_OPTIONS)
     # Livereload server (for gulp watch)
     app.vm.network "forwarded_port", {
@@ -176,7 +175,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Testem server
     app.vm.network "forwarded_port", {
       guest: 7357,
-      host: ENV.fetch("NYC_TREES_PORT_7357", 7357)
+      host: 7357
     }.merge(VAGRANT_NETWORK_OPTIONS)
 
     app.ssh.forward_x11 = true

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -5,6 +5,8 @@ developing: "'development' in group_names"
 not_developing: "'development' not in group_names"
 packing: "'packer' in group_names"
 
+django_test_database: "{{ lookup('env', 'NYC_TREES_TEST_DB_NAME') | default('test_nyc_trees', true) }}"
+
 sauce_labs_api_key_is_defined: lookup('env', 'SAUCE_API_KEY') != ''
 
 redis_port: 6379

--- a/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
@@ -8,6 +8,7 @@ app_config:
   - { file: "NYC_TREES_DB_PASSWORD", content: "{{ postgresql_password }}" }
   - { file: "NYC_TREES_DB_HOST", content: "{{ postgresql_host }}" }
   - { file: "NYC_TREES_DB_PORT", content: "{{ postgresql_port }}" }
+  - { file: "NYC_TREES_TEST_DB_NAME", content: "{{ django_test_database }}" }
   - { file: "NYC_TREES_STATSD_HOST", content: "{{ statsite_host }}" }
   - { file: "DJANGO_SETTINGS_MODULE", content: "{{ django_settings_module }}" }
   - { file: "DJANGO_STATIC_ROOT", content: "{{ app_static_root }}" }

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -47,7 +47,8 @@ DATABASES = {
         'USER': environ.get('NYC_TREES_DB_USER', 'nyc_trees'),
         'PASSWORD': environ.get('NYC_TREES_DB_PASSWORD', 'nyc_trees'),
         'HOST': environ.get('NYC_TREES_DB_HOST', 'localhost'),
-        'PORT': environ.get('NYC_TREES_DB_PORT', 5432)
+        'PORT': environ.get('NYC_TREES_DB_PORT', 5432),
+        'TEST_NAME': environ.get('NYC_TREES_TEST_DB_NAME', 'test_nyc_trees')
     }
 }
 


### PR DESCRIPTION
This changeset builds on the environmental variable virtual machine IP assignment by making IP address assignment to the application virtual machine occur via DHCP. In addition, the `NYC_TREES_TEST_DB_NAME` environmental variable provides a way to change the test database.