### PR TITLE
Add DEFAULT_FROM_EMAIL

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -38,6 +38,9 @@ STATSD_CLIENT = 'django_statsd.clients.normal'
 STATSD_HOST = environ.get('NYC_TREES_STATSD_HOST', 'localhost')
 # END STATSD CONFIGURATION
 
+# EMAIL CONFIGURATION
+DEFAULT_FROM_EMAIL = 'azaveadev@azavea.com'
+# END EMAIL CONFIGURATION
 
 # DATABASE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases


### PR DESCRIPTION
This changeset adds a `DEFAULT_FROM_EMAIL` setting with the Azavea domain so that it is not rejected by Amazon SES.

Attempts to resolve: https://github.com/azavea/nyc-trees/issues/392