### PR TITLE
Add reservable layer

### DIFF
--- a/src/nyc_trees/apps/core/templates/core/partials/config.js
+++ b/src/nyc_trees/apps/core/templates/core/partials/config.js
@@ -6,12 +6,7 @@
         },
         "urls": {
             "geocode": "{% url 'geocode' %}",
-            "layers": {
-                "progress": {
-                    "tiles": "{{ progress_tiles_url }}",
-                    "grids": "{{ progress_grids_url }}"
-                }
-            }
+            "layers": {{ layers_json|safe }}
         },
         "bounds": [[{{nyc_bounds.ymin}}, {{nyc_bounds.xmin}}], [{{nyc_bounds.ymax}}, {{nyc_bounds.xmax}}]]
     };

--- a/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
@@ -3,10 +3,10 @@
 {% load utils %}
 
 {% block content %}
-    <aside class="pageheading col-am-4">
+    <aside class="pageheading col-xs-12">
         <div class="pageheading-description block">
             <div class="row">
-                <div class="col-as-12">
+                <div class="col-xs-4">
                     <h2>Reservations</h2>
                 </div>
             </div>

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -68,7 +68,7 @@ function addLocationMarker(map, location) {
 function initBaseMap(map) {
     var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         osmAttrib = 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        osm = new L.TileLayer(osmUrl, {attribution: osmAttrib});
+        osm = new L.TileLayer(osmUrl, {maxZoom: zoom.MAX, attribution: osmAttrib});
 
     map.addLayer(osm);
 }

--- a/src/nyc_trees/js/src/mapUtil.js
+++ b/src/nyc_trees/js/src/mapUtil.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var zoom = {
-    NEIGHBORHOOD: 16
+    NEIGHBORHOOD: 16,
+    MAX: 19
 };
 
 module.exports = {

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var MapModule = require('./map'),
+    zoom = require('./mapUtil').zoom,
     L = require('leaflet');
 
 var progressMap = MapModule.create({
@@ -9,4 +10,6 @@ var progressMap = MapModule.create({
     search: true
 });
 
-L.tileLayer(config.urls.layers.progress.tiles).addTo(progressMap);
+L.tileLayer(config.urls.layers.progress.tiles, {
+    maxZoom: zoom.MAX
+}).addTo(progressMap);

--- a/src/nyc_trees/js/src/reservationPage.js
+++ b/src/nyc_trees/js/src/reservationPage.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var MapModule = require('./map'),
+    zoom = require('./mapUtil').zoom,
     L = require('leaflet');
 
 var reservationMap = MapModule.create({
@@ -10,4 +11,6 @@ var reservationMap = MapModule.create({
 });
 
 // TODO: Only show this layer in "add" mode.
-L.tileLayer(config.urls.layers.reservable.tiles).addTo(reservationMap);
+L.tileLayer(config.urls.layers.reservable.tiles, {
+    maxZoom: zoom.MAX
+}).addTo(reservationMap);

--- a/src/nyc_trees/js/src/reservationPage.js
+++ b/src/nyc_trees/js/src/reservationPage.js
@@ -8,3 +8,6 @@ var reservationMap = MapModule.create({
     legend: true,
     search: true
 });
+
+// TODO: Only show this layer in "add" mode.
+L.tileLayer(config.urls.layers.reservable.tiles).addTo(reservationMap);

--- a/src/nyc_trees/nyc_trees/context_processors.py
+++ b/src/nyc_trees/nyc_trees/context_processors.py
@@ -58,7 +58,7 @@ def _make_layers_context(request):
         params = ''
 
     context = {}
-    for layer in ['progress']:
+    for layer in ['progress', 'reservable']:
         tile_url = tiler_url_format % _make_tiler_url_kwargs(request, layer)
         context[layer] = {
             'tiles': tile_url + '.png' + params,
@@ -96,7 +96,8 @@ def _tiler_cache_busters(request):
             reservation_updated_at)
 
     return {
-        "progress": progress_cache_buster
+        "progress": progress_cache_buster,
+        "reservable": progress_cache_buster  # uses the same tables as progress
     }
 
 

--- a/src/nyc_trees/nyc_trees/tests.py
+++ b/src/nyc_trees/nyc_trees/tests.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+import json
+
 from django.contrib.gis.geos import LineString, MultiLineString
 from django.test import TestCase
 
@@ -27,12 +29,11 @@ class ContextProcessorTest(TestCase):
 
     def test_full_request(self):
         context = config(make_request())
-        self.assertTrue('progress_tiles_url' in context,
-                        'Expected the context dict to have a "progress_tiles" '
+        self.assertTrue('layers_json' in context,
+                        'Expected the context dict to have a "layers_json" '
                         'key.')
-        self.assertTrue(context['progress_tiles_url'],
-                        'Expected the "progress_tiles" key of the context '
-                        'dict to be truthy.')
+        self.assertTrue(json.loads(context['layers_json']),
+                        'Expected "layers_json" to be parsable as JSON')
 
     def test_ajax_request(self):
         context = config(make_request(

--- a/src/tiler/files.js
+++ b/src/tiler/files.js
@@ -1,0 +1,76 @@
+"use strict";
+
+/*
+
+Read a directory of files and return an object where the key is the
+file name without the file extension and the value is a function that
+takes a template context object and returns the string content of the
+file after template replacement. If the SQL file does not contain any
+template tags, the function simply returns the static string, ignoring
+the context object argument.
+
+Example
+-------
+
+$ ls ./sql
+.
+..
+bar.sql
+foo.sql
+user_foo.sql
+
+$ node
+> var queries = require('./queries')('./sql');
+undefined
+> queries.bar
+[Function]
+
+*/
+
+var _ = require('lodash'),
+    fs = require('fs'),
+    path = require('path');
+
+module.exports = function(dirName) {
+    return _(dirToFilesObj(dirName))
+        .mapValues(utf8FileToContentFunction)
+        .value();
+};
+
+function dirToFilesObj(dirName) {
+     return _(fs.readdirSync(dirName))
+        .filter(isRealFile)
+        .reduce(_.partial(objAddFileReference, dirName), {});}
+
+function objAddFileReference(dirName, obj, fileName) {
+    obj[stripExtension(fileName)] = path.join(dirName, fileName);
+    return obj;
+}
+
+function isRealFile(filePath) {
+    return (filePath !== '.' && filePath !== '..');
+}
+
+function stripExtension(filename) {
+    return filename.replace(/\.[^/.]+$/, "");
+}
+
+function isTemplate(str) {
+    return !!str.match(/<%=/);
+}
+
+function utf8FileToContentFunction(filePath) {
+    return contentToFunction(
+        fs.readFileSync(filePath, {encoding: 'utf8'})
+    );
+}
+
+function contentToFunction(content) {
+    if (isTemplate(content)) {
+        return _.template(content);
+    } else {
+        return function() {
+            return content;
+        };
+    }
+}

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -21,7 +21,8 @@ var Windshaft = require('windshaft'),
     styles = files('./style'),
 
     interactivity = {
-        progress: 'id,group_id,survey_type'
+        progress: 'id,group_id,survey_type',
+        reservable: 'id,group_id,survey_type,restriction'
     },
 
     config = {

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -3,7 +3,7 @@
 var Windshaft = require('windshaft'),
     fs = require('fs'),
     _ = require('lodash'),
-
+    files = require('./files'),
     port = process.env.PORT || 4000,
 
     dbUser = process.env.NYC_TREES_DB_USER || 'nyc_trees',
@@ -17,10 +17,12 @@ var Windshaft = require('windshaft'),
     statsdHost = process.env.NYC_TREES_STATSD_HOST || 'localhost',
     statsdPort = process.env.NYC_TREES_STATSD_PORT || 8125,
 
-    progressSql = fs.readFileSync('sql/progress.sql', {encoding: 'utf8'}),
-    userProgressSql = _.template(fs.readFileSync('sql/user_progress.sql', {encoding: 'utf8'})),
+    queries = files('./sql'),
+    styles = files('./style'),
 
-    progressStyle = fs.readFileSync('style/progress.mss', {encoding: 'utf8'}),
+    interactivity = {
+        progress: 'id,group_id,survey_type'
+    },
 
     config = {
         base_url: '/:cache_buster/:dbname/:type',
@@ -49,39 +51,76 @@ var Windshaft = require('windshaft'),
         enable_cors: true,
 
         req2params: function(req, callback) {
-            var user_id;
-
             try {
-                if (req.params.type == 'progress') {
-                    req.params.table = 'survey_blockface';
-                    req.params.interactivity = 'id,group_id,survey_type';
-
-                    req.params.style = progressStyle;
-
-                    if ('user' in req.query) {
-                        user_id = parseInt(req.query.user, 10);
-                        if (isNaN(user_id)) {
-                            callback("Could not parse user id", null);
-                            return;
-                        }
-                        req.params.sql = userProgressSql({user_id: user_id});
-                    } else {
-                        req.params.sql = progressSql;
-                    }
-
-                } else {
-                    callback("Unrecognized request type", null);
-                    return;
-                }
+                // Windshaft needs a table name, even if you are providing
+                // a custom sql statement.
+                req.params.table = 'survey_blockface';
+                req.params.sql = req2sql(req);
+                req.params.style = req2style(req);
+                req.params.interactivity = req2interactivity(req);
+                callback(null, req);
             } catch(err) {
                 callback(err, null);
                 return;
             }
-
-            callback(null, req);
         }
     };
 
-Windshaft.Server(config).listen(port);
+function req2context(req) {
+    // constructs a context object that will be passed to
+    // SQL and CartoCSS templates.
+    var context = {},
+        user_id;
+    if (req.query.user) {
+        user_id = parseInt(req.query.user, 10);
+        if (isNaN(user_id)) {
+            throw 'Could not parse "user" query string argument ' +
+                '(' + req.query.user + ') as an integer';
+        }
+        context.user_id = user_id;
+    }
+    return context;
+}
 
+function req2interactivity(req) {
+    return interactivity[req.params.type];
+}
+
+function req2style(req) {
+    // At the time this was written we have a single stylesheet
+    // for all requests
+    return styles.progress();
+}
+
+function req2sql(req) {
+    /*
+     This function expects the SQL files loaded into the
+     'queries' object to have a specific naming convention. If
+     a user= query string argument is provided, this funciton
+     prepends 'user_' to the 'type' parameter to generate the
+     SQL file name. Example:
+
+     URL:  /123456/nyc_trees/foo/1/2/3.png
+     File: foo.sql
+
+     URL:  /123456/nyc_trees/foo/1/2/3.png?user=1
+     File: user_foo.sql
+
+     */
+    var queryPrefix = req.query.user ? 'user_' : '',
+        queryName = queryPrefix + req.params.type,
+        context = req2context(req),
+        additionalErr = '';
+    if (queries[queryName]) {
+        return queries[queryName](context);
+    } else {
+        if (queries['user_' + queryName]) {
+            additionalErr = 'There is a query defined for user_' + queryName +
+                '. Did you forget the user= query string argument?';
+        }
+        throw 'No query defined for ' + queryName + '. ' + additionalErr;
+    }
+}
+
+Windshaft.Server(config).listen(port);
 console.log("Now serving tiles");

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -1,0 +1,24 @@
+(SELECT
+  block.geom, block.id, turf.group_id,
+  CASE
+    WHEN (block.is_available AND reservation.id IS NULL
+          AND (turf.id IS NULL OR trustedmapper.id IS NOT NULL)) THEN 'available'
+    ELSE 'unavailable'
+  END AS survey_type,
+  CASE
+    WHEN turf.id IS NOT NULL AND trustedmapper.id IS NULL THEN 'group_territory'
+    WHEN reservation.id IS NOT NULL THEN 'reserved'
+    WHEN NOT block.is_available THEN 'unavailable'
+    ELSE 'none'
+  END AS restriction
+  FROM survey_blockface AS block
+  LEFT OUTER JOIN survey_territory AS turf
+    ON block.id = turf.blockface_id
+  LEFT OUTER JOIN survey_blockfacereservation AS reservation
+    ON (block.id = reservation.blockface_id
+        AND reservation.canceled_at IS NULL
+        AND reservation.expires_at > now() at time zone 'utc')
+  LEFT OUTER JOIN users_trustedmapper AS trustedmapper
+    ON (turf.group_id = trustedmapper.group_id
+        AND trustedmapper.user_id = <%= user_id %>)
+) AS query

--- a/src/tiler/style/progress.mss
+++ b/src/tiler/style/progress.mss
@@ -6,8 +6,16 @@
 @unavailable: #455A64;
 
 #survey_blockface {
+  line-join: round;
+  line-cap: round;
+
   line-opacity: 1;
-  line-width: 2;
+
+  line-width: 1;
+  [zoom = 16]{ line-width: 2; }
+  [zoom = 17]{ line-width: 4; }
+  [zoom = 18]{ line-width: 8; }
+  [zoom = 19]{ line-width: 16; }
 
   [survey_type = 'surveyed-by-me'] {
     line-color: @surveyed-by-me;


### PR DESCRIPTION
To guide a person in selecting blocks to add to their reservation, we need a simple available/not available layer.

I am adding this to the initial view of the reservation page for bootstrapping purposes only. When the "add" mode is implemented, it will show this layer only in that mode.

To implement this, I refactored the tile server and config context processor to be easily extensible.