### PR TITLE
Fix pgweb startup sequence after boot

### DIFF
--- a/deployment/ansible/roles/nyc-trees.pgweb/templates/pgweb.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.pgweb/templates/pgweb.conf.j2
@@ -1,6 +1,6 @@
 description	"pgweb"
 
-start on (local-filesystems and net-device-up IFACE!=lo)
+start on postgresql-started
 stop on shutdown
 
 respawn

--- a/deployment/ansible/roles/nyc-trees.postgresql/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.postgresql/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Configure PostgreSQL service definition
+  template: src=postgresql.j2
+            dest=/etc/init.d/postgresql
+            mode=0755
+  notify:
+    - Restart PostgreSQL
+
 - name: Create PostgreSQL super user
   sudo_user: postgres
   postgresql_user: name="{{ postgresql_username }}"

--- a/deployment/ansible/roles/nyc-trees.postgresql/templates/postgresql.j2
+++ b/deployment/ansible/roles/nyc-trees.postgresql/templates/postgresql.j2
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -e
+
+### BEGIN INIT INFO
+# Provides:		postgresql
+# Required-Start:	$local_fs $remote_fs $network $time
+# Required-Stop:	$local_fs $remote_fs $network $time
+# Should-Start:		$syslog
+# Should-Stop:		$syslog
+# Default-Start:	2 3 4 5
+# Default-Stop:		0 1 6
+# Short-Description:	PostgreSQL RDBMS server
+### END INIT INFO
+
+# Setting environment variables for the postmaster here does not work; please
+# set them in /etc/postgresql/<version>/<cluster>/environment instead.
+
+[ -r /usr/share/postgresql-common/init.d-functions ] || exit 0
+
+. /usr/share/postgresql-common/init.d-functions
+
+# versions can be specified explicitly
+if [ -n "$2" ]; then
+    versions="$2 $3 $4 $5 $6 $7 $8 $9"
+else
+    get_versions
+fi
+
+case "$1" in
+    start|stop|restart|reload)
+        if [ "$1" = "start" ]; then
+            create_socket_directory
+        fi
+	if [ -z "`pg_lsclusters -h`" ]; then
+	    log_warning_msg 'No PostgreSQL clusters exist; see "man pg_createcluster"'
+	    exit 0
+	fi
+	for v in $versions; do
+	    $1 $v || EXIT=$?
+	done
+
+    if [ "$1" = "start" ]; then
+        # Emit Upstart event for dependent services to know when to start
+        initctl emit postgresql-started
+    fi
+
+	exit ${EXIT:-0}
+        ;;
+    status)
+	LS=`pg_lsclusters -h`
+	# no clusters -> unknown status
+	[ -n "$LS" ] || exit 4
+	echo "$LS" | awk 'BEGIN {rc=0} {if (match($4, "down")) rc=3; printf ("%s/%s (port %s): %s\n", $1, $2, $3, $4)}; END {exit rc}'
+	;;
+    force-reload)
+	for v in $versions; do
+	    reload $v
+	done
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|reload|force-reload|status} [version ..]"
+        exit 1
+        ;;
+esac
+
+exit 0
+


### PR DESCRIPTION
This changeset sets the Upstart `start on` stanza for `pgweb` to depend on a `initctl` event emitted by the PostgreSQL `init.d` script.