### PR TITLE
Add endpoint for calculating GeoJSON polygon of a group's territory

### DIFF
--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -14,6 +14,8 @@ class Blockface(NycModel, models.Model):
     geom = models.MultiLineStringField()
     is_available = models.BooleanField(default=True)
 
+    objects = models.GeoManager()
+
     def __unicode__(self):
         return '%s (available: %s)' % (self.pk, self.is_available)
 

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -5,7 +5,7 @@ from __future__ import division
 
 from django.contrib.auth.decorators import login_required
 
-from django_tinsel.decorators import route, render_template
+from django_tinsel.decorators import route, render_template, string_to_response
 from django_tinsel.utils import decorate as do
 
 from apps.core.decorators import group_request, group_admin_do
@@ -22,6 +22,10 @@ group_list_page = route(GET=do(render_template('groups/list.html'),
 group_detail = route(GET=do(group_request,
                             render_template('groups/detail.html'),
                             v.group_detail))
+
+group_territory_geojson = route(GET=do(group_request,
+                                       string_to_response("application/json"),
+                                       v.group_territory_geojson))
 
 group_edit = group_admin_do(render_template('groups/settings.html'),
                             route(GET=v.edit_group,

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -14,6 +14,9 @@ urlpatterns = patterns(
 
     url(r'^(?P<group_slug>[\w-]+)/$', r.group_detail, name='group_detail'),
 
+    url(r'^(?P<group_slug>[\w-]+)/territory.json$', r.group_territory_geojson,
+        name='group_territory'),
+
     url(r'^(?P<group_slug>[\w-]+)/edit/$', r.group_edit, name='group_edit'),
 
     url(r'^(?P<group_slug>[\w-]+)/edit/events/$',

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -5,7 +5,7 @@ from __future__ import division
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, Http404
 from django.utils.timezone import now
 
 from libs.formatters import humanize_bytes
@@ -18,7 +18,7 @@ from apps.core.models import Group
 from apps.users.models import Follow
 from apps.users.forms import GroupSettingsForm
 
-from apps.survey.models import Territory, Survey
+from apps.survey.models import Territory, Survey, Blockface
 
 from apps.event.models import Event, EventRegistration
 from apps.event.event_list import EventList
@@ -118,6 +118,17 @@ def redirect_to_group_detail(request):
         reverse('group_detail', kwargs={
             'group_slug': request.group.slug
         }))
+
+
+def group_territory_geojson(request):
+    blockfaces = Blockface.objects \
+        .filter(territory__group=request.group) \
+        .collect()
+
+    if blockfaces:
+        return blockfaces.convex_hull.json
+    else:
+        raise Http404()
 
 
 def edit_group(request, form=None):


### PR DESCRIPTION
Does not attempt to cluster disjoint groups of blockfaces into separate
polygons.

After some research, it seems like the best course of action *may* be to
manually create polygons for those groups which have disjoint territories.