### PR TITLE
Crash gulp build if browserify fails

### DIFF
--- a/src/nyc_trees/gulpfile.js
+++ b/src/nyc_trees/gulpfile.js
@@ -153,6 +153,7 @@ function browserifyTask(bundler) {
         })
         .bundle()
         .on('error', gutil.log.bind(gutil, 'Browserify Error'))
+        .on('error', process.exit.bind(process, 1))
         .pipe(source('common.js'));
 
     var bundles = entryBundles.concat(commonBundle);


### PR DESCRIPTION
We want the gulp process to have an non-zero exit code if there is a problem with bundling.

There may be a better, or more generic way to do this, but this catches our most recent problem.