### PR TITLE
Add support for capturing Windshaft logs and metrics

### DIFF
--- a/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
@@ -5,6 +5,7 @@
   with_items:
     - nginx
     - django
+    - windshaft
   notify:
     - Restart Beaver
 

--- a/deployment/ansible/roles/nyc-trees.beaver/templates/windshaft.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.beaver/templates/windshaft.conf.j2
@@ -1,0 +1,3 @@
+[/var/log/{upstart/nyc-trees-tiler.log,nyc-trees-tiler.log}]
+type: windshaft
+tags: windshaft,beaver

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -13,6 +13,9 @@ var Windshaft = require('windshaft'),
     redisHost = process.env.NYC_TREES_REDIS_HOST || 'localhost',
     redisPort = process.env.NYC_TREES_REDIS_PORT || 6379,
 
+    statsdHost = process.env.NYC_TREES_STATSD_HOST || 'localhost',
+    statsdPort = process.env.NYC_TREES_STATSD_PORT || 8125,
+
     config = {
         base_url: '/:cache_buster/:dbname/:type',
         base_url_notable: '/:cache_buster/:dbname',
@@ -30,6 +33,11 @@ var Windshaft = require('windshaft'),
         redis: {
             host: redisHost,
             port: redisPort
+        },
+
+        statsd: {
+          host: statsdHost,
+          port: statsdPort
         },
 
         enable_cors: true,


### PR DESCRIPTION
This changeset adds support for Windshaft log shipping via Beaver to the shared Logstash instance and populates the StatsD configuration in Windshaft.