### PR TITLE
Delegate NPM upgrade to Node.js role

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -23,3 +23,5 @@ postgresql_package_version: "9.3.5-2.pgdg14.04+1"
 postgresql_support_repository_channel: "9.3"
 
 elasticsearch_cluster_name: "logstash"
+
+nodejs_npm_version: 2.1.14

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,7 +1,7 @@
 azavea.apache2,0.2.1
 azavea.ntp,0.1.0
 azavea.pip,0.1.0
-azavea.nodejs,0.2.0
+azavea.nodejs,0.3.0
 azavea.postgresql,0.2.1
 azavea.postgresql-support,0.2.0
 azavea.postgis,0.1.1

--- a/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
@@ -37,7 +37,6 @@ app_media_root: /var/www/nyc-trees/media/
 
 app_static_cache: /var/cache/nyc-trees/static/
 
-app_npm_version: 2.1.14
 app_sass_version: 3.4.9
 app_postgis_version: 2.1.6
 app_secret_key: "{{ postgresql_password | md5 }}"

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -6,6 +6,6 @@ dependencies:
   - { role: "azavea.postgresql-support" }
   - { role: "azavea.daemontools" }
   - { role: "azavea.nginx", nginx_delete_default_site: True }
-  - { role: "nyc-trees.nodejs" }
+  - { role: "azavea.nodejs" }
   - { role: "azavea.ruby" }
   - { role: "azavea.sauce-connect", when: sauce_labs_api_key_is_defined }

--- a/deployment/ansible/roles/nyc-trees.nodejs/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.nodejs/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - { role: "azavea.nodejs" }

--- a/deployment/ansible/roles/nyc-trees.nodejs/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.nodejs/tasks/main.yml
@@ -1,8 +1,0 @@
----
-- name: Determine what version of NPM is installed
-  command: npm --version
-  register: npm_version
-
-- name: Upgrade NPM
-  command: "/usr/local/node-v{{ nodejs_version }}-{{ nodejs_os }}-{{ nodejs_arch }}/bin/npm install --global --force npm@{{ app_npm_version }}"
-  when: npm_version.stdout != app_npm_version


### PR DESCRIPTION
This changeset delegates the task of upgrading NPM to the Node.js role. Support for upgrading NPM was added in v0.3.0.

See also: https://github.com/azavea/ansible-nodejs/pull/4