### PR TITLE
Include updating follow count on group detail

### DIFF
--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -13,7 +13,7 @@ from apps.core.decorators import group_request, group_admin_do
 from apps.users.views import group as v
 
 
-render_follow_button = render_template('groups/partials/follow_button.html')
+render_follow_detail = render_template('groups/partials/follow_detail.html')
 
 
 group_list_page = route(GET=do(render_template('groups/list.html'),
@@ -31,13 +31,13 @@ follow_group = do(
     login_required,
     group_request,
     route(GET=v.redirect_to_group_detail,
-          POST=do(render_follow_button, v.follow_group)))
+          POST=do(render_follow_detail, v.follow_group)))
 
 unfollow_group = do(
     login_required,
     group_request,
     route(GET=v.redirect_to_group_detail,
-          POST=do(render_follow_button, v.unfollow_group)))
+          POST=do(render_follow_detail, v.unfollow_group)))
 
 # TODO: should this have group_admin
 start_group_map_print_job = route(POST=v.start_group_map_print_job)

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -32,18 +32,8 @@
     </div>
     <div class="pageheading-controls block">
         <div class="row">
-            <div class="col-xs-6 secondary-heading">
-                <span class="h2"><b>653</b></span>
-                <span class="h6">Followers</span>
-            </div>
-            <div class="col-xs-6 text-right">
-                {% if event_list.user_can_edit_group %}
-                <a href="{{edit_url}}" class="btn btn-switch icon-cog">Admin</a>
-                {% else %}
-                <div class="btn-follow-container">
-                    {% include 'groups/partials/follow_button.html' %}
-                </div>
-                {% endif %}
+            <div class="follow-detail">
+                {% include 'groups/partials/follow_detail.html' %}
             </div>
         </div>
     </div>

--- a/src/nyc_trees/apps/users/templates/groups/partials/follow_detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/follow_detail.html
@@ -1,0 +1,17 @@
+{% if render_follow_button_without_count %}
+    {% include 'groups/partials/follow_button.html' %}
+{% else %}
+    <div class="col-xs-6 secondary-heading">
+        <span class="h2"><b>{{ counts.follows }}</b></span>
+        <span class="h6">Follower{{ counts.follows|pluralize }}</span>
+    </div>
+    <div class="col-xs-6 text-right">
+        {% if event_list.user_can_edit_group %}
+            <a href="{{edit_url}}" class="btn btn-switch icon-cog">Admin</a>
+        {% else %}
+        <div class="btn-follow-container">
+            {% include 'groups/partials/follow_button.html' %}
+        </div>
+        {% endif %}
+    </div>
+{% endif  %}

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -76,6 +76,8 @@ def group_detail(request):
     show_mapper_request = group.allows_individual_mappers and \
         not user_is_group_admin(request.user, group)
 
+    follow_count = Follow.objects.filter(group=group).count()
+
     tree_count = get_group_tree_count(group)
 
     group_blocks = Territory.objects \
@@ -112,11 +114,14 @@ def group_detail(request):
             'tree': tree_count,
             'block': block_percent,
             'event': num_events_held,
-            'attendees': num_event_attendees
+            'attendees': num_event_attendees,
+            'follows': follow_count
         },
         'group_events_id': GROUP_EVENTS_ID,
         'layer': get_context_for_territory_layer(request, request.group.id),
-        'territory_bounds': _group_territory_bounds(request.group)
+        'territory_bounds': _group_territory_bounds(request.group),
+        'render_follow_button_without_count': request.POST.get(
+            'render_follow_button_without_count', False)
     }
 
 

--- a/src/nyc_trees/js/src/fetchAndReplace.js
+++ b/src/nyc_trees/js/src/fetchAndReplace.js
@@ -30,7 +30,8 @@ function fetchAndReplace(options) {
             if (url) {
                 event.preventDefault();
                 $.ajax(url, {
-                        type: verb
+                        type: verb,
+                        data: options.data
                     })
                     .done(function(content) {
                         $(options.container).html(content);

--- a/src/nyc_trees/js/src/group_detail.js
+++ b/src/nyc_trees/js/src/group_detail.js
@@ -4,7 +4,7 @@ var fetchAndReplace = require('./fetchAndReplace'),
     mapModule = require('./map');
 
 fetchAndReplace({
-    container: '.btn-follow-container',
+    container: '.follow-detail',
     target: '.btn-follow, .btn-unfollow'
 });
 

--- a/src/nyc_trees/js/src/group_list.js
+++ b/src/nyc_trees/js/src/group_list.js
@@ -13,7 +13,8 @@ var $ = require('jquery'),
 
 fetchAndReplace({
     container: '.btn-follow-container',
-    target: '.btn-follow, .btn-unfollow'
+    target: '.btn-follow, .btn-unfollow',
+    data: { 'render_follow_button_without_count': 'True' }
 });
 
 $groups = $(dom.groups);


### PR DESCRIPTION
This commit adds the correct follower count to the group detail page.

Updating the count when a person clicks the "Follow" button required changing the follow/unfollow views and responses, but the change had to be "backward compatible," since the group list page shows follow/unfollow buttons without counts. To implement this, I added a POST argument that is fed through to the template which then decides whether the button should be rendered alone, or with a count next to it.