### PR TITLE
Make application log writable by owning group

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/tasks/log-rotation.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/log-rotation.yml
@@ -4,7 +4,7 @@
            creates={{ app_log }}
 
 - name: Set log file permissions
-  file: path={{ app_log }} owner=nyc-trees group=nyc-trees mode=0644
+  file: path={{ app_log }} owner=nyc-trees group=nyc-trees mode=0664
 
 - name: Configure Gunicorn log rotation
   template: src=logrotate-nyc-trees-app.j2 dest=/etc/logrotate.d/nyc-trees-app


### PR DESCRIPTION
This changeset give the `nyc-trees` write permission to the application log file. Originally this was disabled because it was presumed that only the application service account would be writing logs. This isn't the case during local development (`vagrant` user).

Resolves: #254

---

```
$ ./scripts/debugserver.sh
+ vagrant ssh app -c 'sudo service nyc-trees-app stop || /bin/true'
Connection to 127.0.0.1 closed.
+ vagrant ssh app -c 'cd /opt/app/ && envdir /etc/nyc-trees.d/env gunicorn --config /etc/nyc-trees.d/gunicorn.py nyc_trees.wsgi'
^CConnection to 127.0.0.1 closed.

$ vagrant ssh app
Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-43-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Tue Jan  6 16:12:37 UTC 2015

  System load:  0.02              Processes:           77
  Usage of /:   4.8% of 39.34GB   Users logged in:     0
  Memory usage: 20%               IP address for eth0: 10.0.2.15
  Swap usage:   0%                IP address for eth1: 33.33.33.3

  Graph this data and manage this system at:
    https://landscape.canonical.com/

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud


Last login: Tue Jan  6 16:12:37 2015 from 10.0.2.2
vagrant@app:~$ cat /var/log/nyc-trees-app.log
[2015-01-06 11:12:38 +0000] [30316] [INFO] Starting gunicorn 19.1.1
[2015-01-06 11:12:38 +0000] [30316] [INFO] Listening at: http://127.0.0.1:8000 (30316)
[2015-01-06 11:12:38 +0000] [30316] [INFO] Using worker: sync
[2015-01-06 11:12:38 +0000] [30327] [INFO] Booting worker with pid: 30327
[2015-01-06 11:12:38 +0000] [30328] [INFO] Booting worker with pid: 30328
[2015-01-06 11:12:40 +0000] [30327] [INFO] Worker exiting (pid: 30327)
[2015-01-06 11:12:40 +0000] [30316] [INFO] Handling signal: int
[2015-01-06 11:12:40 +0000] [30328] [INFO] Worker exiting (pid: 30328)
[2015-01-06 11:12:40 +0000] [30316] [INFO] Shutting down: Master
```