### PR TITLE
Add blue/green deployment support to tiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,26 +71,10 @@ The main tool used is [gulp](http://gulpjs.com/), which is exposed through `npm 
 
 ### Caching
 
-In order to speed up things up, you may want to consider using a local caching proxy. The `VAGRANT_PROXYCONF_ENDPOINT` environmental variable provides a way to supply a caching proxy endpoint for the virtual machines to use:
+In order to speed up things up, you may want to consider using a local caching proxy. The `VAGRANT_PROXYCONF_ENDPOINT` environment variable provides a way to supply a caching proxy endpoint for the virtual machines to use:
 
 ```bash
 $ VAGRANT_PROXYCONF_ENDPOINT="http://192.168.96.10:8123/" vagrant up
-```
-
-### Log Aggregation
-
-In order to view the Kibana web UI, navigate to the following URL from a browser on the virtual machine host:
-
-```
-http://localhost:5601/
-```
-
-### Statistics Aggregation
-
-In order to view the Graphite Web UI, navigate to the following URL from a browser on the virtual machine host:
-
-```
-http://localhost:8080/
 ```
 
 ## Testing
@@ -117,85 +101,4 @@ In addition, other [scripts](scripts/) exist if you want to test just one of the
 
 ## Deployment
 
-Deployment is driven by [Packer](https://www.packer.io), [Troposphere](https://github.com/cloudtools/troposphere), and the [Amazon Web Services CLI](http://aws.amazon.com/cli/).
-
-### Dependencies
-
-The deployment process expects the following resources to exist in the target AWS account:
-
-- An EC2 key pair exported as `AWS_KEY_NAME`
-- Access keys to sign API requests exported as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- An SNS topic for global notifications exported as `AWS_SNS_TOPIC`
-- The name of a Route 53 hosted zone to connect to the application load balancers exported as `AWS_APP_HOSTED_ZONE`
-
-In addition, export the following environmental variables for the AWS CLI:
-
-```bash
-$ export AWS_DEFAULT_OUTPUT=text
-$ export AWS_DEFAULT_REGION=us-east-1
-```
-
-Lastly, install the AWS CLI, Boto, and Troposphere:
-
-```bash
-$ cd deployment
-$ pip install -r deployment/requirements.txt
-```
-
-### Amazon Machine Images (AMIs)
-
-In order to generate AMIs for the application, tile, and monitoring servers, use the following `make` targets:
-
-```bash
-$ make app-ami
-$ make tiler-ami
-$ make monitoring-ami
-```
-
-### CloudFormation (via Troposphere)
-
-After at least one AMI of each type exists, use the following command to generate all of the CloudFormation templates:
-
-```bash
-$ make build
-```
-
-#### Launch the AWS Virtual Private Cloud (VPC)
-
-Use the following command to create the VPC stack:
-
-```
-$ make vpc-stack
-```
-
-#### Create Route 53 Private Hosted Zones
-
-Next, create the internal to the VPC private hosted zones:
-
-```bash
-$ make private-hosted-zones
-```
-
-#### Launch the Data Stores
-
-After the private hosted zones exist, create the data store stack:
-
-```
-$ make data-store-stack
-```
-
-#### Launch the Application Servers
-
-Now that the VPC and data store stacks are setup, we can launch the application server stack, which will make use of the most recent AMIs available:
-
-```
-$ make app-stack
-```
-
-#### Activate Application Servers
-
-Depending on which color stack you just deployed (Blue or Green), activate DNS for the hosted zone:
-
-```
-$ make app-stack-[green,blue]
-```
+For more details around the Amazon Web Services deployment process, please see the deployment [README](deployment/README.md).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Wire up the proxy if:
   #
   #   - The vagrant-proxyconf Vagrant plugin is installed
-  #   - The user set the VAGRANT_PROXYCONF_ENDPOINT environmental variable
+  #   - The user set the VAGRANT_PROXYCONF_ENDPOINT environment variable
   #
   if Vagrant.has_plugin?("vagrant-proxyconf") &&
      !VAGRANT_PROXYCONF_ENDPOINT.nil?

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -45,8 +45,20 @@ delete-green-app-stack:
 delete-blue-app-stack:
 	./deployment-helper.sh delete-blue-app-stack
 
+delete-green-tiler-stack:
+	./deployment-helper.sh delete-green-tiler-stack
+
+delete-blue-tiler-stack:
+	./deployment-helper.sh delete-blue-tiler-stack
+
 app-stack-green: build
 	./deployment-helper.sh toggle-green-app-stack
 
 app-stack-blue: build
 	./deployment-helper.sh toggle-blue-app-stack
+
+tiler-stack-green: build
+	./deployment-helper.sh toggle-green-tiler-stack
+
+tiler-stack-blue: build
+	./deployment-helper.sh toggle-blue-tiler-stack

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,97 @@
+# Amazon Web Services Deployment
+
+Deployment is driven by [Packer](https://www.packer.io), [Troposphere](https://github.com/cloudtools/troposphere), and the [Amazon Web Services CLI](http://aws.amazon.com/cli/).
+
+## Dependencies
+
+The deployment process expects the following environment variables to be overridden:
+
+```bash
+$ export AWS_DEFAULT_PROFILE=nyc-trees-stg
+$ export AWS_PROFILE=nyc-trees-stg
+$ export AWS_DEFAULT_OUTPUT=text
+$ export AWS_DEFAULT_REGION=us-east-1
+$ export AWS_SNS_TOPIC=arn:aws:sns:us-east-1...
+$ export AWS_PUBLIC_HOSTED_ZONE=treescount.nycgovparks.org
+```
+
+Lastly, install the AWS CLI, Boto, and Troposphere:
+
+```bash
+$ cd deployment
+$ pip install -r deployment/requirements.txt
+```
+
+## Amazon Machine Images (AMIs)
+
+In order to generate AMIs for the application, tile, and monitoring servers, use the following `make` targets:
+
+```bash
+$ make app-ami
+$ make tiler-ami
+$ make monitoring-ami
+```
+
+## CloudFormation (via Troposphere)
+
+After at least one AMI of each type exists, use the following command to generate all of the CloudFormation templates:
+
+```bash
+$ make build
+```
+
+### Launch the AWS Virtual Private Cloud (VPC)
+
+Use the following command to create the VPC stack:
+
+```
+$ make vpc-stack
+```
+
+### Create Route 53 Private Hosted Zones
+
+Next, create the internal to the VPC private hosted zones:
+
+```bash
+$ make private-hosted-zones
+```
+
+### Launch the Data Stores
+
+After the private hosted zones exist, create the data store stack:
+
+```
+$ make data-store-stack
+```
+
+### Launch the Tile Servers
+
+Now that the VPC and data store stacks are setup, we can launch the tile server stack, which will make use of the most recent AMIs available:
+
+```
+$ make tiler-stack
+```
+
+### Activate Tile Servers
+
+Depending on which color stack you just deployed (Blue or Green), activate DNS for the hosted zone:
+
+```
+$ make tiler-stack-[green,blue]
+```
+
+### Launch the Application Servers
+
+Next, launch the application server stack, which will also make use of the most recent AMIs available:
+
+```
+$ make app-stack
+```
+
+### Activate Application Servers
+
+Depending on which color stack you just deployed (Blue or Green), activate DNS for the hosted zone:
+
+```
+$ make app-stack-[green,blue]
+```

--- a/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
@@ -16,7 +16,7 @@ app_config:
   - { file: "DJANGO_MEDIA_ROOT", content: "{{ app_media_root }}" }
   - { file: "DJANGO_POSTGIS_VERSION", content: "{{ app_postgis_version }}" }
   - { file: "DJANGO_SECRET_KEY", content: "{{ app_secret_key }}" }
-  - { file: "TILER_HOST", content: "//{{ tiler_host }}" }
+  - { file: "TILER_HOST", content: "{{ tiler_host }}" }
 
 app_sauce_labs_config:
   - { file: "SELENIUM_HOST", content: "{{ lookup('env', 'SELENIUM_HOST') }}" }

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -4,54 +4,55 @@
     "aws_region": "us-east-1",
     "aws_instance_type": "m3.large",
     "aws_ssh_username": "ubuntu",
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_ubuntu_ami": ""
   },
   "builders": [
     {
       "name": "nyc-trees-monitoring",
       "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key` }}",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `aws_ubuntu_ami`}}",
       "instance_type": "{{user `aws_instance_type`}}",
       "ssh_username": "{{user `aws_ssh_username`}}",
       "ami_name": "nyc-trees-monitoring-{{timestamp}}-{{user `version`}}",
+      "run_tags": {
+        "PackerBuilder": "amazon-ebs"
+      },
       "tags": {
-        "name": "nyc-trees-monitoring",
-        "version": "{{user `version`}}"
+        "Name": "nyc-trees-monitoring",
+        "Version": "{{user `version`}}"
       }
     },
     {
       "name": "nyc-trees-tiler",
       "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key` }}",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `aws_ubuntu_ami`}}",
       "instance_type": "{{user `aws_instance_type`}}",
       "ssh_username": "{{user `aws_ssh_username`}}",
       "ami_name": "nyc-trees-tiler-{{timestamp}}-{{user `version`}}",
+      "run_tags": {
+        "PackerBuilder": "amazon-ebs"
+      },
       "tags": {
-        "name": "nyc-trees-tiler",
-        "version": "{{user `version`}}"
+        "Name": "nyc-trees-tiler",
+        "Version": "{{user `version`}}"
       }
     },
     {
       "name": "nyc-trees-app",
       "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key` }}",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `aws_ubuntu_ami`}}",
       "instance_type": "{{user `aws_instance_type`}}",
       "ssh_username": "{{user `aws_ssh_username`}}",
       "ami_name": "nyc-trees-app-{{timestamp}}-{{user `version`}}",
+      "run_tags": {
+        "PackerBuilder": "amazon-ebs"
+      },
       "tags": {
-        "name": "nyc-trees-app",
-        "version": "{{user `version`}}"
+        "Name": "nyc-trees-app",
+        "Version": "{{user `version`}}"
       }
     }
   ],
@@ -79,6 +80,9 @@
       "playbook_file": "ansible/tile-servers.yml",
       "playbook_dir": "ansible",
       "inventory_file": "ansible/inventory/packer-tile-server",
+      "extra_arguments": [
+        "--extra-vars 'tiler_deploy_branch={{user `version`}}'"
+      ],
       "only": [
         "nyc-trees-tiler"
       ]

--- a/deployment/troposphere/app_hosted_zone_template.py
+++ b/deployment/troposphere/app_hosted_zone_template.py
@@ -6,18 +6,18 @@ import troposphere.route53 as r53
 t = Template()
 
 t.add_version('2010-09-09')
-t.add_description('Hosted zone records stack for the nyc-trees project.')
+t.add_description('Application hosted zone records for the nyc-trees project.')
 
 #
 # Parameters
 #
 hosted_zone_name_param = t.add_parameter(Parameter(
-    'AppServerHostedZone', Type='String',
+    'PublicHostedZone', Type='String',
     Default='treescount.azavea.com',
-    Description='Hosted zone name for application server endpoint'
+    Description='Hosted zone name for public DNS'
 ))
 
-hosted_zone_alias_target_param = t.add_parameter(Parameter(
+app_server_hosted_zone_alias_target_param = t.add_parameter(Parameter(
     'AppServerAliasTarget', Type='String',
     Description='Alias target for the hosted zone record set'
 ))
@@ -32,15 +32,18 @@ app_server_load_balancer_hosted_zone_id_param = t.add_parameter(
 #
 # Route53 Resources
 #
-private_dns_records_sets = t.add_resource(r53.RecordSetGroup(
-    'dnsAppServerRecords',
+public_dns_records_sets = t.add_resource(r53.RecordSetGroup(
+    'dnsPublicRecords',
     HostedZoneName=Join('', [Ref(hosted_zone_name_param), '.']),
     RecordSets=[
         r53.RecordSet(
             'dnsAppServers',
             AliasTarget=r53.AliasTarget(
                 Ref(app_server_load_balancer_hosted_zone_id_param),
-                Join('', [Ref(hosted_zone_alias_target_param), '.'])
+                Join(
+                    '',
+                    [Ref(app_server_hosted_zone_alias_target_param), '.']
+                )
             ),
             Name=Ref(hosted_zone_name_param),
             Type='A'

--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -37,13 +37,12 @@ app_server_ami_param = t.add_parameter(Parameter(
     Description='Application server AMI'
 ))
 
-# app_server_instance_profile_param = t.add_parameter(Parameter(
-#     'AppServerInstanceProfile', Type='String',
-#     Default=
-#     'arn:aws:iam::900325299081:instance-profile/AppServerInstanceProfile',
-#     Description='Physical resource ID of an AWS::IAM::Role for the '
-#                 'application servers'
-# ))
+app_server_instance_profile_param = t.add_parameter(Parameter(
+    'AppServerInstanceProfile', Type='String',
+    Default='SendEmail',
+    Description='Physical resource ID of an AWS::IAM::Role for the '
+                'application servers'
+))
 
 app_server_instance_type_param = t.add_parameter(Parameter(
     'AppServerInstanceType', Type='String', Default='t2.micro',
@@ -163,7 +162,7 @@ app_server_load_balancer = t.add_resource(elb.LoadBalancer(
 app_server_launch_config = t.add_resource(asg.LaunchConfiguration(
     'lcAppServer',
     ImageId=Ref(app_server_ami_param),
-    # IamInstanceProfile=Ref(app_server_instance_profile_param),
+    IamInstanceProfile=Ref(app_server_instance_profile_param),
     InstanceType=Ref(app_server_instance_type_param),
     KeyName=Ref(keyname_param),
     SecurityGroups=[Ref(app_server_security_group)]

--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -198,8 +198,7 @@ database_server_instance = t.add_resource(rds.DBInstance(
     EngineVersion='9.3.5',
     MasterUsername=Ref(database_server_master_username_param),
     MasterUserPassword=Ref(database_server_master_password_param),
-    # TODO Toggle this to True in production
-    MultiAZ=False,
+    MultiAZ=True,
     PreferredBackupWindow='01:00-01:30',  # 9:00-9:30PM ET
     PreferredMaintenanceWindow='mon:01:30-mon:02:30',  # 9:30PM-10:30PM ET
     VPCSecurityGroups=[Ref(database_server_security_group)],

--- a/deployment/troposphere/tiler_hosted_zone_template.py
+++ b/deployment/troposphere/tiler_hosted_zone_template.py
@@ -1,0 +1,77 @@
+from troposphere import Template, Parameter, Ref, GetAtt
+
+import template_utils as utils
+import troposphere.route53 as r53
+import troposphere.cloudfront as cf
+
+t = Template()
+
+t.add_version('2010-09-09')
+t.add_description('Tiler hosted zone records for the nyc-trees project.')
+
+#
+# Parameters
+#
+hosted_zone_name_param = t.add_parameter(Parameter(
+    'PublicHostedZone', Type='String',
+    Default='treescount.azavea.com',
+    Description='Hosted zone name for public DNS'
+))
+
+tile_server_hosted_zone_alias_target_param = t.add_parameter(Parameter(
+    'TileServerAliasTarget', Type='String',
+    Description='Alias target for the hosted zone record set'
+))
+
+#
+# CloudFront Resources
+#
+cloudfront_tile_distribution = t.add_resource(cf.Distribution(
+    'tileDistribution',
+    DistributionConfig=cf.DistributionConfig(
+        Origins=[
+            cf.Origin(
+                Id='tileOriginId',
+                DomainName=Ref(tile_server_hosted_zone_alias_target_param),
+                CustomOriginConfig=cf.CustomOrigin(
+                    OriginProtocolPolicy='http-only'
+                )
+            )
+        ],
+        DefaultCacheBehavior=cf.DefaultCacheBehavior(
+            ForwardedValues=cf.ForwardedValues(QueryString=True),
+            TargetOriginId='tileOriginId',
+            ViewerProtocolPolicy='allow-all'
+        ),
+        Enabled=True
+    )
+))
+
+#
+# Route53 Resources
+#
+private_dns_records_sets = t.add_resource(r53.RecordSetGroup(
+    'dnsPrivateRecords',
+    HostedZoneName='nyc-trees.internal.',
+    RecordSets=[
+        r53.RecordSet(
+            'dnsTileServers',
+            Name='tile.service.nyc-trees.internal.',
+            Type='CNAME',
+            TTL='10',
+            ResourceRecords=[
+                GetAtt(cloudfront_tile_distribution, 'DomainName')
+            ]
+        )
+    ]
+))
+
+if __name__ == '__main__':
+    utils.validate_cloudformation_template(t.to_json())
+
+    file_name = __file__.replace('.py', '.json')
+
+    with open(file_name, 'w') as f:
+        f.write(t.to_json())
+
+    print('Template validated and written to %s' % file_name)

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -293,7 +293,7 @@ NYC_BOUNDS = (-74.259088, 40.495996, -73.700272, 40.915256)
 # appended for a second attempt.
 GEOCODE_FALLBACK_SUFFIX = ', New York, NY'
 
-TILER_URL = environ.get('TILER_HOST', 'localhost')
+TILER_URL = '//%s' % environ.get('TILER_HOST', 'localhost')
 
 MAX_GROUP_IMAGE_SIZE_IN_BYTES = 102400  # 100 KB
 

--- a/src/nyc_trees/requirements/production.txt
+++ b/src/nyc_trees/requirements/production.txt
@@ -1,2 +1,4 @@
 -r base.txt
+
 boto==2.34.0
+dnspython>=1.12.0


### PR DESCRIPTION
This changeset adds blue/green deployment support to the tiler with:

- AMI building
- Blue/green CloudFormation stacks
- Toggling between stacks through a CloudFront origin

In addition, the Django application uses DNS resolution (CNAME record) against `tile.service.nyc-trees.internal` to determine its tile host (ultimately, the CloudFront distribution endpoint). The process for toggling between stacks alters the origin of the CloudFront distribution.