### PR TITLE
Fix 403 error when RSVP-ing for training event

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
@@ -25,6 +25,10 @@ The following variables must be in scope:
             <a id="rsvp"
                href="{% url "login" %}?next={{ event.get_absolute_url }}"
                class="btn btn-switch">RSVP</a>
+        {% elif not user.online_training_complete %}
+            <a id="rsvp"
+               href="{% url "training_instructions" %}"
+               class="btn btn-switch btn-rsvp">RSVP</a>
         {% elif not event.includes_training and not user.training_complete %}
             <a id="rsvp"
                href="{% url "training_instructions" %}"

--- a/src/nyc_trees/apps/home/templates/home/training_instructions.html
+++ b/src/nyc_trees/apps/home/templates/home/training_instructions.html
@@ -4,19 +4,22 @@
 
 {# TODO: Design #}
 
+<h2>Training</h2>
 <p>
 Before you're able to RSVP to mapping events you'll need to do the following:
 </p>
-<ul>
-    <li>
-        {% if user.online_training_complete %}<s>{% endif %}
-        Complete your <a href="{% url "training_summary_pure" %}">online training</a>
-        {% if user.online_training_complete %}</s>{% endif %}
-    </li>
-    <li>
-        {% if user.field_training_complete %}<s>{% endif %}
-        Attend a <a href="{% url "events_list_page" %}?active_filter=training">training event</a></li>
-        {% if user.field_training_complete %}</s>{% endif %}
-    </li>
-</ul>
+
+<h3>Step #1</h3>
+<p>
+{% if user.online_training_complete %}<s>{% endif %}
+Complete your <a href="{% url "training_summary_pure" %}">online training</a>.
+{% if user.online_training_complete %}</s>{% endif %}
+</p>
+
+<h3>Step #2</h3>
+<p>
+{% if user.field_training_complete %}<s>{% endif %}
+Attend a <a href="{% url "events_list_page" %}?active_filter=training">training event</a>.
+{% if user.field_training_complete %}</s>{% endif %}
+</p>
 {% endblock %}


### PR DESCRIPTION
Users must complete online training before they can attend a training
event. Now, when the user tries to RSVP for a training event before
completing the online training, they will be forwarded to the training
instructions page.

Fixes #521 

How to test this:
1. Login as a user with no field/online training
2. RSVP to a Mapping event (should redirect to training instructions)
3. RSVP to Training event (should redirect to training instructions)
4. Complete online training steps
5. RSVP to a Mapping event (should redirect to training instructions)
6. RSVP to Training event (should RSVP you to that event)