### PR TITLE
Bump Ansible Beaver role to 0.1.2

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -23,6 +23,6 @@ azavea.java,0.1.1
 azavea.curator,0.1.0
 azavea.ruby,0.3.0
 azavea.sauce-connect,0.2.0
-azavea.beaver,0.1.1
+azavea.beaver,0.1.2
 azavea.swapfile,0.1.0
 azavea.build-essential,0.1.0


### PR DESCRIPTION
This changeset addresses the `python-daemon` installation issues that were failing the Beaver installation.

See also: https://github.com/azavea/ansible-beaver/pull/3