### PR TITLE
Add support for HVM NAT instances

### DIFF
--- a/deployment/troposphere/template_utils.py
+++ b/deployment/troposphere/template_utils.py
@@ -72,7 +72,7 @@ def get_nat_ami_mapping():
     def get_image_id(region):
         c = boto.connect_ec2()
         all_images = c.get_all_images(owners='amazon', filters={
-            'name': '*ami-vpc-nat*'
+            'name': '*ami-vpc-nat-hvm*'
         })
 
         images = [i for i in all_images if 'beta' not in i.name]

--- a/deployment/troposphere/vpc_template.py
+++ b/deployment/troposphere/vpc_template.py
@@ -17,7 +17,7 @@ keyname_param = t.add_parameter(Parameter(
 ))
 
 nat_instance_type_param = t.add_parameter(Parameter(
-    'NATInstanceType', Type='String', Default='t1.micro',
+    'NATInstanceType', Type='String', Default='t2.micro',
     Description='NAT EC2 instance type',
     AllowedValues=utils.EC2_INSTANCE_TYPES,
     ConstraintDescription='must be a valid EC2 instance type.'


### PR DESCRIPTION
This changeset adds HVM AMI support to the NAT instances, which allows us to use `t2.*` instance types vs. the previous `t1.micro`.