### PR TITLE
Add conservative globs to the geospatial libraries dependencies

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
@@ -2,9 +2,9 @@
 - name: Install Geospatial libraries
   apt: pkg={{ item }} state=present
   with_items:
-    - binutils=2.24-5ubuntu3
-    - libproj-dev=4.8.0-2ubuntu2
-    - gdal-bin=1.10.1+dfsg-5ubuntu1
+    - "binutils=2.24*"
+    - "libproj-dev=4.8.0*"
+    - "gdal-bin=1.10.1*"
 
 - name: Configure the main PostgreSQL APT repository
   apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release}}-pgdg main"


### PR DESCRIPTION
This changeset adds globs to the versions of the geospatial libraries used by the Django application.