### PR TITLE
Make application UI visible in test mode

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/test.py
+++ b/src/nyc_trees/nyc_trees/settings/test.py
@@ -3,6 +3,8 @@ import os
 from base import *  # NOQA
 
 # TEST SETTINGS
+ALLOWED_HOSTS = ['localhost']
+
 PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )


### PR DESCRIPTION
This changeset adds an entry to `ALLOWED_HOSTS` so that the application UI can be viewed in test mode. My understanding is that test mode disables Django's debug mode, which triggers `ALLOWED_HOSTS` filtering.