### PR TITLE
Don't show field errors at the top of the event form.

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/partials/event_form.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/event_form.html
@@ -2,7 +2,6 @@
     <fieldset>
         {% csrf_token %}
 
-        {{ form.errors }}
         {{ form.non_field_errors }}
 
         <div class="field">

--- a/src/nyc_trees/templates/registration/activation_complete.html
+++ b/src/nyc_trees/templates/registration/activation_complete.html
@@ -12,7 +12,6 @@ Optional Information
 <form method="POST">
     {% csrf_token %}
 
-    {{ form.errors }}
     {{ form.non_field_errors }}
 
     <div class="field">


### PR DESCRIPTION
These errors will be shown on top of the specific field, so we shouldn't
show them again above the entire form.

Fixes #331