### PR TITLE
Set left on sidebar overlay to fix Safari issue

### DIFF
--- a/src/nyc_trees/sass/partials/_header.scss
+++ b/src/nyc_trees/sass/partials/_header.scss
@@ -186,6 +186,7 @@
   position: fixed;
   height: 100%;
   width: 100%;
+  left: 30rem;
   z-index: $zindex-overlaymenu;
   display: none;
   opacity: .2;


### PR DESCRIPTION
Safari desktop and mobile is rendering the .overlay-menued div on top of the sidebar, which hijacks all link clicking. Setting left: to the same width as the sidebar fixes the issue in Safari and still works in other browsers.

Fixes #505 