### PR TITLE
Add geocoder interface to map module

### DIFF
--- a/src/nyc_trees/.jshintrc
+++ b/src/nyc_trees/.jshintrc
@@ -6,6 +6,7 @@
         "require": false,
         "module": true,
         "exports": true,
-        "config": false
+        "config": false,
+        "console": false
     }
 }

--- a/src/nyc_trees/apps/core/templates/core/settings.js
+++ b/src/nyc_trees/apps/core/templates/core/settings.js
@@ -3,5 +3,9 @@
 window.config = {
     "files": {
         "datetimepicker_polyfill.js": "{{ 'js/datetimepicker_polyfill.js'|static_url }}"
-    }
+    },
+    "urls": {
+        "geocode": "{% url 'geocode' %}"
+    },
+    "bounds": [[{{NYC_BOUNDS_YMIN}}, {{NYC_BOUNDS_XMIN}}], [{{NYC_BOUNDS_YMAX}}, {{NYC_BOUNDS_XMAX}}]]
 }

--- a/src/nyc_trees/apps/geocode/views.py
+++ b/src/nyc_trees/apps/geocode/views.py
@@ -59,7 +59,7 @@ def _make_response_dict(candidates):
     return {'candidates': candidates}
 
 
-def _omgeo_candidate_to_dict(candidate, srid=3857):
+def _omgeo_candidate_to_dict(candidate, srid=4326):
     p = Point(candidate.x, candidate.y, srid=candidate.wkid)
     if candidate.wkid != srid:
         p.transform(srid)
@@ -86,15 +86,15 @@ def _in_bbox(bbox, c):
 
 
 def _build_viewbox():
-    xmin, ymin, xmax, ymax = settings.GEOCODE_BBOX_WEBM
+    xmin, ymin, xmax, ymax = settings.NYC_BOUNDS
     return Viewbox(left=float(xmin),
                    right=float(xmax),
                    bottom=float(ymin),
                    top=float(ymax),
-                   wkid=3857)
+                   wkid=4326)
 
 
 def _build_bbox_dict():
-    xmin, ymin, xmax, ymax = settings.GEOCODE_BBOX_WEBM
+    xmin, ymin, xmax, ymax = settings.NYC_BOUNDS
     return {'xmin': xmin, 'ymin': ymin,
             'xmax': xmax, 'ymax': ymax}

--- a/src/nyc_trees/apps/home/templates/home/partials/location_search.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/location_search.html
@@ -1,0 +1,19 @@
+<script type="text/template" id="template-map-search-toolbar-button">
+    <a class="icon-search location-search-show-button" href="javascript:;" title="Search"></a>
+</script>
+
+<script type="text/template" id="template-map-search">
+    <div class="location-search-container" style="background: pink; display: none;">
+        <input type="text" class="location-search-box">
+        <a class="location-search-button" href="javascript:;" title="Run search">Search</a>
+        <a class="btn icon-cancel location-search-close" href="javascript:;" title="Close search"></a>
+        <div class="location-search-status" style="display: none;">Searching...</div>
+        <!-- location-search-results is appended to location-search-container -->
+    </div>
+</script>
+
+<script type="text/template" id="template-map-search-result-list">
+    <ul class="location-search-results">
+        <li class="location-search-result"><a href="javascript:;"><span class="location-address"></span></a></li>
+    </ul>
+</script>

--- a/src/nyc_trees/apps/home/templates/home/progress.html
+++ b/src/nyc_trees/apps/home/templates/home/progress.html
@@ -4,6 +4,7 @@
 {% block content %}
     <div id="map" style="width: 100%; height: 400px"></div>
     {% include 'home/partials/legend.html' %}
+    {% include 'home/partials/location_search.html' %}
 {% endblock content %}
 
 {% block page_js %}

--- a/src/nyc_trees/js/src/ajaxLatest.js
+++ b/src/nyc_trees/js/src/ajaxLatest.js
@@ -1,0 +1,83 @@
+"use strict";
+
+var $ = require('jquery');
+
+/*
+
+This module builds an "interruptible" ajax function that only delivers
+a successful response for the most recent request.
+
+NOTE: The implementation only supports promises, not callbacks.
+
+Usage:
+
+var ajaxLatest = require('./ajaxLatest'),
+    defaultOptions = {
+        url: '/some/endpoint,
+        type: 'GET',
+        dataType: 'json'
+    },
+    ajax = ajaxLatest(defaultOptions);
+
+    ajax({data:{q:'millennium falcon'}}).done(function(data){
+        alert(data);
+    }).fail(function(jqXhr, errorText, error){
+        if (error && error.superseded) {
+          // fail silently, since another request took over
+        } else {
+          // handle the real ajax error
+        }
+    });
+
+*/
+
+module.exports = function(defaultOptions) {
+    var requests = [],
+        deferreds = [],
+        isMostRecent = function(request) {
+            if (requests.length) {
+                return requests[requests.length - 1] === request;
+            } else {
+                return false;
+            }
+        },
+        actOn = function(request, fn) {
+            var interruptMessage = 'Another request interupted this one.';
+            while (requests.length) {
+                var req = requests.pop(),
+                    def = deferreds.pop();
+                if (req === request) {
+                    fn(def);
+                } else {
+                    req.abort();
+                    def.reject(req, interruptMessage, {
+                        superseded: true,
+                        error: interruptMessage
+                    });
+                }
+            }
+        };
+
+    return function(options) {
+        var request = $.ajax($.extend({}, defaultOptions, options)),
+            deferred = $.Deferred();
+        requests.push(request);
+        deferreds.push(deferred);
+
+        request.done(function(data) {
+            if (isMostRecent(request)) {
+                actOn(request, function(def) {
+                    def.resolve(data);
+                });
+            }
+        }).fail(function(jqXHR, textStatus, errorThrown) {
+            if (isMostRecent(request)) {
+                actOn(request, function(def) {
+                    def.reject(jqXHR, textStatus, errorThrown);
+                });
+            }
+        });
+
+        return deferred;
+    };
+};

--- a/src/nyc_trees/js/src/geocoder.js
+++ b/src/nyc_trees/js/src/geocoder.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var ajaxLatest = require('./ajaxLatest');
+
+module.exports = function(url) {
+    var ajax = ajaxLatest({
+        url: url,
+        type: 'GET',
+        dataType: 'json'
+    });
+    return function(address) {
+        return ajax({data: {address: address}});
+    };
+};

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -3,9 +3,8 @@
 var $ = require('jquery'),
     L = require('leaflet');
 
-var zoom = {
-    NEIGHBORHOOD: 16
-};
+var zoom = require('./mapUtil').zoom,
+    searchController = require('./searchController');
 
 module.exports = {
     create: create
@@ -30,12 +29,11 @@ function create(options) {
     if (options.legend) {
         initLegend($controlsContainer, map);
     }
+    if (options.search) {
+        initLocationSearch($controlsContainer, map);
+    }
 
-    // New York City bounds from http://www.mapdevelopers.com/geocode_bounding_box.php
-    map.fitBounds([
-        [40.495996, -74.259088],
-        [40.915256, -73.700272]
-    ]);
+    map.fitBounds(config.bounds);
 
     return map;
 }
@@ -65,6 +63,10 @@ function initGeolocation($controlsContainer, map) {
         window.alert('Unable to show your location.');
     }
 
+}
+
+function initLocationSearch($controlsContainer, map) {
+    searchController.create($controlsContainer, map);
 }
 
 function initLegend($controlsContainer, map) {

--- a/src/nyc_trees/js/src/mapUtil.js
+++ b/src/nyc_trees/js/src/mapUtil.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var zoom = {
+    NEIGHBORHOOD: 16
+};
+
+module.exports = {
+    zoom: Object.freeze ? Object.freeze(zoom) : zoom,
+
+    setCenterAndZoomLL: function(map, zoom, location) {
+        // Never zoom out, or try to zoom farther than allowed.
+        var zoomToApply = Math.max(
+            map.getZoom(),
+            Math.min(zoom, map.getMaxZoom()));
+
+        map.setView(location, zoomToApply);
+    }
+};

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -2,5 +2,6 @@
 
 require('./map').create({
     geolocation: true,
-    legend: true
+    legend: true,
+    search: true
 });

--- a/src/nyc_trees/js/src/searchController.js
+++ b/src/nyc_trees/js/src/searchController.js
@@ -1,0 +1,164 @@
+"use strict";
+
+var $ = require('jquery'),
+    L = require('leaflet'),
+    geocoder = require('./geocoder'),
+    zoom = require('./mapUtil').zoom,
+    setCenterAndZoomLL = require('./mapUtil').setCenterAndZoomLL;
+
+module.exports = {create: create};
+
+function locationSearch(options) {
+    var $textbox = options.$textbox,
+        $button = options.$button,
+        searching = options.searching || $.noop,
+        found = options.found || $.noop,
+        notFound = options.notFound || $.noop,
+        failure = options.failure || $.noop,
+        geocode = geocoder(options.url),
+        cache = {};
+
+    $textbox.on('keypress', function(e){
+        if (e.keyCode === 13) {
+            $button.click();
+        }
+    });
+
+    $button.on('click', function(e) {
+        var address = $textbox.val().trim();
+        if (!address) {
+            return;
+        }
+        if (cache[address]) {
+            found(cache[address]);
+            return;
+        }
+        searching();
+        geocode(address).done(function(data) {
+            cache[address] = data;
+            found(data);
+        }).fail(function(jqXHR, textStatus, error) {
+            if (!error || !error.superseded) {
+                if (jqXHR.status === 404) {
+                    notFound();
+                } else {
+                    failure(jqXHR, textStatus, error);
+                }
+            }
+        });
+    });
+}
+
+function create($controlsContainer, map) {
+    var searchInProgress = false,
+
+        $showSearchButton = $($('#template-map-search-toolbar-button').html()),
+
+        $searchControlContainer = $($('#template-map-search').html()),
+
+        $textbox = $searchControlContainer.find('.location-search-box'),
+        $doSearchButton = $searchControlContainer.find('.location-search-button'),
+        $status = $searchControlContainer.find('.location-search-status'),
+        $closeSearchButton = $searchControlContainer.find('.location-search-close'),
+
+        SearchControl = L.Control.extend({
+            options: {
+                position: 'topleft'
+            },
+            onAdd: function (map) {
+                // The [0] returns the native DOM element
+                return $searchControlContainer[0];
+            }
+        }),
+        searchControl = new SearchControl(),
+
+        toggleSearch = function() {
+            $showSearchButton.toggleClass('active');
+            $searchControlContainer.toggle();
+            if ($textbox.is(':visible')) {
+                $textbox.focus().select();
+            }
+        },
+
+        updateStatus = function(message, isSearching) {
+            if (message) {
+                $status.text(message).show();
+            } else {
+                $status.hide();
+            }
+            searchInProgress = !!isSearching;
+        },
+
+        addCandidateToList = function($list, $newItem, candidate) {
+            $newItem.find('.location-address').text(candidate.address);
+            $newItem.on('click', 'a',  function() {
+                $list.find('a').off('click');
+                $list.remove();
+                zoomToCandidate(candidate);
+            });
+            $list.append($newItem);
+        },
+
+        showCandidates = function(candidates) {
+            var $list = $($('#template-map-search-result-list').html()),
+                $itemTemplate;
+            updateStatus('Choose an address or search again');
+            $searchControlContainer.find('.location-search-results').remove();
+            $searchControlContainer.append($list);
+            $itemTemplate = $searchControlContainer.find('.location-search-result');
+            $searchControlContainer.find('.location-search-result').remove();
+
+            for(var i = 0, count = candidates.length; i < count; i++) {
+                addCandidateToList($list, $itemTemplate.clone(), candidates[i]);
+            }
+        },
+
+        zoomToCandidate = function(candidate) {
+            var point = L.latLng(candidate.y, candidate.x);
+            setCenterAndZoomLL(map, zoom.NEIGHBORHOOD, point);
+            updateStatus();
+        },
+
+        searching = function() {
+            updateStatus('Searching...', true);
+        },
+
+        found = function(result) {
+            if (result.candidates.length === 1) {
+                zoomToCandidate(result.candidates[0]);
+            } else {
+                showCandidates(result.candidates);
+            }
+        },
+
+        notFound = function() {
+            updateStatus('Sorry, we could not find a location for that address.');
+        },
+
+        failure = function(jqXHR, textStatus, error) {
+            updateStatus('Sorry, there was a problem finding that location.');
+            console.log('Unexpected geocode error: ' + textStatus + ' ' + error);
+        };
+
+    $controlsContainer.prepend($showSearchButton);
+    map.addControl(searchControl);
+
+    locationSearch({
+        url: config.urls.geocode,
+        $button: $doSearchButton,
+        $textbox: $textbox,
+        searching: searching,
+        found: found,
+        notFound: notFound,
+        failure: failure
+    });
+
+    $showSearchButton.on('click', toggleSearch);
+    $closeSearchButton.on('click', toggleSearch);
+
+    $textbox.on('keydown', function(e) {
+        if (!searchInProgress) {
+            updateStatus();
+        }
+    });
+}

--- a/src/nyc_trees/nyc_trees/context_processors.py
+++ b/src/nyc_trees/nyc_trees/context_processors.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf import settings
+
+
+def nyc_bounds(request):
+    return {'NYC_BOUNDS_XMIN': float(settings.NYC_BOUNDS[0]),
+            'NYC_BOUNDS_YMIN': float(settings.NYC_BOUNDS[1]),
+            'NYC_BOUNDS_XMAX': float(settings.NYC_BOUNDS[2]),
+            'NYC_BOUNDS_YMAX': float(settings.NYC_BOUNDS[3])}

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -150,6 +150,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.tz',
     'django.contrib.messages.context_processors.messages',
     'django.core.context_processors.request',
+    'nyc_trees.context_processors.nyc_bounds',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
@@ -273,9 +274,8 @@ OMGEO_SETTINGS = [[
     'omgeo.services.EsriWGS', {}
 ]]
 
-# A conservative bounding box around New York City, drawn freehand
-# on boundingbox.info
-GEOCODE_BBOX_WEBM = (-8279353, 4934956, -8200470, 5005583)
+# New York City bounds from http://www.mapdevelopers.com/geocode_bounding_box.php
+NYC_BOUNDS = (-74.259088, 40.495996, -73.700272, 40.915256)
 
 # If geocoding a string produces no results, this string will be
 # appended for a second attempt.


### PR DESCRIPTION
The geocode interface is split into three layers:

The geocode interface is split into three layers:

1. A generic ``ajaxLatest`` module that allows for interruptible requests.
2. A wrapper around the geocode AJAX requests that converts responses to events.
3.  A controller that pulls markup from template script tags and manages the display of UI elements in response to user events and geocode events.

To keep the ``map`` module lean, I moved a lot of code initially written in that module out to ``searchController``, but I needed access to map zooming helpers that were initially added to ``map``. My solution was to move the helpers out to a new ``mapUtils`` module.

I consulted @jfrankl on the mechanics of how to display the search controls, error messages, and results. The generated markup follows Jeff's design, but needs styling.