### PR TITLE
Add ability to cancel reservations

### DIFF
--- a/src/nyc_trees/apps/core/templates/base.html
+++ b/src/nyc_trees/apps/core/templates/base.html
@@ -67,6 +67,9 @@
             {% block content %}
             {% endblock content %}
         </div>
+        {# This block exists for placing elements that need to be children of the body, like bootstrap modals #}
+        {% block extra_content %}
+        {% endblock extra_content %}
     </body>
     <script type="text/javascript">
       {% include 'core/partials/config.js' %}

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.contrib.gis.db import models
+from django.utils.timezone import now
 
 from apps.core.models import User, Group
 
@@ -52,6 +53,13 @@ class Tree(NycModel, models.Model):
     species = models.ForeignKey(Species, null=True, on_delete=models.PROTECT)
 
 
+class ReservationsQuerySet(models.QuerySet):
+    def current(self):
+        return self \
+            .filter(canceled_at__isnull=True) \
+            .filter(expires_at__gt=now())
+
+
 class BlockfaceReservation(NycModel, models.Model):
     user = models.ForeignKey(User)
     # We do not plan on Blockface records being deleted, but we should
@@ -61,6 +69,8 @@ class BlockfaceReservation(NycModel, models.Model):
     is_mapping_with_paper = models.BooleanField(default=False)
     expires_at = models.DateTimeField()
     canceled_at = models.DateTimeField(null=True, blank=True)
+
+    objects = ReservationsQuerySet.as_manager()
 
     def __unicode__(self):
         return '%s -> %s' % (self.user, self.blockface_id)

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from django_tinsel.decorators import route, render_template
+from django_tinsel.decorators import route, render_template, json_api_call
 
 from apps.core.decorators import individual_mapper_do
 
@@ -31,6 +31,7 @@ reserved_blockface_popup = route(
 
 cancel_reservation = route(
     GET=individual_mapper_do(
+        json_api_call,
         v.cancel_reservation))
 
 reserve_blockfaces = individual_mapper_do(

--- a/src/nyc_trees/apps/survey/templates/survey/partials/reserved_blockface_popup.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/reserved_blockface_popup.html
@@ -13,13 +13,39 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="reserved-blockface-popup-submenu">
                 <li>
-                    <a role="menuitem" tabindex="-1"
-                      href="{% url 'survey' blockface_id=blockface.id %}">
+                    <a role="menuitem" tabindex="-1" href="{% url 'survey' blockface_id=blockface.id %}">
                         Start Mapping
                     </a>
                 </li>
-                <li><a role="menuitem" tabindex="-1" href="#">Cancel Reservation</a></li>
+                <li>
+                    <a role="menuitem" tabindex="-1" href="javascript:" id="cancel-reservation" data-toggle="modal" data-target="#reservation-modal">
+                      Cancel Reservation
+                    </a>
+                </li>
             </ul>
         </div>
     </div>
+    <!-- Bootstrap modals need to be high up in the DOM to prevent z-index issues,
+         but we want to send down new markup for each blockface.
+         The solution I arrived at is to place the modal contents in a script tag,
+         and move them into the modal when this partial is loaded -->
+    <script type="html/template" id="cancel-reservation-template">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="reservation-modal-label">Cancel Reservation</h4>
+            </div>
+            <div class="modal-body">
+                <p>Canceling your reservation will allow another voluntreer to reserve this block.</p>
+                <p>Are you sure you want to cancel?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default pull-left" data-dismiss="modal">Keep Reservation</button>
+                <button type="button" class="btn btn-primary" data-action="cancel-reservation" data-url="{% url 'cancel_reservation' blockface_id=blockface.id %}">
+                    Cancel Reservation
+                </button>
+            </div>
+        </div>
+    </div>
+    </script>
 </div>

--- a/src/nyc_trees/apps/survey/templates/survey/reservations.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reservations.html
@@ -28,6 +28,11 @@
 
 {% endblock main %}
 
+{% block extra_content %}
+<div class="modal fade" id="reservation-modal" tabindex="-1" role="dialog" aria-labelledby="reservation-modal-label" aria-hidden="true" id="modal">
+</div>
+{% endblock extra_content %}
+
 {% block page_js %}
     <script type="text/javascript" src="{{ "js/reservationPage.js"|static_url }}"></script>
 {% endblock page_js %}

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -9,14 +9,22 @@ from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 
 
+from nyc_trees.context_processors import make_layers_context
+
 from apps.users.models import TrustedMapper
 
 from apps.survey.models import BlockfaceReservation, Blockface, Territory
 
 
 def cancel_reservation(request, blockface_id):
-    # TODO: implement
-    pass
+    update_time = now()
+    BlockfaceReservation.objects \
+        .filter(blockface_id=blockface_id) \
+        .filter(user=request.user) \
+        .current() \
+        .update(canceled_at=update_time, updated_at=update_time)
+
+    return make_layers_context(request)
 
 
 def blockface_cart_page(request):
@@ -45,8 +53,14 @@ def reserve_blockfaces_page(request):
 
 def reserved_blockface_popup(request, blockface_id):
     blockface = get_object_or_404(Blockface, id=blockface_id)
+    reservation = BlockfaceReservation.objects \
+        .filter(blockface=blockface) \
+        .filter(user=request.user) \
+        .current()[0]
+
     return {
-        'blockface': blockface
+        'blockface': blockface,
+        'reservation': reservation
     }
 
 

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -28,8 +28,7 @@ def blockface_cart_page(request):
 def reserve_blockfaces_page(request):
     current_reservations_amount = BlockfaceReservation.objects \
         .filter(user=request.user) \
-        .filter(canceled_at__isnull=True) \
-        .filter(expires_at__gt=now()) \
+        .current() \
         .count()
 
     return {
@@ -68,8 +67,7 @@ def confirm_blockface_reservations(request):
 
     already_reserved_blockface_ids = BlockfaceReservation.objects \
         .filter(blockface__id__in=ids) \
-        .filter(canceled_at__isnull=True) \
-        .filter(expires_at__gt=now()) \
+        .current() \
         .values_list('blockface_id', flat=True)
 
     expiration_date = now() + settings.RESERVATION_TIME_PERIOD

--- a/src/nyc_trees/js/src/reservationPage.js
+++ b/src/nyc_trees/js/src/reservationPage.js
@@ -2,15 +2,20 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
+    toastr = require('toastr'),
     MapModule = require('./map'),
     zoom = require('./mapUtil').zoom,
     SelectableBlockfaceLayer = require('./lib/SelectableBlockfaceLayer'),
 
     dom = {
-        actionBar: '#reserve-blockface-action-bar'
+        actionBar: '#reserve-blockface-action-bar',
+        modalTemplate: '#cancel-reservation-template',
+        modalContainer: '#reservation-modal',
+        cancelLink: '[data-action="cancel-reservation"]',
     },
 
-    $actionBar = $(dom.actionBar);
+    $actionBar = $(dom.actionBar),
+    $modalContainer = $(dom.modalContainer);
 
 // Extends the leaflet object
 require('leaflet-utfgrid');
@@ -21,7 +26,7 @@ var reservationMap = MapModule.create({
     search: true
 });
 
-L.tileLayer(config.urls.layers.reservations.tiles, {
+var tileLayer = L.tileLayer(config.urls.layers.reservations.tiles, {
     maxZoom: zoom.MAX
 }).addTo(reservationMap);
 
@@ -36,10 +41,38 @@ var grid = L.utfGrid(config.urls.layers.reservations.grids, {
 
             // Note: this must be kept in sync with
             // src/nyc_trees/apps/survey/urls/blockface.py
-            $actionBar.load('/blockface/' + gridData.id + '/reservation-popup/');
+            $actionBar.load('/blockface/' + gridData.id + '/reservation-popup/', function() {
+                var modalContent = $actionBar.find(dom.modalTemplate).html();
+                $modalContainer.html(modalContent);
+            });
             return true;
         }
     });
 
 reservationMap.addLayer(grid);
 reservationMap.addLayer(selectedLayer);
+
+$modalContainer.on('click', dom.cancelLink, function(e) {
+    var $button = $(e.currentTarget);
+    e.preventDefault();
+
+    $button.prop('disabled', true);
+
+    $.getJSON($button.attr('data-url'), function(layers) {
+        tileLayer.setUrl(layers.reservations.tiles);
+
+        // utfGrid does not expose a setUrl method
+        grid._url = layers.reservations.grids;
+        grid._cache = {};
+        grid._update();
+
+        $actionBar.empty();
+        selectedLayer.clearLayers();
+
+        $modalContainer.modal('hide');
+    }).fail(function() {
+        toastr.error('Could not cancel your reservation, please try again later');
+    }).always(function() {
+        $button.prop('disabled', false);
+    });
+});


### PR DESCRIPTION
Clicking "Cancel This" from the action bar will open a Bootstrap modal

After clicking "Cancel Reservation" on the modal, the reservation is canceled
on the backend, and tile/grid layers are updated on the client.

There are known issues with the legend in desktop mode interfering with the cancel modal that will be fixed by #463