### PR TITLE
Add glob to RELP package version

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -23,3 +23,4 @@ elasticsearch_cluster_name: "logstash"
 nodejs_npm_version: 2.1.14
 
 java_version: "7u75-*"
+relp_version: "7.4.4-*"


### PR DESCRIPTION
This changeset sets the package version of RELP to the highest version that begins with `7.4.4`.