### PR TITLE
Link directly to training events from training instructions page

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/training_instructions.html
+++ b/src/nyc_trees/apps/home/templates/home/training_instructions.html
@@ -15,7 +15,7 @@ Before you're able to RSVP to mapping events you'll need to do the following:
     </li>
     <li>
         {% if user.field_training_complete %}<s>{% endif %}
-        Attend a <a href="{% url "events_list_page" %}#training">training event</a></li>
+        Attend a <a href="{% url "events_list_page" %}?active_filter=training">training event</a></li>
         {% if user.field_training_complete %}</s>{% endif %}
     </li>
 </ul>


### PR DESCRIPTION
Since we can link directly to the event tabs via query string, we don't have
to do any additional work to support tab hash on the events page.

Closes #523