### PR TITLE
Clean up z-index values to be lower than Bootstrap's

### DIFF
--- a/src/nyc_trees/sass/partials/_header.scss
+++ b/src/nyc_trees/sass/partials/_header.scss
@@ -78,7 +78,6 @@
   border: 0;
   padding: 1.0rem 1.0rem;
   width: auto;
-  z-index: 6200;
 }
 
 .icon-bar {
@@ -106,7 +105,7 @@
   background-color: $nav-side-color;
   width: 30rem;
   left: -30rem;
-  z-index: 1000;
+  z-index: 1;
   transition: all 400ms $transition;
   .menu-active & {
     left: 0;
@@ -125,7 +124,6 @@
 }
 
 .main-header {
-  z-index: 1000;
   position: relative;
 }
 
@@ -188,7 +186,7 @@
   position: fixed;
   height: 100%;
   width: 100%;
-  z-index: 6000;
+  z-index: $zindex-overlaymenu;
   display: none;
   opacity: .2;
   .menu-active & {

--- a/src/nyc_trees/sass/partials/_home.scss
+++ b/src/nyc_trees/sass/partials/_home.scss
@@ -63,20 +63,20 @@ $hero-box-side-padding: 3rem;
 .ticker-box.ticker-box-bg:after {
   top: 3px;
   background-color: #fff;
-  z-index: 90;
+  z-index: $zindex-base-ticker + 1;
 }
 
 .ticker-box.ticker-box-bg:before {
   top: 5px;
   background-color: #ccc;
-  z-index: 80;
+  z-index: $zindex-base-ticker;
 }
 
 .ticker-box-top {
   background-color: #eee;
-  z-index: 100;
+  z-index: $zindex-above-ticker;
   &:after {
-    z-index: 200;
+    z-index: $zindex-above-ticker + 1;
     content: "";
     position: absolute;
     left: 0;

--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -4,7 +4,7 @@
     position: static;
   }
   .action-bar .dropdown-menu {
-    z-index: 1100;
+    z-index: $zindex-modal + 1;
   }
 }
 
@@ -29,7 +29,6 @@
   }
   .nav-tabs {
     position: relative;
-    z-index: 3000;
   }
 }
 
@@ -68,7 +67,6 @@
   bottom: 0;
   right: 0;
   left: 0;
-  z-index: 1200;
 }
 
 .map-sidebar-context {
@@ -79,7 +77,6 @@
 }
 
 .location-search-container {
-  z-index: 2000;
   position: relative;
   font-size: $font-size-h6;
   background-color: #fff;
@@ -160,7 +157,7 @@
   }
   .map-sidebar {
     position: absolute;
-    z-index: 2000;
+    z-index: 1;
     top: 8rem;
     left: 2rem;
     width: 32rem;

--- a/src/nyc_trees/sass/partials/_variables.scss
+++ b/src/nyc_trees/sass/partials/_variables.scss
@@ -315,6 +315,14 @@ $zindex-modal-background:  1040;
 $zindex-modal:             1050;
 
 
+// Custom z-index variables
+// Try to keep these below the bootstrap z-index values above, especially the modal ones
+
+$zindex-base-ticker: 10;
+$zindex-above-ticker: 100;
+$zindex-overlaymenu: 6000;
+
+
 //== Media queries breakpoints
 //
 //## Define the breakpoints at which your layout will change, adapting to different screen sizes.


### PR DESCRIPTION
I was having a lot of trouble getting Bootstrap modals to work properly,
because the z-index values in our SCSS was significantly higher than
Bootstrap's.

This moves most of z-index values to be based off of variables, defined
directly below the Bootstrap z-index definitions, and lowers all z-index
values where appropriate.

I also removed several z-index properties altogether because I could not
determine what effect, if any, they had.