### PR TITLE
Unpin minor version of PostgreSQL related packages

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -13,10 +13,11 @@ apache_port: 8080
 graphite_web_port: "{{ apache_port }}"
 
 postgresql_version: "9.3"
-postgresql_package_version: "9.3.5*.pgdg14.04+1"
+postgresql_package_version: "9.3.*.pgdg14.04+1"
 postgresql_support_repository_channel: "9.3"
+postgresql_support_libpq_version: "9.3.*.pgdg14.04+1"
 postgis_version: "2.1"
-postgis_package_version: "2.1.5*.pgdg14.04+1"
+postgis_package_version: "2.1.*.pgdg14.04+1"
 
 elasticsearch_cluster_name: "logstash"
 


### PR DESCRIPTION
This changeset extends the glob for the version number of PostgreSQL related packages so that the minor version is included. Originally, the minor version was being included because the version of PostgreSQL being used in RDS is `9.5.3`.

Attempts to resolve: #453