### PR TITLE
List/Approve/Reject individual mappers

### DIFF
--- a/src/nyc_trees/apps/survey/tests.py
+++ b/src/nyc_trees/apps/survey/tests.py
@@ -79,6 +79,7 @@ class ConfirmBlockfaceReservationTests(TestCase):
 
         self.assert_blocks_reserved(0, self.block1)
 
-        TrustedMapper.objects.create(group=group, user=self.user)
+        TrustedMapper.objects.create(group=group, user=self.user,
+                                     is_approved=True)
 
         self.assert_blocks_reserved(01, self.block1)

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -76,7 +76,7 @@ def confirm_blockface_reservations(request):
         .select_related('territory')
 
     user_trusted_group_ids = TrustedMapper.objects \
-        .filter(user=request.user) \
+        .filter(user=request.user, is_approved=True) \
         .values_list('group_id', flat=True)
 
     already_reserved_blockface_ids = BlockfaceReservation.objects \

--- a/src/nyc_trees/apps/users/migrations/0004_trustedmapper_is_approved.py
+++ b/src/nyc_trees/apps/users/migrations/0004_trustedmapper_is_approved.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0003_auto_20150113_1210'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='trustedmapper',
+            name='is_approved',
+            field=models.NullBooleanField(),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/users/models.py
+++ b/src/nyc_trees/apps/users/models.py
@@ -65,6 +65,7 @@ class Follow(NycModel, models.Model):
 class TrustedMapper(NycModel, models.Model):
     user = models.ForeignKey(User)
     group = models.ForeignKey(Group)
+    is_approved = models.NullBooleanField()
 
     class Meta:
         unique_together = ("user", "group")

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -47,5 +47,6 @@ unfollow_group = do(
 start_group_map_print_job = route(POST=v.start_group_map_print_job)
 
 edit_user_mapping_priveleges = group_admin_do(
+    render_template('groups/partials/grant_access_button.html'),
     route(PUT=v.give_user_mapping_priveleges,
           DELETE=v.remove_user_mapping_priveleges))

--- a/src/nyc_trees/apps/users/templates/groups/partials/grant_access_button.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/grant_access_button.html
@@ -1,0 +1,17 @@
+{% comment %}
+
+The following variables must be in scope:
+===
+  - mapper (object)  TrustedMapper model
+
+{% endcomment %}
+
+<a href="javascript:void(0)"
+   class="btn btn-approve {% if mapper.is_approved %}btn-default{% else %}btn-switch{% endif %}"
+    data-url="{% url 'edit_user_mapping_priveleges' group_slug=mapper.group.slug username=mapper.user.username %}"
+    data-verb="PUT">Approve</a>
+
+<a href="javascript:void(0)"
+   class="btn btn-deny {% if mapper.is_approved == False %}btn-default{% else %}btn-switch{% endif %}"
+    data-url="{% url 'edit_user_mapping_priveleges' group_slug=mapper.group.slug username=mapper.user.username %}"
+    data-verb="DELETE">Deny</a>

--- a/src/nyc_trees/apps/users/templates/groups/settings.html
+++ b/src/nyc_trees/apps/users/templates/groups/settings.html
@@ -135,7 +135,7 @@
                     </div>
                     <hr>
                 </div>
-                <div class="mappers-view content--disabled">
+                <div class="mappers-view">
                     <ul class="nav nav-tabs nav-tabs--filter">
                         <li class="active">
                             <a data-toggle="tab" href="#pending">Pending</a>
@@ -148,51 +148,46 @@
                         <div class="tab-content">
                             <div class="tab-pane active" id="pending">
                                 <div class="mapper block item">
+                                    {% for mapper in pending_mappers %}
                                     <div class="row">
                                         <div class="col-xs-6">
                                             <h4>
-                                                rreading
+                                                {{ mapper.user.username }}
                                             </h4>
                                             <h5 class="nobold">
-                                                Rachel Reading
+                                                {{ mapper.user.first_name }}
+                                                {{ mapper.user.last_name }}
                                             </h5>
                                         </div>
                                         <div class="col-xs-6 text-right">
-                                            <a href="{{edit_url}}" class="btn btn-switch">Access Granted</a>
+                                            <div class="btn-grant-access-container">
+                                            {% include 'groups/partials/grant_access_button.html' %}
+                                            </div>
                                         </div>
                                     </div>
+                                    {% endfor %}
                                 </div>
                             </div>
                             <div class="tab-pane" id="all">
                                 <div class="mapper block item">
+                                    {% for mapper in all_mappers %}
                                     <div class="row">
                                         <div class="col-xs-6">
                                             <h4>
-                                                rreading
+                                                {{ mapper.user.username }}
                                             </h4>
                                             <h5 class="nobold">
-                                                Rachel Reading
+                                                {{ mapper.user.first_name }}
+                                                {{ mapper.user.last_name }}
                                             </h5>
                                         </div>
                                         <div class="col-xs-6 text-right">
-                                            <a href="{{edit_url}}" class="btn btn-switch">Access Granted</a>
+                                            <div class="btn-grant-access-container">
+                                            {% include 'groups/partials/grant_access_button.html' %}
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="mapper block item">
-                                    <div class="row">
-                                        <div class="col-xs-6">
-                                            <h4>
-                                                rreading
-                                            </h4>
-                                            <h5 class="nobold">
-                                                Rachel Reading
-                                            </h5>
-                                        </div>
-                                        <div class="col-xs-6 text-right">
-                                            <a href="{{edit_url}}" class="btn btn-switch">Access Granted</a>
-                                        </div>
-                                    </div>
+                                    {% endfor %}
                                 </div>
                             </div>
                         </div>

--- a/src/nyc_trees/js/src/group_settings.js
+++ b/src/nyc_trees/js/src/group_settings.js
@@ -1,3 +1,19 @@
 "use strict";
 
+var fetchAndReplace = require('./fetchAndReplace');
+
 require('./event_list');
+
+// Because onclick events are triggered for each defined target in the
+// fetchAndReplace container, a target such as ".btn-approve, .btn-deny" will
+// trigger 2 requests whenever either of the buttons are pressed.
+// The workaround is to define a single target for each fetchAndReplace
+// configuration.
+fetchAndReplace({
+    container: '.btn-grant-access-container',
+    target: '.btn-approve'
+});
+fetchAndReplace({
+    container: '.btn-grant-access-container',
+    target: '.btn-deny'
+});

--- a/src/tiler/sql/user_progress.sql
+++ b/src/tiler/sql/user_progress.sql
@@ -23,6 +23,7 @@
         AND reservation.expires_at > now() at time zone 'utc')
   LEFT OUTER JOIN users_trustedmapper AS trustedmapper
     ON (turf.group_id = trustedmapper.group_id
-        AND trustedmapper.user_id = <%= user_id %>)
+        AND trustedmapper.user_id = <%= user_id %>
+        AND trustedmapper.is_approved)
   ORDER BY block.id, survey.created_at DESC NULLS LAST
 ) AS query

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -28,6 +28,7 @@
             AND reservation.expires_at > now() at time zone 'utc')
       LEFT OUTER JOIN users_trustedmapper AS trustedmapper
         ON (turf.group_id = trustedmapper.group_id
-            AND trustedmapper.user_id = <%= user_id %>)
+            AND trustedmapper.user_id = <%= user_id %>
+            AND trustedmapper.is_approved)
     ) AS subquery
 ) AS query


### PR DESCRIPTION
This lists mappers on the group admin page and adds an Approve/Deny button next to each mapper request.

How to test:
1. Since there is currently no interface to request group mapper status, manually create an entry in the superadmin [http://localhost:8000/admin/users/trustedmapper/](http://localhost:8000/admin/users/trustedmapper/).
2. Requests with unknown (NULL) status should appear in the Mappers > Pending tab.
3. Requests with approved/denied status should appear in the Mappers > All tab.