### PR TITLE
Pull service virtual machine IP in Ansible vs. Vagrant

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -9,3 +9,11 @@ postgresql_password: nyc_trees
 postgresql_database: nyc_trees
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "33.33.33.1/24", method: "md5" }
+
+services_ip: "{{ lookup('env', 'NYC_TREES_SERVICES_IP') | default('33.33.33.30', true) }}"
+
+redis_host: "{{ services_ip }}"
+postgresql_host: "{{ services_ip }}"
+relp_host: "{{ services_ip }}"
+graphite_host: "{{ services_ip }}"
+statsite_host: "{{ services_ip }}"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -9,3 +9,11 @@ postgresql_password: nyc_trees
 postgresql_database: nyc_trees
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "33.33.33.1/24", method: "md5" }
+
+services_ip: "{{ lookup('env', 'NYC_TREES_SERVICES_IP') | default('33.33.33.30', true) }}"
+
+redis_host: "{{ services_ip }}"
+postgresql_host: "{{ services_ip }}"
+relp_host: "{{ services_ip }}"
+graphite_host: "{{ services_ip }}"
+statsite_host: "{{ services_ip }}"


### PR DESCRIPTION
This changeset alters the changes made in #244 by accessing environmental variable directly in Ansible vs. funneling them through Vagrant's Ansible provisioner `extra_vars`.

The goal here is to avoid an edge case in how Vagrant passes `extra_vars` to the `ansible-playbook` command in a Windows/Cygwin environment.

Attempts to resolve #260.