### PR TITLE
Add footer to non-map pages

### DIFF
--- a/src/nyc_trees/apps/core/templates/base.html
+++ b/src/nyc_trees/apps/core/templates/base.html
@@ -70,6 +70,15 @@
         {# This block exists for placing elements that need to be children of the body, like bootstrap modals #}
         {% block extra_content %}
         {% endblock extra_content %}
+
+        {% block footer %}
+            <footer>
+                <div class="container">
+                    <img class="section-about-logo pull-left" src="/static/img/logo-nycparks.png" srcset="/static/img/logo-nycparks@2x.png 2x">
+                    <p>A project of New York City Parks</p>
+                </div>
+            </footer>
+        {% endblock footer %}
     </body>
     <script type="text/javascript">
       {% include 'core/partials/config.js' %}

--- a/src/nyc_trees/apps/core/templates/base_map.html
+++ b/src/nyc_trees/apps/core/templates/base_map.html
@@ -14,3 +14,7 @@
 </div>
 
 {% endblock %}
+
+{% block footer %}
+{# Map pages hide the footer to maximize viewable area #}
+{% endblock footer%}

--- a/src/nyc_trees/apps/core/templates/base_reservation.html
+++ b/src/nyc_trees/apps/core/templates/base_reservation.html
@@ -28,3 +28,8 @@
 </div>
 
 {% endblock %}
+
+
+{% block footer %}
+{# Map pages hide the footer to maximize viewable area #}
+{% endblock footer%}

--- a/src/nyc_trees/apps/event/templates/event/event_list_page.html
+++ b/src/nyc_trees/apps/event/templates/event/event_list_page.html
@@ -83,6 +83,10 @@
 </div>
 
 
+{% block footer %}
+{# Map pages hide the footer to maximize viewable area #}
+{% endblock footer%}
+
 {% block page_js %}
 <script type="text/javascript" src="{{ "js/event_list_page.js"|static_url }}"></script>
 {% endblock page_js %}


### PR DESCRIPTION
The footer is excluded from full screen map page to maximize the viewable area.

Fixes #601
Fixes #516



![screen shot 2015-02-17 at 8 48 29 am](https://cloud.githubusercontent.com/assets/17363/6231135/ea152efe-b681-11e4-837b-072c056925a5.png)

![screen shot 2015-02-17 at 8 48 42 am](https://cloud.githubusercontent.com/assets/17363/6231133/ea12736c-b681-11e4-8005-68fab8bca6ea.png)

![screen shot 2015-02-17 at 8 49 09 am](https://cloud.githubusercontent.com/assets/17363/6231134/ea150d5c-b681-11e4-99eb-93c693b288c7.png)

