### PR TITLE
Use updated Beaver role with support for installing docutils

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -23,6 +23,6 @@ azavea.java,0.1.1
 azavea.curator,0.1.0
 azavea.ruby,0.3.0
 azavea.sauce-connect,0.2.0
-azavea.beaver,0.1.0
+azavea.beaver,0.1.1
 azavea.swapfile,0.1.0
 azavea.build-essential,0.1.0


### PR DESCRIPTION
This changeset fixes a missing `python-docutils` dependency required by Beaver. It is still unclear what caused this regression. Beaver appeared to be installing cleanly last week.

Attempts to resolve #290.

(Sorry for the back-to-back PRs, Steve.)