### PR TITLE
Add support for log shipping to Logstash via Beaver

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -23,3 +23,4 @@ azavea.java,0.1.1
 azavea.curator,0.1.0
 azavea.ruby,0.3.0
 azavea.sauce-connect,0.2.0
+azavea.beaver,0.1.0

--- a/deployment/ansible/roles/nyc-trees.beaver/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.beaver" }

--- a/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
-- name: Configure Beaver to collect Nginx logs
-  template: src=nginx.conf.j2
-            dest="{{ beaver_conf_dir }}/conf.d/nginx"
+- name: Configure Beaver to ship logs
+  template: src="{{ item }}.conf.j2"
+            dest="{{ beaver_conf_dir }}/conf.d/{{ item }}"
+  with_items:
+    - nginx
+    - django
   notify:
     - Restart Beaver
 

--- a/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Configure Beaver to collect Nginx logs
+  template: src=nginx.conf.j2
+            dest="{{ beaver_conf_dir }}/conf.d/nginx"
+  notify:
+    - Restart Beaver
+
+- name: Add Beaver user to service group
+  user: name=beaver
+        append=yes
+        groups=adm
+        state=present

--- a/deployment/ansible/roles/nyc-trees.beaver/templates/django.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.beaver/templates/django.conf.j2
@@ -1,0 +1,5 @@
+[/var/log/{upstart/nyc-trees-app.log,nyc-trees-app.log}]
+multiline_regex_after = (^\s+File.*, line \d+, in)
+multiline_regex_before = (^Traceback \(most recent call last\):)|(^\s+File.*, line \d+, in)|(^\w+Error: )
+type: django
+tags: django,beaver

--- a/deployment/ansible/roles/nyc-trees.beaver/templates/nginx.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.beaver/templates/nginx.conf.j2
@@ -1,0 +1,13 @@
+[/var/log/nginx/error.log]
+type: nginx
+tags: nginx,beaver
+
+[/var/log/nginx/access.log]
+format: rawjson
+type: nginx
+tags: nginx,beaver
+
+[/var/log/nginx/*.access.log]
+format: rawjson
+type: nginx
+tags: nginx,beaver

--- a/deployment/ansible/roles/nyc-trees.beaver/vars/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/vars/main.yml
@@ -1,0 +1,3 @@
+---
+beaver_version: "33.0.0"
+beaver_redis_url: "redis://{{ redis_host }}:{{ redis_port }}/0"

--- a/deployment/ansible/roles/nyc-trees.monitoring/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.monitoring/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
   - { role: "azavea.relp" }
   - { role: "nyc-trees.collectd" }
+  - { role: "nyc-trees.beaver" }


### PR DESCRIPTION
This changeset adds support for Nginx and Django log shipping to the shared Logstash instance via Beaver. Nginx is already configured to emit its logs in JSON format. Beaver simply slurps them up and passes them along to Logstash. Django logs are shipped line-by-line unless they are a traceback, in that case the entire traceback is tucked into a single message.

![screen shot 2015-01-07 at 13 36 32](https://cloud.githubusercontent.com/assets/43639/5651094/859c652a-9672-11e4-814e-1ae7e657d64b.png)

![screen shot 2015-01-07 at 15 15 40](https://cloud.githubusercontent.com/assets/43639/5652746/8df092a0-9681-11e4-9187-6f8cba9a3098.png)
