### PR TITLE
Add Tasseo as a dashboard for select Graphite metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Service                | Port  | URL
 Django Web Application | 8000  | [http://localhost:8000](http://localhost:8000)
 Graphite Dashboard     | 8080  | [http://localhost:8080](http://localhost:8080)
 Kibana Dashboard       | 15601 | [http://localhost:15601](http://localhost:15601)
+Tasseo                 | 15000 | [http://localhost:15000](http://localhost:15000)
 PostgreSQL             | 15432 |
 pgweb                  | 15433 | [http://localhost:15433](http://localhost:15433)
 Redis                  | 16379 | `redis-cli -h localhost 16379`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,6 +95,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       guest: 8080,
       host: 8080
     }.merge(VAGRANT_NETWORK_OPTIONS)
+    # Tasseo
+    services.vm.network "forwarded_port", {
+      guest: 5000,
+      host: 15000
+    }.merge(VAGRANT_NETWORK_OPTIONS)
     # Kibana
     services.vm.network "forwarded_port", {
       guest: 5601,

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -6,6 +6,7 @@ sauce_labs_api_key_is_defined: lookup('env', 'SAUCE_API_KEY') != ''
 redis_port: 6379
 postgresql_port: 5432
 kibana_port: 5601
+tasseo_port: 5000
 relp_port: 20514
 graphite_port: 2003
 statsite_port: 8125

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -19,3 +19,5 @@ graphite_host: "{{ services_ip }}"
 statsite_host: "{{ services_ip }}"
 
 tiler_host: "{{ lookup('env', 'NYC_TREES_TILER_IP') | default('33.33.33.20', true) }}"
+
+tasseo_graphite_url: "http://{{ graphite_host }}:{{ graphite_web_port }}"

--- a/deployment/ansible/group_vars/monitoring-servers
+++ b/deployment/ansible/group_vars/monitoring-servers
@@ -1,3 +1,0 @@
----
-relp_host: "127.0.0.1"
-graphite_host: "127.0.0.1"

--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -17,3 +17,5 @@ tiler_host: "tile.service.nyc-trees.internal"
 postgresql_username: nyctrees
 postgresql_password: nyctrees
 postgresql_database: nyc_trees
+
+tasseo_graphite_url: "http://$(curl -s http://instance-data.ec2.internal/latest/meta-data/public-hostname):{{ graphite_web_port }}"

--- a/deployment/ansible/monitoring-servers.yml
+++ b/deployment/ansible/monitoring-servers.yml
@@ -11,4 +11,5 @@
 
     - { role: "nyc-trees.graphite", when: "['test'] | is_not_in(group_names)" }
     - { role: "nyc-trees.logstash", when: "['test'] | is_not_in(group_names)" }
+    - { role: "nyc-trees.tasseo", when: "['test'] | is_not_in(group_names)" }
     - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -12,8 +12,8 @@ azavea.logstash,0.1.0
 azavea.relp,0.1.1
 azavea.kibana,0.2.1
 azavea.unzip,0.1.0
-azavea.graphite,0.2.0
-azavea.statsite,0.1.0
+azavea.graphite,0.4.0
+azavea.statsite,0.1.1
 azavea.daemontools,0.1.0
 azavea.collectd,0.2.0
 azavea.git,0.1.0
@@ -26,3 +26,4 @@ azavea.sauce-connect,0.2.0
 azavea.beaver,0.1.2
 azavea.swapfile,0.1.0
 azavea.build-essential,0.1.0
+azavea.tasseo,0.1.1

--- a/deployment/ansible/roles/nyc-trees.tasseo/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.tasseo/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.tasseo" }

--- a/deployment/ansible/roles/nyc-trees.tasseo/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.tasseo/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure Tasseo
+  template: src=nyc-trees.js.j2
+            dest="{{ tasseo_dir }}/tasseo-{{ tasseo_version }}/dashboards/nyc-trees.js"
+  notify:
+    - Restart Tasseo

--- a/deployment/ansible/roles/nyc-trees.tasseo/templates/nyc-trees.js.j2
+++ b/deployment/ansible/roles/nyc-trees.tasseo/templates/nyc-trees.js.j2
@@ -1,0 +1,50 @@
+var period = 10;
+var metrics = [
+    {
+        "alias": "django.percent-error",
+        "target": "scale(divideSeries(transformNull(sumSeries(statsite.counts.django.response.{4,5}*),0),transformNull(sumSeries(statsite.counts.django.response.{1,2,3}*),0)),100)",
+        "unit": "%",
+        "warning": 10,
+        "critical": 15
+    },
+    {
+        "alias": "django.1-3XX",
+        "target": "transformNull(sumSeries(statsite.counts.django.response.{1,2,3}*),0)"
+    },
+    {
+        "alias": "django.4-5XX",
+        "target": "transformNull(sumSeries(statsite.counts.django.response.{4,5}*),0)"
+    },
+    {% if ['packer'] | is_in(group_names) -%}
+    {
+        "alias": "email.percent-error",
+        "target": "scale(divideSeries(transformNull(sumSeries(statsite.counts.email.message.failure),0),transformNull(sumSeries(statsite.counts.email.message.success),0)),100)",
+        "unit": "%",
+        "warning": 10,
+        "critical": 15
+    },
+    {
+        "alias": "email.success",
+        "target": "transformNull(statsite.counts.email.message.success,0)"
+    },
+    {
+        "alias": "email.failure",
+        "target": "transformNull(statsite.counts.email.message.failure,0)"
+    },
+    {% endif %}
+    {
+        "alias": "windshaft.percent-error",
+        "target": "scale(divideSeries(transformNull(sumSeries(statsite.counts.windshaft.tiles.{error,failure}),0),transformNull(statsite.counts.windshaft.tiles.success,0)),100)",
+	"unit": "%",
+        "warning": 10,
+        "critical": 15
+    },
+    {
+        "alias": "windshaft.success",
+        "target": "transformNull(statsite.counts.windshaft.tiles.success,0)"
+    },
+    {
+        "alias": "windshaft.failure",
+        "target": "transformNull(sumSeries(statsite.counts.windshaft.tiles.{error,failure}),0)"
+    }
+];

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -14,5 +14,6 @@
     - { role: "azavea.redis", when: "['development', 'test'] | some_are_in(group_names)" }
 
     - { role: "nyc-trees.graphite", when: "['test'] | is_not_in(group_names)" }
-    - { role: "nyc-trees.logstash", when: "['test'] | is_not_in(group_names)"}
+    - { role: "nyc-trees.logstash", when: "['test'] | is_not_in(group_names)" }
+    - { role: "nyc-trees.tasseo", when: "['test'] | is_not_in(group_names)" }
     - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }

--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -93,7 +93,7 @@ bastion_security_group = t.add_resource(ec2.SecurityGroup(
     SecurityGroupIngress=[
         ec2.SecurityGroupRule(IpProtocol='tcp', CidrIp=utils.OFFICE_CIDR,
                               FromPort=p, ToPort=p)
-        for p in [22, 5601, 8080]
+        for p in [22, 5000, 5601, 8080]
     ] + [
         ec2.SecurityGroupRule(IpProtocol='tcp', CidrIp=utils.VPC_CIDR,
                               FromPort=p, ToPort=p)

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -36,6 +36,7 @@ TEMPLATE_DEBUG = DEBUG
 
 # STATSD CONFIGURATION
 STATSD_CLIENT = 'django_statsd.clients.normal'
+STATSD_PREFIX = 'django'
 STATSD_HOST = environ.get('NYC_TREES_STATSD_HOST', 'localhost')
 # END STATSD CONFIGURATION
 


### PR DESCRIPTION
This changeset adds support for Tasseo, which is a dashboard for highlighting select Graphite metrics. As of right now, the only metrics highlighted are:

- Django response codes
- E-mail success/failures
- Windshaft success/failures

![tasseo](https://cloud.githubusercontent.com/assets/43639/6133223/79d5cf3c-b126-11e4-9f41-13e72f7a24d9.png)
