### PR TITLE
Fix bug with new reservations counts

### DIFF
--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -44,7 +44,7 @@ def reserve_blockfaces_page(request):
 
     return {
         'reservations': {
-            'current': current_reservations_amount,
+            'current': 0,
             'total': RESERVATIONS_LIMIT - current_reservations_amount
         },
         'legend_entries': [


### PR DESCRIPTION
The "current" reservations should reflect how many blockfaces are
selected on the page, not how many blockfaces are reserved.