### PR TITLE
Enable Django flatpages for training material

### DIFF
--- a/src/nyc_trees/apps/home/routes.py
+++ b/src/nyc_trees/apps/home/routes.py
@@ -16,3 +16,6 @@ progress_page = route(GET=do(render_template('home/progress.html'),
                              v.progress_page))
 
 retrieve_job_status = do(v.retrieve_job_status)
+
+training_list_page = route(GET=do(render_template('home/training.html'),
+                                  v.training_list_page))

--- a/src/nyc_trees/apps/home/templates/flatpages/default.html
+++ b/src/nyc_trees/apps/home/templates/flatpages/default.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+    {{ flatpage.content }}
+{% endblock content %}

--- a/src/nyc_trees/apps/home/templates/home/training.html
+++ b/src/nyc_trees/apps/home/templates/home/training.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% endblock %}

--- a/src/nyc_trees/apps/home/urls.py
+++ b/src/nyc_trees/apps/home/urls.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from django.conf.urls import patterns, url
+from django.conf.urls import patterns, url, include
 
 from apps.home import routes as r
 
@@ -17,11 +17,9 @@ urlpatterns = patterns(
     url(r'^jobs/(?P<job_id>\d+)/$', r.retrieve_job_status,
         name='retrieve_job_status'),
 
-    # TODO: The following are all good candidates for the Django flatpages app
-    #
-    # url(r'^faq/$', route(GET=faq_page)),
-    # url(r'^about/$', route(GET=about_page)),
-    # url(r'^training/$', route(GET=training_material_list_page)),
-    # url(r'^training/(?P<training_material_url_name>\w+)/$',
-    #     route(GET=training_material_detail_page)),
+    url(r'^training/$', r.training_list_page),
+
+    # "training" instead of "training/" because the flatpages admin interface
+    # insists that the "URL" (really a URL segment) start with a leading slash
+    url(r'^training', include('django.contrib.flatpages.urls')),
 )

--- a/src/nyc_trees/apps/home/views.py
+++ b/src/nyc_trees/apps/home/views.py
@@ -20,6 +20,11 @@ def progress_page(request):
     return context
 
 
+def training_list_page(request):
+    # TODO: implement
+    return {}
+
+
 def retrieve_job_status(request):
     # TODO: implement
     pass

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -13,9 +13,10 @@ DJANGO_ROOT = dirname(dirname(abspath(__file__)))
 # Absolute filesystem path to the top-level nyc_trees/ folder:
 SITE_ROOT = dirname(DJANGO_ROOT)
 
-
 # Site name:
 SITE_NAME = basename(DJANGO_ROOT)
+
+SITE_ID = 1  # Needed by django.contrib.sites (used by Django flatpages)
 
 # Add our project to our pythonpath, this way we don't need to type our project
 # name in our dotted import paths:
@@ -195,8 +196,10 @@ DJANGO_APPS = (
     # Default Django apps:
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.flatpages',
     'django.contrib.gis',
     'django.contrib.sessions',
+    'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
 


### PR DESCRIPTION
To test:
* Run migrations
* In the Django admin, click "Add" next to "Flat Pages"
* Enter `/test/` for the `URL`, and some HTML content.
* Choose the only site, probably labeled `example.com`. (The name doesn't matter, but in production we should set it to the actual site name so users aren't confused.)
* Browse to the page you just created, at `/training/test`