### PR TITLE
Force square group images

### DIFF
--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -15,7 +15,9 @@
                         <div class="col-xs-4">
                             {# TODO: Show a default image if group.image is null #}
                             {% if group.image %}
-                            <img class="group-branding" src="{{group.image.url}}"/>
+                            <div class="group-branding">
+                                <img src="{{group.image.url}}"/>
+                            </div>
                             {% endif %}
                         </div>
                         <div class="col-xs-8">

--- a/src/nyc_trees/sass/partials/_groups.scss
+++ b/src/nyc_trees/sass/partials/_groups.scss
@@ -1,7 +1,6 @@
 .group-branding {
+  width: 100px;
+  height: 100px;
   border-radius: 50%;
-  background-color: blue;
+  overflow: hidden;
 }
-
-
-


### PR DESCRIPTION
This will force the group icons to have the same height and width.

Downside: forcing this using css means we need to specify a height and width. We'll need to use media queries to adjust this based on screen size, which is a bit of a pain, but not bad.

In terms of style, I suspect that these will change a bit once we are looking at some real logos, but this will prevent the "oval effect" for now.