### PR TITLE
Glob Firefox and Xvfb test dependencies

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/tasks/dev-and-test-dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dev-and-test-dependencies.yml
@@ -8,7 +8,7 @@
     - Restart nyc-trees-app
 
 - name: Install Firefox for UI tests
-  apt: pkg=firefox=34.0+build2-0ubuntu0.14.04.1 state=present
+  apt: pkg=firefox="3*" state=present
 
 - name: Install Xvfb for JavaScript tests
-  apt: pkg=xvfb=2:1.15.1-0ubuntu2.5 state=present
+  apt: pkg=xvfb="2:1.15.1*" state=present


### PR DESCRIPTION
This changeset uses APT globbing support to relax the version specification associated with Firefox and Xvfb.

Attempts to resolve: #320