### PR TITLE
Require that users complete training before they can RSVP for an event

### DIFF
--- a/src/nyc_trees/apps/core/decorators.py
+++ b/src/nyc_trees/apps/core/decorators.py
@@ -11,7 +11,9 @@ from django.shortcuts import get_object_or_404
 
 from django_tinsel.utils import decorate as do
 
-from apps.core.helpers import user_is_census_admin, user_is_group_admin
+from apps.core.helpers import (user_is_census_admin, user_is_group_admin,
+                               user_has_online_training,
+                               user_has_field_training)
 from apps.core.models import Group
 
 
@@ -60,18 +62,24 @@ def user_must_be_group_admin(view_fn):
 
 
 def user_must_have_online_training(view_fn):
-    # TODO: implement
     @wraps(view_fn)
     def wrapper(request, *args, **kwargs):
-        return view_fn(request, *args, **kwargs)
+        if user_has_online_training(request.user):
+            return view_fn(request, *args, **kwargs)
+        else:
+            raise PermissionDenied('%s has not completed online training yet'
+                                   % request.user)
     return wrapper
 
 
 def user_must_have_field_training(view_fn):
-    # TODO: implement
     @wraps(view_fn)
     def wrapper(request, *args, **kwargs):
-        return view_fn(request, *args, **kwargs)
+        if user_has_field_training(request.user):
+            return view_fn(request, *args, **kwargs)
+        else:
+            raise PermissionDenied('%s has not attended a training event yet'
+                                   % request.user)
     return wrapper
 
 

--- a/src/nyc_trees/apps/core/helpers.py
+++ b/src/nyc_trees/apps/core/helpers.py
@@ -1,5 +1,3 @@
-from apps.event.models import EventRegistration
-
 
 def user_is_census_admin(user):
     return user.is_authenticated() and user.is_census_admin
@@ -15,8 +13,7 @@ def user_has_online_training(user):
 
 
 def user_has_field_training(user):
-    return user.is_authenticated() and EventRegistration.objects.filter(
-        user=user, did_attend=True, event__includes_training=True)
+    return user.is_authenticated() and user.field_training_complete
 
 
 def user_is_individual_mapper(user):

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -101,6 +101,10 @@ class User(NycModel, AbstractUser):
         from apps.home.training import training_summary
         return training_summary.is_complete(self)
 
+    @property
+    def training_complete(self):
+        return self.online_training_complete and self.field_training_complete
+
 
 class Group(NycModel, models.Model):
     name = models.CharField(max_length=255, unique=True)

--- a/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
@@ -1,3 +1,13 @@
+{% comment %}
+
+The following variables must be in scope:
+===
+  - user (object)      Model object
+  - event (object)     Model object
+  - rsvp_count (int)   Number of RSVPd users
+  - is_admin (bool)    Is this user a group admin?
+  - is_rsvped (bool)   Is this user RSVPd to this event?
+{% endcomment %}
 <div class="col-xs-6">
     <p>
         {{ rsvp_count }} / {{ event.max_attendees }}
@@ -5,25 +15,32 @@
     </p>
 </div>
 <div class="col-xs-6 text-right">
-    {% if not user.is_authenticated and can_rsvp %}
+{% if can_rsvp %}
+    {% if not user.is_authenticated %}
     <a id="rsvp"
        href="{% url "login" %}?next={{ event.get_absolute_url }}"
        class="btn btn-switch">RSVP</a>
     {% elif is_admin %}
-    <a href="{{ event_edit_url }}" class="btn btn-switch"><i class="icon-cog"></i>Admin</a>
+    <a href="{{ event_edit_url }}"
+       class="btn btn-switch"><i class="icon-cog"></i>Admin</a>
+    {% elif not event.includes_training and not user.training_complete %}
+    <a id="rsvp"
+       href="{% url "training_instructions" %}"
+       class="btn btn-switch btn-rsvp">RSVP</a>
     {% elif is_rsvped %}
     <a id="rsvp"
        href="#"
        data-verb="DELETE"
        data-url="{{ rsvp_url }}"
        class="btn btn-switch btn-rsvp active">RSVPed</a>
-    {% elif can_rsvp %}
+    {% else %}
     <a id="rsvp"
        href="#"
        data-verb="POST"
        data-url="{{ rsvp_url }}"
        class="btn btn-switch btn-rsvp">RSVP</a>
-    {% else %}
-    <a id="rsvp" href="#" class="btn btn-switch disabled">At Capacity</a>
     {% endif %}
+{% else %}
+<a id="rsvp" href="#" class="btn btn-switch disabled">At Capacity</a>
+{% endif %}
 </div>

--- a/src/nyc_trees/apps/home/templates/home/training_instructions.html
+++ b/src/nyc_trees/apps/home/templates/home/training_instructions.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+{# TODO: Design #}
+
+<p>
+Before you're able to RSVP to mapping events you'll need to do the following:
+</p>
+<ul>
+    <li>
+        {% if user.online_training_complete %}<s>{% endif %}
+        Complete your <a href="{% url "training_summary_pure" %}">online training</a>
+        {% if user.online_training_complete %}</s>{% endif %}
+    </li>
+    <li>
+        {% if user.field_training_complete %}<s>{% endif %}
+        Attend a <a href="{% url "events_list_page" %}#training">training event</a></li>
+        {% if user.field_training_complete %}</s>{% endif %}
+    </li>
+</ul>
+{% endblock %}

--- a/src/nyc_trees/apps/home/training/routes.py
+++ b/src/nyc_trees/apps/home/training/routes.py
@@ -25,6 +25,10 @@ intro_quiz = do(login_required,
                       POST=do(render_template('home/quiz_complete_page.html'),
                               v.complete_quiz)))
 
+training_instructions = route(GET=do(
+    render_template('home/training_instructions.html'),
+    v.training_instructions))
+
 
 def make_flatpage_route(name):
     return route(GET=do(

--- a/src/nyc_trees/apps/home/training/views.py
+++ b/src/nyc_trees/apps/home/training/views.py
@@ -60,3 +60,7 @@ def complete_quiz(request):
         'score': score,
         'passed_quiz': passed_quiz,
     }
+
+
+def training_instructions(request):
+    return {}

--- a/src/nyc_trees/apps/home/urls.py
+++ b/src/nyc_trees/apps/home/urls.py
@@ -6,6 +6,7 @@ from __future__ import division
 from django.conf.urls import patterns, url, include
 
 from apps.home import routes as r
+from apps.home.training import routes as tr
 from apps.home.training import (training_summary, getting_started,
                                 the_mapping_method,
                                 tree_data, tree_surroundings,
@@ -38,6 +39,9 @@ urlpatterns = patterns(
     url(r'^training/progress/intro_quiz/$', **intro_quiz.previous_step.mark_kwargs()),                 # NOQA
     # groups_to_follow does not have a mark endpoint because its previous step is tracked differently  # NOQA
     url(r'^training/progress/$', **training_summary.previous_step.mark_kwargs()),                      # NOQA
+
+    url(r'^training/instructions', tr.training_instructions,
+        name='training_instructions'),
 
     # "training/pages" instead of "training/pages/" because the
     # flatpages admin interface insists that the "URL" (really a URL


### PR DESCRIPTION
This alters the `user_must_have_online_training` decorator and redirects users to a "training instructions" page if they try to RSVP for an event before they have completed training.

Refs #405 