### PR TITLE
Add CloudWatch alarms to the application and tiler ELBs

### DIFF
--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -2,6 +2,7 @@ from troposphere import Template, Parameter, Ref, Tags, Output, GetAtt, ec2
 
 import template_utils as utils
 import troposphere.autoscaling as asg
+import troposphere.cloudwatch as cw
 import troposphere.elasticloadbalancing as elb
 
 t = Template()
@@ -154,6 +155,46 @@ app_server_load_balancer = t.add_resource(elb.LoadBalancer(
         Name='elbAppServer',
         Color=Ref(color_param)
     )
+))
+
+t.add_resource(cw.Alarm(
+    'alarmAppServerBackend4XX',
+    AlarmDescription='Application server backend 4XXs',
+    AlarmActions=[Ref(notification_arn_param)],
+    Statistic='Sum',
+    Period=300,
+    Threshold=5,
+    EvaluationPeriods=1,
+    ComparisonOperator='GreaterThanThreshold',
+    MetricName='HTTPCode_Backend_4XX',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(app_server_load_balancer)
+        )
+    ],
+))
+
+t.add_resource(cw.Alarm(
+    'alarmAppServerBackend5XX',
+    AlarmDescription='Application server backend 5XXs',
+    AlarmActions=[Ref(notification_arn_param)],
+    Statistic='Sum',
+    Period=60,
+    Threshold=0,
+    EvaluationPeriods=1,
+    ComparisonOperator='GreaterThanThreshold',
+    MetricName='HTTPCode_Backend_5XX',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(app_server_load_balancer)
+        )
+    ],
 ))
 
 #

--- a/deployment/troposphere/tiler_template.py
+++ b/deployment/troposphere/tiler_template.py
@@ -2,6 +2,7 @@ from troposphere import Template, Parameter, Ref, Tags, Output, GetAtt, ec2
 
 import template_utils as utils
 import troposphere.autoscaling as asg
+import troposphere.cloudwatch as cw
 import troposphere.elasticloadbalancing as elb
 
 t = Template()
@@ -155,6 +156,46 @@ tile_server_load_balancer = t.add_resource(elb.LoadBalancer(
         Name='elbTileServer',
         Color=Ref(color_param)
     )
+))
+
+t.add_resource(cw.Alarm(
+    'alarmTileServerBackend4XX',
+    AlarmDescription='Tile server backend 4XXs',
+    AlarmActions=[Ref(notification_arn_param)],
+    Statistic='Sum',
+    Period=300,
+    Threshold=5,
+    EvaluationPeriods=1,
+    ComparisonOperator='GreaterThanThreshold',
+    MetricName='HTTPCode_Backend_4XX',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(tile_server_load_balancer)
+        )
+    ],
+))
+
+t.add_resource(cw.Alarm(
+    'alarmTileServerBackend5XX',
+    AlarmDescription='Tile server backend 5XXs',
+    AlarmActions=[Ref(notification_arn_param)],
+    Statistic='Sum',
+    Period=60,
+    Threshold=0,
+    EvaluationPeriods=1,
+    ComparisonOperator='GreaterThanThreshold',
+    MetricName='HTTPCode_Backend_5XX',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(tile_server_load_balancer)
+        )
+    ],
 ))
 
 #


### PR DESCRIPTION
This changeset adds CloudWatch alarms to the application and tiler Elastic Load Balancers (ELBs). The two  metrics right now are backend 4XX and 5XX failures.