### PR TITLE
Bump version of PostGIS Ansible role

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -19,8 +19,10 @@ apache_port: 8080
 graphite_web_port: "{{ apache_port }}"
 
 postgresql_version: "9.3"
-postgresql_package_version: "9.3.5-2.pgdg14.04+1"
+postgresql_package_version: "9.3.5*.pgdg14.04+1"
 postgresql_support_repository_channel: "9.3"
+postgis_version: "2.1"
+postgis_package_version: "2.1.5*.pgdg14.04+1"
 
 elasticsearch_cluster_name: "logstash"
 

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -4,7 +4,7 @@ azavea.pip,0.1.0
 azavea.nodejs,0.3.0
 azavea.postgresql,0.2.1
 azavea.postgresql-support,0.2.0
-azavea.postgis,0.1.1
+azavea.postgis,0.2.0
 azavea.redis,0.1.0
 azavea.nginx,0.2.0
 azavea.mapnik,0.1.0


### PR DESCRIPTION
This changeset updates the PostGIS Ansible role to avoid having PostgreSQL 9.3 and 9.4 installed on the services VM.

See also: https://github.com/azavea/ansible-postgis/pull/3