### PR TITLE
Add individual mapper status workflow

### DIFF
--- a/src/nyc_trees/apps/core/decorators.py
+++ b/src/nyc_trees/apps/core/decorators.py
@@ -12,6 +12,7 @@ from django.shortcuts import get_object_or_404
 from django_tinsel.utils import decorate as do
 
 from apps.core.helpers import (user_is_census_admin, user_is_group_admin,
+                               user_is_individual_mapper,
                                user_has_online_training,
                                user_has_field_training)
 from apps.core.models import Group
@@ -84,10 +85,13 @@ def user_must_have_field_training(view_fn):
 
 
 def user_must_be_individual_mapper(view_fn):
-    # TODO: implement
     @wraps(view_fn)
     def wrapper(request, *args, **kwargs):
-        return view_fn(request, *args, **kwargs)
+        if user_is_individual_mapper(request.user):
+            return view_fn(request, *args, **kwargs)
+        else:
+            raise PermissionDenied('%s is not an individual mapper'
+                                   % request.user)
     return wrapper
 
 ##############################################################################

--- a/src/nyc_trees/apps/core/migrations/0015_auto_20150213_1321.py
+++ b/src/nyc_trees/apps/core/migrations/0015_auto_20150213_1321.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0014_auto_20150203_1604'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='individual_mapper',
+            field=models.NullBooleanField(),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -105,6 +105,17 @@ class User(NycModel, AbstractUser):
     def training_complete(self):
         return self.online_training_complete and self.field_training_complete
 
+    @property
+    def eligible_to_become_individual_mapper(self):
+        """
+        Return True if user has completed online training, attended a mapping
+        event, and one other training/mapping event.
+        """
+        from apps.event.models import EventRegistration
+        return self.field_training_complete and \
+            EventRegistration.objects.filter(user=self,
+                                             did_attend=True).count() >= 2
+
 
 class Group(NycModel, models.Model):
     name = models.CharField(max_length=255, unique=True)

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -28,7 +28,7 @@ REFERRER_AD = (
 
 
 class User(NycModel, AbstractUser):
-    individual_mapper = models.BooleanField(default=False)
+    individual_mapper = models.NullBooleanField()
     requested_individual_mapping_at = models.DateTimeField(null=True,
                                                            blank=True)
 
@@ -111,6 +111,9 @@ class User(NycModel, AbstractUser):
         Return True if user has completed online training, attended a mapping
         event, and one other training/mapping event.
         """
+        # Has an admin rescinded mapper status?
+        if self.individual_mapper is False:
+            return False
         from apps.event.models import EventRegistration
         return self.field_training_complete and \
             EventRegistration.objects.filter(user=self,

--- a/src/nyc_trees/apps/core/templates/core/partials/nav.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/nav.html
@@ -22,7 +22,9 @@
             <li{% if active_page == "training" %} class="active"{% endif %}><a href="{% url 'training_summary_pure' %}">Training</a></li>
             <li{% if active_page == "groups" %} class="active"{% endif %}><a href="{% url 'group_list_page' %}">Groups</a></li>
             <li{% if active_page == "events" %} class="active"{% endif %}><a href="{% url 'events_list_page' %}">Events</a></li>
+            {% if show_reservations %}
             <li{% if active_page == "reservations" %} class="active"{% endif %}><a href="{% url 'reservations' %}">Reservations</a></li>
+            {% endif %}
             <li{% if active_page == "achievements" %} class="active"{% endif %}><a href="#">Achievements</a></li>
         {% endif %}
         <li{% if active_page == "about" %} class="active"{% endif %}><a href="#">About &amp; FAQ</a></li>

--- a/src/nyc_trees/apps/home/routes.py
+++ b/src/nyc_trees/apps/home/routes.py
@@ -7,6 +7,8 @@ from django_tinsel.decorators import route, render_template
 from django_tinsel.utils import decorate as do
 
 from apps.home import views as v
+from apps.core.decorators import individual_mapper_do
+
 
 home_page = route(GET=do(render_template('home/home.html'),
                          v.home_page))
@@ -15,3 +17,7 @@ progress_page = route(GET=do(render_template('home/progress.html'),
                              v.progress_page))
 
 retrieve_job_status = do(v.retrieve_job_status)
+
+individual_mapper_instructions = individual_mapper_do(
+    render_template('home/individual_mapper_instructions.html'),
+    v.individual_mapper_instructions)

--- a/src/nyc_trees/apps/home/templates/home/individual_mapper_instructions.html
+++ b/src/nyc_trees/apps/home/templates/home/individual_mapper_instructions.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load utils %}
+
+{% block content %}
+{# TODO: Design #}
+
+<p>You have been approved for individual mapper status!</p>
+<p><a href="#">Learn more</a></p>
+
+<a href="{% url "reservations" %}" class="btn btn-default">Reservations</a>
+{% endblock %}

--- a/src/nyc_trees/apps/home/urls.py
+++ b/src/nyc_trees/apps/home/urls.py
@@ -21,6 +21,10 @@ urlpatterns = patterns(
 
     url(r'^progress/$', r.progress_page, name='progress_page'),
 
+    url(r'^individual-mapper-instructions/$',
+        r.individual_mapper_instructions,
+        name='individual_mapper_instructions'),
+
     url(r'^jobs/(?P<job_id>\d+)/$', r.retrieve_job_status,
         name='retrieve_job_status'),
 

--- a/src/nyc_trees/apps/home/views.py
+++ b/src/nyc_trees/apps/home/views.py
@@ -27,3 +27,7 @@ def progress_page(request):
 def retrieve_job_status(request):
     # TODO: implement
     pass
+
+
+def individual_mapper_instructions(request):
+    pass

--- a/src/nyc_trees/apps/users/__init__.py
+++ b/src/nyc_trees/apps/users/__init__.py
@@ -37,6 +37,8 @@ def user_profile_context(user, its_me):
         'show_individual_mapper': (user.individual_mapper and
                                    (its_me or user.profile_is_public)),
         'show_reservations': (user.individual_mapper and its_me),
+        'show_request_access': (not user.individual_mapper and
+                                user.eligible_to_become_individual_mapper),
         'follows': _get_follows_context(user),
         'reservations': _get_reservations_context(user),
         'privacy_categories': get_privacy_categories(privacy_form),

--- a/src/nyc_trees/apps/users/routes/user.py
+++ b/src/nyc_trees/apps/users/routes/user.py
@@ -9,6 +9,9 @@ from django_tinsel.decorators import route, render_template
 from django_tinsel.utils import decorate as do
 
 from apps.users.views import user as v
+from apps.core.decorators import (user_must_have_field_training,
+                                  user_must_have_online_training)
+
 
 render_user_template = render_template('users/profile.html')
 render_settings_template = render_template('users/settings.html')
@@ -32,6 +35,8 @@ user_detail = route(
 
 request_individual_mapper_status = do(
     login_required,
+    user_must_have_field_training,
+    user_must_have_online_training,
     route(POST=v.request_individual_mapper_status))
 
 start_form_for_reservation_job = route(POST=v.start_form_for_reservation_job)

--- a/src/nyc_trees/apps/users/templates/users/partials/activity.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/activity.html
@@ -1,3 +1,5 @@
+{% load utils %}
+
 {% if soft_launch %}
     <section class="soft-launch">
         {% with title="Your Profile" section_id="soft-launch" public=False %}
@@ -5,6 +7,15 @@
         {% endwith %}
     </section>
 {% else %}
+    {% if show_request_access %}
+    <section class="request-mapper-status">
+        <form method="POST" action="{% url "request_individual_mapper_status" username=user.username %}">
+            {% csrf_token %}
+            <input type="submit" class="btn btn-default" value="Request Individual Mapper Status" />
+        </form>
+    </section>
+    {% endif %}
+
     {% if show_contributions %}
     <section class="contributions">
         {% with title=contributions_title section_id="contributions" public=user.contributions_are_public %}

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -34,11 +34,10 @@ urlpatterns = patterns(
         name='edit_user_mapping_priveleges'),
 
     # Keep in sync with src/nyc_trees/js/src/reserveBlockfacePage.js
-    url(r'^(?P<group_slug>[\w-]+)/request-individual-mapper-status/$',
+    url(r'^(?P<group_slug>[\w-]+)/request-trusted-mapper-status/$',
         r.request_mapper_status,
         name='request_mapper_status'),
 
     url(r'^(?P<group_slug>[\w-]+)/events/$',
         group_detail_events.endpoint, name=group_detail_events.url_name()),
-
 )

--- a/src/nyc_trees/apps/users/views/user.py
+++ b/src/nyc_trees/apps/users/views/user.py
@@ -6,8 +6,9 @@ from __future__ import division
 from datetime import timedelta
 
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponseRedirect, HttpResponseBadRequest
-from django.shortcuts import get_object_or_404
+from django.http import (Http404, HttpResponseRedirect, HttpResponseBadRequest,
+                         HttpResponseForbidden)
+from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
 
 from apps.core.models import User
@@ -101,8 +102,14 @@ def update_user(request, username):
 
 
 def request_individual_mapper_status(request, username):
-    # TODO: implement
-    pass
+    user = request.user
+    if not user.eligible_to_become_individual_mapper:
+        return HttpResponseForbidden()
+    if not user.individual_mapper:
+        user.individual_mapper = True
+        user.requested_individual_mapping_at = timezone.now()
+        user.clean_and_save()
+    return redirect('individual_mapper_instructions')
 
 
 def start_form_for_reservation_job(request, username):

--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -121,7 +121,7 @@ $(dom.requestAccessModal).on('click', dom.requestAccessButton, function() {
     $.ajax({
             // Keep this URL in sync with "request_mapper_status"
             // in src/nyc_trees/apps/users/urls/group.py
-            url: '/group/' + groupSlug + '/request-individual-mapper-status/',
+            url: '/group/' + groupSlug + '/request-trusted-mapper-status/',
             type: 'POST'
         })
         .done(function() {

--- a/src/nyc_trees/nyc_trees/context_processors.py
+++ b/src/nyc_trees/nyc_trees/context_processors.py
@@ -34,6 +34,13 @@ def user_settings_privacy_url(request):
     return {'user_settings_privacy_url': full_url}
 
 
+def show_reservations(request):
+    return {
+        'show_reservations': (request.user.is_authenticated()
+                              and request.user.individual_mapper)
+    }
+
+
 def config(request):
     # At the time this function was written, the generated context was
     # only used in the base.html template, and our AJAX requests all

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -159,6 +159,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'nyc_trees.context_processors.config',
     'nyc_trees.context_processors.my_events_now',
     'nyc_trees.context_processors.soft_launch',
+    'nyc_trees.context_processors.show_reservations',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders


### PR DESCRIPTION
Once a user has completed online training, attended 1 training event, and 1 other event, they should see a button on their user profile to request individual mapper status. When clicked, this button will immediately grant access to the reservations page and the ability to reserve blockfaces.

Migrations must be run for testing.

See #517 for a description of the workflow that should be followed for verification purposes.