### PR TITLE
Fix errors on reserve blockface page

### DIFF
--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -77,6 +77,9 @@ var selectedLayer = new SelectableBlockfaceLayer(reservationMap, grid, {
 });
 
 grid.on('click', function(e) {
+    if (!e.data) {
+        return;
+    }
     if (selectedBlockfacesCount >= blockfaceLimit) {
         toastr.error('You have reached your reservation limit');
     } else if (e.data.restriction !== 'none') {
@@ -89,10 +92,14 @@ reservationMap.addLayer(selectedLayer);
 
 // Load any existing data.
 var state = progress.load();
-if (state && state.selections.length > 0) {
+if (state) {
     $.each(state.selections, function(id, data) {
         selectedLayer.addBlockface(data);
     });
-    // Zoom to extent of selected blockface reservations.
-    reservationMap.fitBounds(selectedLayer.getBounds());
+    try {
+        // Zoom to extent of selected blockface reservations.
+        reservationMap.fitBounds(selectedLayer.getBounds());
+    } catch (ex) {
+        // Ignore Leaflet fitBounds error when there are no selections.
+    }
 }


### PR DESCRIPTION
This appeared to work when I first tested it but Objects don't have a
length property, obviously. Also, suppress an error when clicking empty
spaces on the map.