### PR TITLE
Use updated Kibana role with support for version 4 beta 3

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -10,7 +10,7 @@ azavea.nginx,0.2.0
 azavea.mapnik,0.1.0
 azavea.logstash,0.1.0
 azavea.relp,0.1.1
-azavea.kibana,0.2.0
+azavea.kibana,0.2.1
 azavea.unzip,0.1.0
 azavea.graphite,0.2.0
 azavea.statsite,0.1.0


### PR DESCRIPTION
This changeset bumps the version of Kibana used to query the Logstash index to 4 beta 3.

See also: https://github.com/azavea/ansible-kibana/pull/3