### PR TITLE
Fix Vagrant provision false positive

### DIFF
--- a/scripts/vagrant-up.sh
+++ b/scripts/vagrant-up.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 
 source "${DIR}/vagrant-env.sh"
@@ -8,5 +10,5 @@ vagrant up --no-provision
 
 for vm in services tiler app;
 do
-  with_backoff vagrant provision ${vm}
+  with_backoff vagrant reload --provision ${vm}
 done


### PR DESCRIPTION
This changeset tries to address the scenario where a `vagrant provision` on a halted virtual machine returns an exit status of 0. Now a step to bring up the specific virtual machine is wrapped in an exponential backoff function along with the provisioning step. If bringing the virtual machine up fails, provisioning will never be attempted.

Attempts to resolve: #297