### PR TITLE
Add HTTP caching support for tiles and static assets

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
@@ -19,10 +19,20 @@ server {
   access_log /var/log/nginx/nyc-trees-app.access.log logstash_json;
 
   location /static/ {
+    {% if ['packer'] | is_in(group_names) -%}
+    etag on;
+    expires max;
+    {% endif %}
+
     alias {{ app_static_root }};
   }
 
   location /media/ {
+    {% if ['packer'] | is_in(group_names) -%}
+    etag on;
+    expires 1h;
+    {% endif %}
+
     alias {{ app_media_root }};
   }
 

--- a/deployment/ansible/roles/nyc-trees.tiler/templates/nginx-nyc-trees-tiler.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.tiler/templates/nginx-nyc-trees-tiler.conf.j2
@@ -17,6 +17,10 @@ server {
   access_log /var/log/nginx/nyc-trees-tiler.access.log logstash_json;
 
   location / {
+    {% if ['packer'] | is_in(group_names) -%}
+    expires max;
+    {% endif %}
+
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;


### PR DESCRIPTION
This changeset adds HTTP caching support to production deployments by:

- Enabling the Cache-Control, Expires, and ETag headers for static assets
- Enabling the Cache-Control and Expires headers for tiles

It is worth noting that when the tiler is fronted by CloudFront, CloudFront will choose the greater of Cache-Control vs. 24 hours, but reserves the right to purge infrequently accessed assets from edge locations to make way to more frequently accessed ones.

Attempts to resolve #302 and #303.