### PR TITLE
Wire up "Request Individual Mapper Status" button on group detail page

### DIFF
--- a/src/nyc_trees/apps/core/helpers.py
+++ b/src/nyc_trees/apps/core/helpers.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from apps.users.models import TrustedMapper
+
 
 def user_is_census_admin(user):
     return user.is_authenticated() and user.is_census_admin
@@ -18,3 +25,10 @@ def user_has_field_training(user):
 
 def user_is_individual_mapper(user):
     return user.is_authenticated() and user.individual_mapper
+
+
+def user_is_trusted_mapper(user, group):
+    return user.is_authenticated() and \
+        TrustedMapper.objects.filter(group=group,
+                                     user=user,
+                                     is_approved=True).exists()

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -105,7 +105,6 @@ class User(NycModel, AbstractUser):
     def training_complete(self):
         return self.online_training_complete and self.field_training_complete
 
-    @property
     def eligible_to_become_individual_mapper(self):
         """
         Return True if user has completed online training, attended a mapping
@@ -118,6 +117,13 @@ class User(NycModel, AbstractUser):
         return self.field_training_complete and \
             EventRegistration.objects.filter(user=self,
                                              did_attend=True).count() >= 2
+
+    def eligible_to_become_trusted_mapper(self, group):
+        from apps.core.helpers import (user_is_group_admin,
+                                       user_is_trusted_mapper)
+        return group.allows_individual_mappers and \
+            not user_is_group_admin(self, group) and \
+            not user_is_trusted_mapper(self, group)
 
 
 class Group(NycModel, models.Model):

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -105,11 +105,47 @@
     <section>
         <h4 class="section-heading">Individual Mapping</h4>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu congue lorem, id feugiat tortor. Aliquam ante elit, sodales eget porttitor vel, commodo et felis.</p>
-        <button class="btn btn-primary btn-mobile--max">Request Individual Mapper Status</button>
+        <button class="btn btn-primary btn-mobile--max"
+                data-action="request-access"
+                data-group-slug="{{ group.slug }}">Request Individual Mapper Status</button>
     </section>
     {% endif %}
 
 {% endblock main %}
+
+{% block extra_content %}
+<div class="modal fade" id="request-access-complete-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Request Sent</h4>
+            </div>
+            <div class="modal-body">
+                <p>Your request has been sent.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="request-access-fail-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Error Sending Request</h4>
+            </div>
+            <div class="modal-body">
+                <p>There was a problem submitting your request. Please try again.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock extra_content %}
 
 {% block page_js %}
 <script type="text/javascript" src="{{ "js/group_detail.js"|static_url }}"></script>

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -33,6 +33,7 @@ urlpatterns = patterns(
         r.edit_user_mapping_priveleges,
         name='edit_user_mapping_priveleges'),
 
+    # Keep in sync with src/nyc_trees/js/src/group_detail.js
     # Keep in sync with src/nyc_trees/js/src/reserveBlockfacePage.js
     url(r'^(?P<group_slug>[\w-]+)/request-trusted-mapper-status/$',
         r.request_mapper_status,

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -73,11 +73,10 @@ def group_detail(request):
                   .as_context(request, group_slug=group.slug))
     user_is_following = Follow.objects.filter(user_id=request.user.id,
                                               group=group).exists()
-    show_mapper_request = group.allows_individual_mappers and \
-        not user_is_group_admin(request.user, group)
+
+    show_mapper_request = request.user.eligible_to_become_trusted_mapper(group)
 
     follow_count = Follow.objects.filter(group=group).count()
-
     tree_count = get_group_tree_count(group)
 
     group_blocks = Territory.objects \

--- a/src/nyc_trees/js/src/group_detail.js
+++ b/src/nyc_trees/js/src/group_detail.js
@@ -1,8 +1,15 @@
 "use strict";
 
-var fetchAndReplace = require('./fetchAndReplace'),
-    $ = require('jquery'),
+var $ = require('jquery'),
+    fetchAndReplace = require('./fetchAndReplace'),
     mapModule = require('./map');
+
+var dom = {
+    modals: '.modal',
+    requestAccessButton: '[data-action="request-access"]',
+    requestAccessCompleteModal: '#request-access-complete-modal',
+    requestAccessFailModal: '#request-access-fail-modal'
+};
 
 fetchAndReplace({
     container: '.follow-detail',
@@ -19,3 +26,20 @@ if ($('#map').length > 0) {
 
     mapModule.addTileLayer(territoryMap);
 }
+
+$(dom.requestAccessButton).click(function() {
+    var groupSlug = $(dom.requestAccessButton).data('group-slug');
+    $(dom.modals).modal('hide');
+    $.ajax({
+            // Keep this URL in sync with "request_mapper_status"
+            // in src/nyc_trees/apps/users/urls/group.py
+            url: '/group/' + groupSlug + '/request-trusted-mapper-status/',
+            type: 'POST'
+        })
+        .done(function() {
+            $(dom.requestAccessCompleteModal).modal('show');
+        })
+        .fail(function() {
+            $(dom.requestAccessFailModal).modal('show');
+        });
+});


### PR DESCRIPTION
How to test:
1. Select a group that allows individual mappers
2. Login as a non-group admin that is not a trusted mapper (for your test group)
3. Go to the group detail page
4. You should see a "Request Individual Mapper" button
5. Clicking this button should create a new mapper request in the Group Admin page
6. When a group admin approves this request, the button should disappear from the group detail page