### PR TITLE
Add DNS support for monitoring server

### DIFF
--- a/deployment/deployment-helper.sh
+++ b/deployment/deployment-helper.sh
@@ -175,7 +175,8 @@ case "$1" in
     AWS_PRIVATE_SUBNETS=$(echo "${AWS_VPC_STACK_OUTPUTS}" | grep "PrivateSubnets" | cut -f2)
 
     # Build parameters argument
-    AWS_STACK_PARAMS="ParameterKey=KeyName,ParameterValue=${AWS_KEY_NAME}"
+    AWS_STACK_PARAMS="ParameterKey=PublicHostedZone,ParameterValue=${AWS_PUBLIC_HOSTED_ZONE}"
+    AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=KeyName,ParameterValue=${AWS_KEY_NAME}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=GlobalNotificationsARN,ParameterValue=${AWS_SNS_TOPIC}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=VpcId,ParameterValue=${AWS_VPC_ID}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=BastionHostAMI,ParameterValue=${AWS_BASTION_HOST_AMI}"


### PR DESCRIPTION
This changeset gives the monitoring server a subdomain off of the default Route 53 hosted zone.

For example, if the default hosted zone is `treescount.foo.com`, these CloudFormation changes will create an A record of `monitoring.treescount.foo.com` under the `treescount.foo.com` hosted zone that points to the public IP address of the monitoring server.