### PR TITLE
Validate event dates using Eastern not UTC

### DIFF
--- a/src/nyc_trees/apps/event/forms.py
+++ b/src/nyc_trees/apps/event/forms.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from datetime import datetime
+from pytz import timezone
 
 from floppyforms.__future__ import ModelForm, DateField, TimeField, RadioSelect
 
@@ -48,7 +49,7 @@ class EventForm(ModelForm):
 
     def clean(self):
         cleaned_data = super(EventForm, self).clean()
-        right_now = now()
+        right_now = now().astimezone(timezone('US/Eastern'))
         today = right_now.date()
 
         if 'date' in cleaned_data:

--- a/src/nyc_trees/requirements/base.txt
+++ b/src/nyc_trees/requirements/base.txt
@@ -10,3 +10,4 @@ django-floppyforms==1.3.0
 python-dateutil==2.2
 django-statsd-mozilla==0.3.14
 python-omgeo==1.7.1
+pytz==2014.10


### PR DESCRIPTION
The date fields are passed in to the ``clean`` method as they appear on the form, which means they will always be Eastern US time. We need to convert now() to Eastern US time before doing any comparisons.