### PR TITLE
Only initialize group detail map if it has territory.

### DIFF
--- a/src/nyc_trees/js/src/group_detail.js
+++ b/src/nyc_trees/js/src/group_detail.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var fetchAndReplace = require('./fetchAndReplace'),
+    $ = require('jquery'),
     mapModule = require('./map');
 
 fetchAndReplace({
@@ -11,8 +12,10 @@ fetchAndReplace({
 require('./event_list');
 require('./copyEventUrl');
 
-var territoryMap = mapModule.create({
-    static: true
-});
+if ($('#map').length > 0) {
+    var territoryMap = mapModule.create({
+        static: true
+    });
 
-mapModule.addTileLayer(territoryMap);
+    mapModule.addTileLayer(territoryMap);
+}


### PR DESCRIPTION
If a group has no territory, we were not creating the "map" element, but
still trying to initialize the leaflet map.

Fixes #585