### PR TITLE
Request mapper status

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/partials/reserve_blockface_modals.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/reserve_blockface_modals.html
@@ -1,0 +1,98 @@
+<div class="modal fade" id="limit-reached-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Reservations Limit Reached</h4>
+            </div>
+            <div class="modal-body">
+                <p>You have reached the maximum limit for the amount of blockfaces that may be reserved.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="already-reserved-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Unavailable Blockface</h4>
+            </div>
+            <div class="modal-body">
+                <p>The blockface you selected has already been reserved.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="request-access-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Unavailable Blockface</h4>
+            </div>
+            <div class="modal-body">
+                <p>Contact this group to request permission to map blockfaces in this territory.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-action="request-access">
+                    Request Mapping Permission
+                </button>
+                <button type="button" class="btn" data-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="request-access-complete-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Request Sent</h4>
+            </div>
+            <div class="modal-body">
+                <p>Your request has been sent.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="request-access-fail-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Error Sending Request</h4>
+            </div>
+            <div class="modal-body">
+                <p>There was a problem submitting your request. Please try again.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="unavailable-blockface-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Unavailable Blockface</h4>
+            </div>
+            <div class="modal-body">
+                <p>The blockface you selected is not available for mapping.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/nyc_trees/apps/survey/templates/survey/reservations.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reservations.html
@@ -31,7 +31,7 @@
 {% endblock main %}
 
 {% block extra_content %}
-<div class="modal fade" id="reservation-modal" tabindex="-1" role="dialog" aria-labelledby="reservation-modal-label" aria-hidden="true" id="modal">
+<div class="modal fade" id="reservation-modal" tabindex="-1" role="dialog" aria-labelledby="reservation-modal-label" aria-hidden="true">
 </div>
 {% endblock extra_content %}
 

--- a/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
@@ -38,6 +38,10 @@
 
 {% endblock main %}
 
+{% block extra_content %}
+{% include "survey/partials/reserve_blockface_modals.html" %}
+{% endblock extra_content %}
+
 {% block page_js %}
     <script type="text/javascript" src="{{ "js/reserveBlockfacePage.js"|static_url }}"></script>
 {% endblock page_js %}

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -5,7 +5,7 @@ from __future__ import division
 
 from django.contrib.auth.decorators import login_required
 
-from django_tinsel.decorators import route, render_template
+from django_tinsel.decorators import route, render_template, json_api_call
 from django_tinsel.utils import decorate as do
 
 from apps.core.decorators import group_request, group_admin_do
@@ -46,3 +46,9 @@ edit_user_mapping_priveleges = group_admin_do(
     render_template('groups/partials/grant_access_button.html'),
     route(PUT=v.give_user_mapping_priveleges,
           DELETE=v.remove_user_mapping_priveleges))
+
+request_mapper_status = do(
+    login_required,
+    group_request,
+    json_api_call,
+    route(POST=v.request_mapper_status))

--- a/src/nyc_trees/apps/users/templates/groups/settings.html
+++ b/src/nyc_trees/apps/users/templates/groups/settings.html
@@ -135,6 +135,7 @@
                     </div>
                     <hr>
                 </div>
+                {% if group.allows_individual_mappers %}
                 <div class="mappers-view">
                     <ul class="nav nav-tabs nav-tabs--filter">
                         <li class="active">
@@ -193,6 +194,7 @@
                         </div>
                     </div>
                 </div>
+                {% endif %}
             </div>
         </div>
 

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -33,6 +33,11 @@ urlpatterns = patterns(
         r.edit_user_mapping_priveleges,
         name='edit_user_mapping_priveleges'),
 
+    # Keep in sync with src/nyc_trees/js/src/reserveBlockfacePage.js
+    url(r'^(?P<group_slug>[\w-]+)/request-individual-mapper-status/$',
+        r.request_mapper_status,
+        name='request_mapper_status'),
+
     url(r'^(?P<group_slug>[\w-]+)/events/$',
         group_detail_events.endpoint, name=group_detail_events.url_name()),
 

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -206,3 +206,12 @@ def _grant_mapping_access(group, username, is_approved):
     return {
         'mapper': mapper
     }
+
+
+def request_mapper_status(request):
+    mapper, created = TrustedMapper.objects.update_or_create(
+        group=request.group,
+        user=request.user)
+    return {
+        'success': True
+    }

--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -2,17 +2,24 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
-    toastr = require('toastr'),
     mapModule = require('./map'),
     zoom = require('./mapUtil').zoom,
     SelectableBlockfaceLayer = require('./lib/SelectableBlockfaceLayer'),
     SavedState = require('./lib/SavedState'),
 
     dom = {
+        modals: '.modal',
         currentReservations: "#current-reservations",
         totalReservations: "#total-reservations",
         finishReservations: "#finish-reservations",
-        hiddenInput: "#reservation-ids"
+        hiddenInput: "#reservation-ids",
+        requestAccessButton: '[data-action="request-access"]',
+        limitReachedModal: '#limit-reached-modal',
+        alreadyReservedModal: '#already-reserved-modal',
+        requestAccessModal: '#request-access-modal',
+        requestAccessCompleteModal: '#request-access-complete-modal',
+        requestAccessFailModal: '#request-access-fail-modal',
+        unavailableBlockfaceModal: '#unavailable-blockface-modal'
     };
 
 // Extends the leaflet object
@@ -93,14 +100,36 @@ grid.on('click', function(e) {
     if (!e.data) {
         return;
     }
-    if (selectedBlockfacesCount >= blockfaceLimit) {
-        toastr.error('You have reached your reservation limit');
+    if (e.data.restriction === 'group_territory') {
+        $(dom.requestAccessModal)
+            .find(dom.requestAccessButton)
+            .data('group-slug', e.data.group_slug);
+        $(dom.requestAccessModal).modal('show');
+    } else if (e.data.restriction === 'reserved') {
+        $(dom.alreadyReservedModal).modal('show');
     } else if (e.data.restriction !== 'none') {
-        toastr.error('The blockface you selected is not available');
+        $(dom.unavailableBlockfaceModal).modal('show');
     }
 });
 
 reservationMap.addLayer(selectedLayer);
+
+$(dom.requestAccessModal).on('click', dom.requestAccessButton, function() {
+    var groupSlug = $(dom.requestAccessButton).data('group-slug');
+    $(dom.modals).modal('hide');
+    $.ajax({
+            // Keep this URL in sync with "request_mapper_status"
+            // in src/nyc_trees/apps/users/urls/group.py
+            url: '/group/' + groupSlug + '/request-individual-mapper-status/',
+            type: 'POST'
+        })
+        .done(function() {
+            $(dom.requestAccessCompleteModal).modal('show');
+        })
+        .fail(function() {
+            $(dom.requestAccessFailModal).modal('show');
+        });
+});
 
 // Load any existing data.
 var state = progress.load();

--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -59,8 +59,9 @@ var progress = new SavedState({
 
 var selectedLayer = new SelectableBlockfaceLayer(reservationMap, grid, {
     onAdd: function(gridData) {
-        if (selectedBlockfacesCount < blockfaceLimit &&
-                gridData.restriction === 'none') {
+        if (selectedBlockfacesCount >= blockfaceLimit) {
+            $(dom.limitReachedModal).modal('show');
+        } else if (gridData.restriction === 'none') {
             selectedBlockfaces[gridData.id] = gridData;
             selectedBlockfacesCount++;
             $current.text(selectedBlockfacesCount);

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -22,7 +22,7 @@ var Windshaft = require('windshaft'),
 
     interactivity = {
         progress: 'id,group_id,survey_type',
-        reservable: 'id,group_id,survey_type,restriction,geojson',
+        reservable: 'id,group_id,group_slug,survey_type,restriction,geojson',
         reservations: 'id,geojson'
     },
 


### PR DESCRIPTION
Click on unavailable blockfaces to request group mapper status.

How to test:

1. Restart tiler and rebuild JS
2. Enable `individual_mapper` on your test user
3. Go to the "new reservations" page [http://localhost:8000/blockface/reserve/](http://localhost:8000/blockface/reserve/)
3. If a group has `allows_individual_mappers` disabled, when you click on blocks, you should get a generic error message.
4. If a group has `allows_individual_mappers` enabled, when you click on blocks, you should get a popup that asks if you would like to request permission for group mapper status.
5. The mapper status request should appear on the group admin page [http://localhost:8000/group/east-side/edit/](http://localhost:8000/group/east-side/edit/) (replace group name)