### PR TITLE
Add support for EBS volume SSD storage

### DIFF
--- a/deployment/deployment-helper.sh
+++ b/deployment/deployment-helper.sh
@@ -8,14 +8,14 @@ fi
 
 function get_latest_ubuntu_ami() {
   # 1. Get list of daily Ubuntu AMIs
-  # 2. Filter AMIs with EBS instance store, amd64 architecture, and in
+  # 2. Filter AMIs with EBS SSD instance store, amd64 architecture, and in
   #    AWS_DEFAULT_REGION
   # 3. Filter again by HVM AMIs
   # 4. Sort by date in reverse
   # 5. Take the top row
   # 6. Take the 8th column
   curl -s "http://cloud-images.ubuntu.com/query/trusty/server/daily.txt" \
-    | egrep "ebs\s+amd64\s+${AWS_DEFAULT_REGION}" \
+    | egrep "ebs-ssd\s+amd64\s+${AWS_DEFAULT_REGION}" \
     | grep "hvm" \
     | sort -k4 -r \
     | head -n1 \

--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -162,7 +162,10 @@ bastion_host = t.add_resource(ec2.Instance(
     BlockDeviceMappings=[
         {
             "DeviceName": "/dev/sda1",
-            "Ebs": {"VolumeSize": "256"}
+            "Ebs": {
+                "VolumeType": "gp2",
+                "VolumeSize": "256"
+            }
         }
     ],
     InstanceType=Ref(bastion_instance_type_param),


### PR DESCRIPTION
This changeset switches our default EBS volume types from `standard` (AKA magnetic) to `gp2` (AKA general purpose SSD) by using an SSD based AMI.

See also: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html