### PR TITLE
Hide group URL on detail page if not set

### DIFF
--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -66,15 +66,17 @@
                 <div class="col-xs-4 text-right"><a href="mailto:{{group.contact_email}}" class="btn btn-default">Email</a></div>
             </div>
         </div>
-        <div class="description block item">
-            <div class="row">
-                <div class="col-xs-8">
-                    <h5>Website</h5>
-                    <div class="h6">{{group.contact_url}}</div>
+        {% if group.contact_url %}
+            <div class="description block item">
+                <div class="row">
+                    <div class="col-xs-8">
+                        <h5>Website</h5>
+                        <div class="h6">{{group.contact_url}}</div>
+                    </div>
+                    <div class="col-xs-4 text-right"><a href="{{group.contact_url}}" class="btn btn-default">Visit</a></div>
                 </div>
-                <div class="col-xs-4 text-right"><a href="{{group.contact_url}}" class="btn btn-default">Visit</a></div>
             </div>
-        </div>
+        {% endif %}
     </section>
     <section class="contributions">
         <h4 class="section-heading">Contributions</h4>


### PR DESCRIPTION
A button that goes nowhere is confusing to a person viewing the group detail page.

Fixes #553 