### PR TITLE
Drastically reduce dom repainting; Fixes #528 (I think)

### DIFF
--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -37,7 +37,7 @@ body {
   width: 100%;
   transition: all 500ms $transition;
   position: relative;
-  height: 100%;
+  min-height: 100%;
   font-feature-settings: "kern" 1;
   text-rendering: geometricPrecision;
 }

--- a/src/nyc_trees/sass/partials/_header.scss
+++ b/src/nyc_trees/sass/partials/_header.scss
@@ -104,22 +104,35 @@
   bottom: 0;
   background-color: $nav-side-color;
   width: 30rem;
-  left: -30rem;
+  -webkit-transform: translateX(-30rem);
+  -moz-transform: translateX(-30rem);
+  -ms-transform: translateX(-30rem);
+  transform: translateX(-30rem);
+  position: absolute;
   z-index: 1;
   transition: all 400ms $transition;
   .menu-active & {
-    left: 0;
+    -webkit-transform: translateX(0);
+    -moz-transform: translateX(0);
+    -ms-transform: translateX(0);
+    transform: translateX(0);
     box-shadow: 0px 1rem 6rem 0px #0A0B0B;
   }
 }
 
 .right-content {
-  left: 0;
+  -webkit-transform: translateX(0);
+  -moz-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
   position: relative;
-  height: 100%;
+  min-height: 100vh;
   transition: all 400ms $transition;
   .menu-active & {
-    left: 30rem;
+    -webkit-transform: translateX(30rem);
+    -moz-transform: translateX(30rem);
+    -ms-transform: translateX(30rem);
+    transform: translateX(30rem);
   }
 }
 
@@ -183,13 +196,11 @@
 }
 
 .overlay-menued {
-  position: fixed;
+  position: absolute;
   height: 100%;
   width: 100%;
-  left: 30rem;
   z-index: $zindex-overlaymenu;
   display: none;
-  opacity: .2;
   .menu-active & {
     display: block;
     transition: all 400ms $transition;


### PR DESCRIPTION
Justin,

This should increase the scrolling speed on iOS (and all devices). I removed all fixed elements, which were causing the browser to repaint the entire window, since they were in moving elements.

More information here:

https://remysharp.com/2012/05/24/issues-with-position-fixed-scrolling-on-ios

I can try adding the css you suggested if this doesn't do it.