### PR TITLE
Refactor app and tiler dependencies and add filter plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,22 +77,6 @@ In order to speed up things up, you may want to consider using a local caching p
 $ VAGRANT_PROXYCONF_ENDPOINT="http://192.168.96.10:8123/" vagrant up
 ```
 
-### Log Aggregation
-
-In order to view the Kibana web UI, navigate to the following URL from a browser on the virtual machine host:
-
-```
-http://localhost:5601/
-```
-
-### Statistics Aggregation
-
-In order to view the Graphite Web UI, navigate to the following URL from a browser on the virtual machine host:
-
-```
-http://localhost:8080/
-```
-
 ## Testing
 
 In order to simulate the testing environment used in CI, bring up the testing environment with:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ In order to speed up things up, you may want to consider using a local caching p
 $ VAGRANT_PROXYCONF_ENDPOINT="http://192.168.96.10:8123/" vagrant up
 ```
 
+### Log Aggregation
+
+In order to view the Kibana web UI, navigate to the following URL from a browser on the virtual machine host:
+
+```
+http://localhost:5601/
+```
+
+### Statistics Aggregation
+
+In order to view the Graphite Web UI, navigate to the following URL from a browser on the virtual machine host:
+
+```
+http://localhost:8080/
+```
+
 ## Testing
 
 In order to simulate the testing environment used in CI, bring up the testing environment with:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,6 +47,7 @@ ANSIBLE_GROUPS = {
   "app-servers" => [ "app" ],
   "tile-servers" => [ "tiler" ],
   "services" => [ "services" ],
+  "monitoring-servers" => [ "services" ]
 }
 
 if !ENV["VAGRANT_ENV"].nil? && ENV["VAGRANT_ENV"] == "TEST"
@@ -58,7 +59,6 @@ if !ENV["VAGRANT_ENV"].nil? && ENV["VAGRANT_ENV"] == "TEST"
   VAGRANT_NETWORK_OPTIONS = { auto_correct: true }
 else
   ANSIBLE_ENV_GROUPS = {
-    "monitoring-servers" => [ "services" ],
     "development:children" => [
       "app-servers", "tile-servers", "services", "monitoring-servers"
     ]

--- a/deployment/ansible/app-servers.yml
+++ b/deployment/ansible/app-servers.yml
@@ -14,8 +14,6 @@
 
   roles:
     - { role: "nyc-trees.common" }
-    - { role: "nyc-trees.monitoring", when: not_testing }
-
     - { role: "nyc-trees.app" }
 
   post_tasks:

--- a/deployment/ansible/app-servers.yml
+++ b/deployment/ansible/app-servers.yml
@@ -10,7 +10,7 @@
       lineinfile: dest="/etc/hosts"
                   regexp="^127.0.0.1"
                   line="127.0.0.1 localhost {{ statsite_host }}"
-      when: packing
+      when: "['packer'] | is_in(group_names)"
 
   roles:
     - { role: "nyc-trees.common" }
@@ -21,4 +21,4 @@
       lineinfile: dest="/etc/hosts"
                   regexp="^127.0.0.1"
                   line="127.0.0.1 localhost"
-      when: packing
+      when: "['packer'] | is_in(group_names)"

--- a/deployment/ansible/filter_plugins/custom_filters.py
+++ b/deployment/ansible/filter_plugins/custom_filters.py
@@ -1,0 +1,45 @@
+class FilterModule(object):
+    ''' Additional filters for use within Ansible. '''
+
+    def filters(self):
+        return {
+            'is_not_in': self.is_not_in,
+            'is_in': self.is_in,
+            'some_are_in': self.some_are_in
+        }
+
+    def is_not_in(self, *t):
+        """Determnies if there are no elements in common between x and y
+
+            x | is_not_in(y)
+
+        Arguments
+        :param t: A tuple with two elements (x and y)
+        """
+        groups_to_test, all_group_names = t
+
+        return set(groups_to_test).isdisjoint(set(all_group_names))
+
+    def is_in(self, *t):
+        """Determnies if all of the elements in x are a subset of y
+
+            x | is_in(y)
+
+        Arguments
+        :param t: A tuple with two elements (x and y)
+        """
+        groups_to_test, all_group_names = t
+
+        return set(groups_to_test).issubset(set(all_group_names))
+
+    def some_are_in(self, *t):
+        """Determnies if any element in x intersects with y
+
+            x | some_are_in(y)
+
+        Arguments
+        :param t: A tuple with two elements (x and y)
+        """
+        groups_to_test, all_group_names = t
+
+        return len(set(groups_to_test) & set(all_group_names)) > 0

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,11 +1,4 @@
 ---
-not_testing: "'test' not in group_names"
-developing_or_testing: "'development' in group_names or 'test' in group_names"
-developing: "'development' in group_names"
-not_developing: "'development' not in group_names"
-packing: "'packer' in group_names"
-not_monitoring: "'monitoring-servers' not in group_names"
-
 django_test_database: "{{ lookup('env', 'NYC_TREES_TEST_DB_NAME') | default('test_nyc_trees', true) }}"
 
 sauce_labs_api_key_is_defined: lookup('env', 'SAUCE_API_KEY') != ''

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,6 +4,7 @@ developing_or_testing: "'development' in group_names or 'test' in group_names"
 developing: "'development' in group_names"
 not_developing: "'development' not in group_names"
 packing: "'packer' in group_names"
+not_monitoring: "'monitoring-servers' not in group_names"
 
 django_test_database: "{{ lookup('env', 'NYC_TREES_TEST_DB_NAME') | default('test_nyc_trees', true) }}"
 

--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -12,9 +12,8 @@ postgresql_host: "database.service.nyc-trees.internal"
 relp_host: "monitoring.service.nyc-trees.internal"
 graphite_host: "monitoring.service.nyc-trees.internal"
 statsite_host: "monitoring.service.nyc-trees.internal"
-tile_server_endpoint: "tile.service.nyc-trees.internal"
+tiler_host: "tile.service.nyc-trees.internal"
 
 postgresql_username: nyctrees
 postgresql_password: nyctrees
 postgresql_database: nyc_trees
-

--- a/deployment/ansible/monitoring-servers.yml
+++ b/deployment/ansible/monitoring-servers.yml
@@ -9,6 +9,6 @@
   roles:
     - { role: "nyc-trees.common" }
 
-    - { role: "nyc-trees.graphite", when: not_testing }
-    - { role: "nyc-trees.logstash", when: not_testing }
-    - { role: "azavea.kibana", when: not_testing }
+    - { role: "nyc-trees.graphite", when: "['test'] | is_not_in(group_names)" }
+    - { role: "nyc-trees.logstash", when: "['test'] | is_not_in(group_names)" }
+    - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -2,10 +2,7 @@
 dependencies:
   - { role: "azavea.python", python_development: True }
   - { role: "azavea.pip" }
-  - { role: "azavea.git" }
   - { role: "azavea.postgresql-support" }
-  - { role: "azavea.daemontools" }
-  - { role: "azavea.nginx", nginx_delete_default_site: True }
-  - { role: "azavea.nodejs" }
   - { role: "azavea.ruby" }
   - { role: "azavea.sauce-connect", when: sauce_labs_api_key_is_defined }
+  - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.app.", when: not_testing }

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -5,4 +5,4 @@ dependencies:
   - { role: "azavea.postgresql-support" }
   - { role: "azavea.ruby" }
   - { role: "azavea.sauce-connect", when: sauce_labs_api_key_is_defined }
-  - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.app.", when: not_testing }
+  - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.app.", when: "['test'] | is_not_in(group_names)" }

--- a/deployment/ansible/roles/nyc-trees.app/tasks/app.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/app.yml
@@ -3,12 +3,10 @@
   git: repo=https://github.com/azavea/nyc-trees.git
        dest=/opt/nyc-trees
        version="{{ app_deploy_branch }}"
-  when: packing
 
 - name: Ensure that app_home exists
   file: path="{{ app_home }}"
         state=directory
-  when: packing
 
 - name: Synchronize Django application into app_home
   synchronize: archive=no
@@ -18,4 +16,3 @@
                set_remote_user=no
                src=/opt/nyc-trees/src/nyc_trees/
                dest="{{ app_home }}/"
-  when: packing

--- a/deployment/ansible/roles/nyc-trees.app/tasks/configuration.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/configuration.yml
@@ -11,14 +11,14 @@
         append=yes
         group=nyc-trees
         state=present
-  when: developing_or_testing
+  when: "['development', 'test'] | some_are_in(group_names)"
 
 - name: Add Ubuntu user to the nyc-trees group
   user: name=ubuntu
         append=yes
         group=nyc-trees
         state=present
-  when: packing
+  when: "['packer'] | is_in(group_names)"
 
 - name: Create configuration file directory
   file: path={{ app_config_home }}

--- a/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
@@ -15,6 +15,6 @@
 
 - name: Install application Python dependencies for production
   pip: chdir="{{ app_home }}/requirements" requirements=production.txt
-  when: packing
+  when: "['packer'] | is_in(group_names)"
   notify:
     - Restart nyc-trees-app

--- a/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - { include: configuration.yml }
-- { include: app.yml }
+- { include: app.yml, when: "['packer'] | is_in(group_names)" }
 - { include: dependencies.yml }
-- { include: dev-and-test-dependencies.yml, when: developing_or_testing }
+- { include: dev-and-test-dependencies.yml, when: "['development', 'test'] | some_are_in(group_names)" }
 - { include: static-files.yml }
 - { include: reverse-proxy.yml }
 - { include: log-rotation.yml }

--- a/deployment/ansible/roles/nyc-trees.app/tasks/static-files.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/static-files.yml
@@ -25,16 +25,16 @@
   command: npm run build
   args:
     chdir: "{{ app_home }}"
-  when: not_developing
+  when: "['development'] | is_not_in(group_names)"
 
 - name: Create static files and run collectstatic (development)
   command: npm run build-debug
   args:
     chdir: "{{ app_home }}"
-  when: developing
+  when: "['development'] | is_in(group_names)"
 
 - name: Create JS test harness
   template: src=testem-harness.html.j2
             dest={{ app_static_root }}/test.html
   sudo_user: nyc-trees
-  when: developing_or_testing
+  when: "['development', 'test'] | some_are_in(group_names)"

--- a/deployment/ansible/roles/nyc-trees.app/templates/gunicorn-nyc-trees.py.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/gunicorn-nyc-trees.py.j2
@@ -1,6 +1,6 @@
 bind = "127.0.0.1:8000"
 
-{% if 'development' in group_names or 'test' in group_names -%}
+{% if ['development', 'test'] | some_are_in(group_names) -%}
 accesslog = "-"
 errorlog = "-"
 loglevel = 'debug'

--- a/deployment/ansible/roles/nyc-trees.app/templates/upstart-nyc-trees-app.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/upstart-nyc-trees-app.conf.j2
@@ -1,6 +1,6 @@
 description	"nyc-trees-app"
 
-{% if 'development' in group_names or 'test' in group_names -%}
+{% if ['development', 'test'] | some_are_in(group_names) -%}
 start on (vagrant-mounted)
 {% else %}
 start on (local-filesystems and net-device-up IFACE!=lo)

--- a/deployment/ansible/roles/nyc-trees.collectd/default/main.yml
+++ b/deployment/ansible/roles/nyc-trees.collectd/default/main.yml
@@ -1,0 +1,2 @@
+---
+collectd_prefix: "collectd."

--- a/deployment/ansible/roles/nyc-trees.collectd/templates/write_graphite.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.collectd/templates/write_graphite.conf.j2
@@ -2,7 +2,7 @@
 	<Carbon>
 		Host "{{ graphite_host }}"
 		Port "{{ graphite_port }}"
-		Prefix "collectd."
+		Prefix "{{ collectd_prefix }}"
 		Protocol "tcp"
 	</Carbon>
 </Plugin>

--- a/deployment/ansible/roles/nyc-trees.common/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.common/meta/main.yml
@@ -1,3 +1,7 @@
 ---
 dependencies:
   - { role: "azavea.ntp" }
+  - { role: "azavea.git" }
+  - { role: "azavea.nginx", nginx_delete_default_site: True, when: not_monitoring | bool }
+  - { role: "azavea.daemontools", when: not_monitoring | bool }
+  - { role: "azavea.nodejs", when: not_monitoring | bool }

--- a/deployment/ansible/roles/nyc-trees.common/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.common/meta/main.yml
@@ -2,6 +2,6 @@
 dependencies:
   - { role: "azavea.ntp" }
   - { role: "azavea.git" }
-  - { role: "azavea.nginx", nginx_delete_default_site: True, when: not_monitoring | bool }
-  - { role: "azavea.daemontools", when: not_monitoring | bool }
-  - { role: "azavea.nodejs", when: not_monitoring | bool }
+  - { role: "azavea.nginx", nginx_delete_default_site: True, when: "['monitoring-servers'] | is_not_in(group_names)" }
+  - { role: "azavea.daemontools", when: "['monitoring-servers'] | is_not_in(group_names)" }
+  - { role: "azavea.nodejs", when: "['monitoring-servers'] | is_not_in(group_names)" }

--- a/deployment/ansible/roles/nyc-trees.common/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.common/tasks/main.yml
@@ -5,11 +5,11 @@
 
 - name: Stop Puppet service
   service: name=puppet state=stopped
-  when: puppet_installed.stat.exists and developing_or_testing
+  when: "puppet_installed.stat.exists and ['development', 'test'] | some_are_in(group_names)"
 
 - name: Remove Puppet service
   file: path=/etc/init.d/puppet state=absent
-  when: puppet_installed.stat.exists and developing_or_testing
+  when: "puppet_installed.stat.exists and ['development', 'test'] | some_are_in(group_names)"
 
 - name: Check if Chef service definition exists
   stat: path=/etc/init.d/chef-client
@@ -17,8 +17,8 @@
 
 - name: Stop Chef service
   service: name=chef-client state=stopped
-  when: chef_installed.stat.exists and developing_or_testing
+  when: "chef_installed.stat.exists and ['development', 'test'] | some_are_in(group_names)"
 
 - name: Remove Chef service
   file: path=/etc/init.d/chef-client state=absent
-  when: chef_installed.stat.exists and developing_or_testing
+  when: "chef_installed.stat.exists and ['development', 'test'] | some_are_in(group_names)"

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/write_graphite.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/write_graphite.conf.j2
@@ -2,7 +2,7 @@
 	<Carbon>
 		Host "{{ graphite_host }}"
 		Port "{{ graphite_port }}"
-		Prefix "collectd."
+		Prefix "collectd.monitoring."
 		Protocol "tcp"
 	</Carbon>
 </Plugin>

--- a/deployment/ansible/roles/nyc-trees.tiler/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/meta/main.yml
@@ -2,5 +2,5 @@
 dependencies:
   - { role: "azavea.mapnik" }
   - { role: "azavea.build-essential" }
-  - { role: "azavea.swapfile", when: developing_or_testing }
-  - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.tile.", when: not_testing }
+  - { role: "azavea.swapfile", when: "['development', 'test'] | some_are_in(group_names)" }
+  - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.tile.", when: "['test'] | is_not_in(group_names)" }

--- a/deployment/ansible/roles/nyc-trees.tiler/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/meta/main.yml
@@ -1,8 +1,6 @@
 ---
 dependencies:
-  - { role: "azavea.nginx", nginx_delete_default_site: True }
   - { role: "azavea.mapnik" }
-  - { role: "azavea.daemontools" }
   - { role: "azavea.build-essential" }
   - { role: "azavea.swapfile", when: developing_or_testing }
-  - { role: "azavea.nodejs" }
+  - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.tile.", when: not_testing }

--- a/deployment/ansible/roles/nyc-trees.tiler/tasks/app.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/tasks/app.yml
@@ -3,12 +3,10 @@
   git: repo=https://github.com/azavea/nyc-trees.git
        dest=/opt/nyc-trees
        version="{{ tiler_deploy_branch }}"
-  when: packing
 
 - name: Ensure that tiler_home exists
   file: path="{{ tiler_home }}"
         state=directory
-  when: packing
 
 - name: Synchronize tiler application into tiler_home
   synchronize: archive=no
@@ -18,4 +16,3 @@
                set_remote_user=no
                src=/opt/nyc-trees/src/tiler/
                dest="{{ tiler_home }}/"
-  when: packing

--- a/deployment/ansible/roles/nyc-trees.tiler/tasks/configuration.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/tasks/configuration.yml
@@ -11,14 +11,14 @@
         append=yes
         group=nyc-trees
         state=present
-  when: developing_or_testing
+  when: "['development', 'test'] | some_are_in(group_names)"
 
 - name: Add Ubuntu user to the nyc-trees group
   user: name=ubuntu
         append=yes
         group=nyc-trees
         state=present
-  when: packing
+  when: "['packer'] | is_in(group_names)"
 
 - name: Create configuration file directory
   file: path={{ tiler_config_home }}

--- a/deployment/ansible/roles/nyc-trees.tiler/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - { include: configuration.yml }
-- { include: app.yml }
+- { include: app.yml, when: "['packer'] | is_in(group_names)" }
 - { include: dependencies.yml }
 - { include: reverse-proxy.yml }
 - { include: log-rotation.yml }

--- a/deployment/ansible/roles/nyc-trees.tiler/templates/upstart-nyc-trees-tiler.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.tiler/templates/upstart-nyc-trees-tiler.conf.j2
@@ -1,6 +1,6 @@
 description	"nyc-trees-tiler"
 
-{% if 'development' in group_names or 'test' in group_names -%}
+{% if ['development', 'test'] | some_are_in(group_names) -%}
 start on (vagrant-mounted)
 {% else %}
 start on (local-filesystems and net-device-up IFACE!=lo)

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -1,7 +1,5 @@
 ---
-- hosts:
-    - services
-    - monitoring-servers
+- hosts: services
   sudo: True
 
   pre_tasks:
@@ -11,9 +9,10 @@
   roles:
     - { role: "nyc-trees.common" }
 
-    - { role: "nyc-trees.postgresql", when: developing_or_testing }
-    - { role: "nyc-trees.pgweb", when: developing_or_testing }
-    - { role: "azavea.redis", when: developing_or_testing }
-    - { role: "nyc-trees.graphite", when: not_testing }
-    - { role: "nyc-trees.logstash", when: not_testing }
-    - { role: "azavea.kibana", when: not_testing }
+    - { role: "nyc-trees.postgresql", when: "['development', 'test'] | some_are_in(group_names)" }
+    - { role: "nyc-trees.pgweb", when: "['development', 'test'] | some_are_in(group_names)" }
+    - { role: "azavea.redis", when: "['development', 'test'] | some_are_in(group_names)" }
+
+    - { role: "nyc-trees.graphite", when: "['test'] | is_not_in(group_names)" }
+    - { role: "nyc-trees.logstash", when: "['test'] | is_not_in(group_names)"}
+    - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -1,5 +1,7 @@
 ---
-- hosts: services
+- hosts:
+    - services
+    - monitoring-servers
   sudo: True
 
   pre_tasks:
@@ -12,11 +14,6 @@
     - { role: "nyc-trees.postgresql", when: developing_or_testing }
     - { role: "nyc-trees.pgweb", when: developing_or_testing }
     - { role: "azavea.redis", when: developing_or_testing }
-
-- hosts: monitoring-servers
-  sudo: True
-
-  roles:
     - { role: "nyc-trees.graphite", when: not_testing }
     - { role: "nyc-trees.logstash", when: not_testing }
     - { role: "azavea.kibana", when: not_testing }

--- a/deployment/ansible/tile-servers.yml
+++ b/deployment/ansible/tile-servers.yml
@@ -8,6 +8,4 @@
 
   roles:
     - { role: "nyc-trees.common" }
-    - { role: "nyc-trees.monitoring", when: not_testing }
-
     - { role: "nyc-trees.tiler" }


### PR DESCRIPTION
This pull request contains two commits because I couldn't get the refactoring to work without the addition of the customer filters.

One commit adjusts the shared dependencies between the application and tiler so that they exist in one place (`nyc-trees.common`). The other adds custom filters to help determining a node's group membership.