### PR TITLE
Don't use filename as a key in javascript

### DIFF
--- a/src/nyc_trees/apps/core/templates/core/partials/config.js
+++ b/src/nyc_trees/apps/core/templates/core/partials/config.js
@@ -2,7 +2,7 @@
 (function(window, Object) {
     window.config = {
         "files": {
-            "datetimepicker_polyfill.js": "{{ 'js/datetimepicker_polyfill.js'|static_url }}"
+            "dtpPolyfill": "{{ 'js/datetimepicker_polyfill.js'|static_url }}"
         },
         "urls": {
             "geocode": "{% url 'geocode' %}",

--- a/src/nyc_trees/js/src/event_form.js
+++ b/src/nyc_trees/js/src/event_form.js
@@ -17,7 +17,7 @@ var dom = {
 
 Modernizr.load({
     test: Modernizr.inputtypes.date && Modernizr.inputtypes.time,
-    nope: config.files["datetimepicker_polyfill.js"]
+    nope: config.files.dtpPolyfill
 });
 
 $(dom.useMyInfo).on('click', function(e) {


### PR DESCRIPTION
fixes #484 on github

The build tooling replaces occurrences of this filename with a modified
version that has a snippet of a sha attached to it. We use this filename
as a key in configuration and it caused a failed key lookup.