### PR TITLE
Fix settings.js view

### DIFF
--- a/src/nyc_trees/apps/core/views.py
+++ b/src/nyc_trees/apps/core/views.py
@@ -8,6 +8,7 @@ from calendar import timegm
 
 from django.conf import settings
 from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.utils.timezone import make_aware, utc
 
 from apps.survey.models import Blockface, Survey
@@ -19,13 +20,19 @@ def js_settings(request):
 
     max_timestamp = lambda *datetimes: timegm(max(*datetimes).utctimetuple())
 
-    return render_to_response('core/settings.js', {
+    context = {
         "tiler_url": settings.TILER_URL,
         "db_name": settings.DATABASES['default']['NAME'],
         "cache_buster": {
             "progress": max_timestamp(blockface_updated_at, survey_updated_at)
         }
-    })
+    }
+
+    return render_to_response('core/settings.js',
+                              context,
+                              content_type='application/javascript',
+                              # required to invoke the context processors
+                              context_instance=RequestContext(request))
 
 
 def _get_last_updated_datetime(Model):


### PR DESCRIPTION
The JS settings view was recently moved out of the urls file into a proper view function. The new view pipeline was no longer returning the correct content-type header and was not running the context processors. This commit restores those items.