### PR TITLE
Make location search UI take up less space

### DIFF
--- a/src/nyc_trees/js/src/searchController.js
+++ b/src/nyc_trees/js/src/searchController.js
@@ -106,7 +106,7 @@ function create($controlsContainer, map) {
         },
 
         showCandidates = function(candidates) {
-            updateStatus('Choose an address or search again', {resultsFound: true});
+            updateStatus('', {resultsFound: true});
             removeResults();
             for(var i = 0, count = candidates.length; i < count; i++) {
                 addCandidateToList($results, $itemTemplate.clone(), candidates[i]);
@@ -116,7 +116,14 @@ function create($controlsContainer, map) {
         zoomToCandidate = function(candidate) {
             var point = L.latLng(candidate.y, candidate.x);
             setCenterAndZoomLL(map, zoom.NEIGHBORHOOD, point);
+            dismiss();
+        },
+
+        dismiss = function() {
             updateStatus();
+            // Ensure software keyboard is hidden on mobile
+            document.activeElement.blur();
+            toggleSearch();
         },
 
         searching = function() {


### PR DESCRIPTION
I talked over our options with @jfrankl and made two changes to make location search more useful on small mobile phones.

1. The status message is hidden when there are multiple results. The
   message was not helpful and it now allows an extra result to be
   shown.

2. The search UI is hidden automatically after zooming to a result. This
   allows more of the map to be visible. It is not likely that a
   person will immediately search again and, if they do, making them tap
   the search toolbar button again is worth the extra space gained in
   trade.

Fixes #507 
Fixes #509 