### PR TITLE
Disable soft launch until better setting available

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/production.py
+++ b/src/nyc_trees/nyc_trees/settings/production.py
@@ -83,4 +83,4 @@ except exception.DNSException:
                      environ.get('TILER_HOST'))
 # END TILER CONFIGURATION
 
-SOFT_LAUNCH_ENABLED = True
+SOFT_LAUNCH_ENABLED = False


### PR DESCRIPTION
We want to exercise the full application in our staging environment (which uses production settings) but can't with this flag set to True. The plan is to replace this simple settings flag with a database-backed system with finer grained control over "on" and "off."