### PR TITLE
Add more detailed tags to AMIs

### DIFF
--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -20,7 +20,10 @@
       },
       "tags": {
         "Name": "nyc-trees-monitoring",
-        "Version": "{{user `version`}}"
+        "Version": "{{user `version`}}",
+        "Created": "{{ isotime }}",
+        "Service": "Monitoring",
+        "Environment": "Staging"
       }
     },
     {
@@ -36,7 +39,10 @@
       },
       "tags": {
         "Name": "nyc-trees-tiler",
-        "Version": "{{user `version`}}"
+        "Version": "{{user `version`}}",
+        "Created": "{{ isotime }}",
+        "Service": "Tiler",
+        "Environment": "Staging"
       }
     },
     {
@@ -52,7 +58,10 @@
       },
       "tags": {
         "Name": "nyc-trees-app",
-        "Version": "{{user `version`}}"
+        "Version": "{{user `version`}}",
+        "Created": "{{ isotime }}",
+        "Service": "Application",
+        "Environment": "Staging"
       }
     }
   ],


### PR DESCRIPTION
This changeset adds the following tags to all AMIs:

- Created (human-readable timestamp of when the AMI was created)
- Service (name of the service this AMI contains)
- Environment (target environment for this AMI)

---

**Example of AMI tagging**:

![ec2_management_console](https://cloud.githubusercontent.com/assets/43639/6169261/487ff46a-b29a-11e4-91f2-e5e95d10d355.png)