### PR TITLE
Show all blockfaces on reservation page

### DIFF
--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
-from apps.core.views import map_legend
 
 from apps.users.models import TrustedMapper
 
@@ -34,9 +33,13 @@ def blockface_cart_page(request):
 
 
 def reservations_page(request):
-    context = map_legend(request)
-    context['layer'] = get_context_for_reservations_layer(request)
-    return context
+    return {
+        'legend_entries': [
+            {'css_class': 'reserved', 'label': 'Reserved by you'},
+            {'css_class': 'unavailable', 'label': 'Not reserved by you'},
+        ],
+        'layer': get_context_for_reservations_layer(request)
+    }
 
 
 def reserve_blockfaces_page(request):

--- a/src/tiler/sql/user_reservations.sql
+++ b/src/tiler/sql/user_reservations.sql
@@ -2,11 +2,14 @@
   <% if (is_utf_grid) { %>
   ST_AsGeoJSON(block.geom) AS geojson,
   <% } %>
-  block.geom, block.id, 'reserved' as survey_type
+  block.geom, block.id, CASE WHEN reservation.user_id = <%= user_id %> THEN  'reserved' ELSE 'unavailable' END as survey_type
   FROM survey_blockface AS block
-  INNER JOIN survey_blockfacereservation AS reservation
+  LEFT OUTER JOIN survey_blockfacereservation AS reservation
     ON (block.id = reservation.blockface_id
         AND reservation.canceled_at IS NULL
+        AND reservation.user_id = <%= user_id %>
         AND reservation.expires_at > now() at time zone 'utc')
-  WHERE reservation.user_id = <%= user_id %>
+  <% if (is_utf_grid) { %>
+    WHERE reservation.user_id = <%= user_id %>
+  <% } %>
 ) AS query


### PR DESCRIPTION
An individual mapper will have at most 20 blockfaces reserved at any given time. This left us with a largely empty reservation map, so we decided to show the other blockfaces as unavailable.

Fixes #566