### PR TITLE
Add exponential backoff script for CI interactions with Vagrant

### DIFF
--- a/scripts/vagrant-env.sh
+++ b/scripts/vagrant-env.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+VAGRANT_RETRY_ATTEMPTS=3
+VAGRANT_TIMEOUT=5
+
+# Shout out to Phil: http://stackoverflow.com/a/8351489
+#
+function with_backoff {
+  local timeout=${VAGRANT_TIMEOUT}
+  local max_attempts=${VAGRANT_RETRY_ATTEMPTS}
+  local attempt=0
+  local exitCode=0
+
+  while [[ $attempt < $max_attempts ]]
+  do
+    set +e
+    "$@"
+    exitCode=$?
+    set -e
+
+    if [[ $exitCode == 0 ]]
+    then
+      break
+    fi
+
+    echo ""
+    echo "Failure detected; waiting ${timeout} seconds..."
+    echo ""
+
+    sleep $timeout
+
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout * 2 ))
+  done
+
+  if [[ $exitCode != 0 ]]
+  then
+    echo "Vagrant has failed the provisioning process ${max_attempts} times."
+    echo "Please inspect the failures manually and retry the build."
+  fi
+
+  return $exitCode
+}

--- a/scripts/vagrant-up.sh
+++ b/scripts/vagrant-up.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+source "${DIR}/vagrant-env.sh"
+
+vagrant up --no-provision
+
+for vm in services tiler app;
+do
+  with_backoff vagrant provision ${vm}
+done


### PR DESCRIPTION
This changeset adds a script that wraps the Vagrant provisioning process inside of an exponential backoff function. The first failure waits 5 seconds, second waits 10, and third waits 20.

The goal of this changeset is to get past transient failures we encounter in CI that cause the entire build to fail.