### PR TITLE
Show reservations link in side nav

### DIFF
--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -105,6 +105,11 @@ class User(NycModel, AbstractUser):
     def training_complete(self):
         return self.online_training_complete and self.field_training_complete
 
+    def attended_at_least_two_events(self):
+        from apps.event.models import EventRegistration
+        return EventRegistration.objects.filter(user=self,
+                                                did_attend=True).count() >= 2
+
     def eligible_to_become_individual_mapper(self):
         """
         Return True if user has completed online training, attended a mapping
@@ -113,10 +118,8 @@ class User(NycModel, AbstractUser):
         # Has an admin rescinded mapper status?
         if self.individual_mapper is False:
             return False
-        from apps.event.models import EventRegistration
-        return self.field_training_complete and \
-            EventRegistration.objects.filter(user=self,
-                                             did_attend=True).count() >= 2
+        return (self.field_training_complete and
+                self.attended_at_least_two_events())
 
     def eligible_to_become_trusted_mapper(self, group):
         from apps.core.helpers import (user_is_group_admin,

--- a/src/nyc_trees/apps/core/templates/core/partials/nav.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/nav.html
@@ -26,9 +26,7 @@
             <li{% if active_page == "training" %} class="active"{% endif %}><a href="{% url 'training_summary_pure' %}">Training</a></li>
             <li{% if active_page == "groups" %} class="active"{% endif %}><a href="{% url 'group_list_page' %}">Groups</a></li>
             <li{% if active_page == "events" %} class="active"{% endif %}><a href="{% url 'events_list_page' %}">Events</a></li>
-            {% if show_reservations %}
             <li{% if active_page == "reservations" %} class="active"{% endif %}><a href="{% url 'reservations' %}">Reservations</a></li>
-            {% endif %}
             <li{% if active_page == "achievements" %} class="active"{% endif %}><a href="#">Achievements</a></li>
         {% endif %}
         <li{% if active_page == "about" %} class="active"{% endif %}><a href="#">About &amp; FAQ</a></li>

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -15,7 +15,8 @@ from apps.survey import views as v
 #####################################
 
 reservations = route(
-    GET=individual_mapper_do(
+    GET=do(
+        login_required,
         render_template('survey/reservations.html'),
         v.reservations_page))
 

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -3,11 +3,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django.contrib.auth.decorators import login_required
+
 from django_tinsel.decorators import route, render_template, json_api_call
 from django_tinsel.utils import decorate as do
 
 from apps.core.decorators import individual_mapper_do
-
 from apps.survey import views as v
 
 #####################################
@@ -42,6 +43,11 @@ reserve_blockfaces = individual_mapper_do(
 blockface_reservations_confirmation_page = individual_mapper_do(
     render_template('survey/reserve_blockface_confirmation.html'),
     route(POST=v.confirm_blockface_reservations))
+
+reservations_instructions = do(
+    login_required,
+    render_template('survey/reservations_instructions.html'),
+    v.reservations_instructions)
 
 #####################################
 # SURVEY ROUTES

--- a/src/nyc_trees/apps/survey/templates/survey/reservations.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reservations.html
@@ -8,7 +8,11 @@
 {% block aside %}
 
   <div class="map-sidebar">
-    <h2>Reservations<a href="{% url 'reserve_blockface_page' %}" id="new-reservation" class="btn btn-primary pull-right">New</a></h2>
+    <h2>Reservations
+        <a id="new-reservation" class="btn btn-primary pull-right"
+        {% if user.individual_mapper %}href="{% url 'reserve_blockface_page' %}"
+        {% else %}href="{% url 'reservations_instructions' %}"
+        {% endif %}>New</a></h2>
     <p class="pageheading-description-detail hidden-xs">
       The new reservation map shows lorem ipsum dolor sit amet, consectetur adipiscing
       elit. Sed eu congue lorem, id feugiat tortor. Aliquam ante elit, sodales eget

--- a/src/nyc_trees/apps/survey/urls/blockface.py
+++ b/src/nyc_trees/apps/survey/urls/blockface.py
@@ -8,6 +8,7 @@ from django.conf.urls import patterns, url
 from apps.survey.routes import (reserve_blockface_page, cancel_reservation,
                                 reserve_blockfaces, survey, reservations,
                                 reserved_blockface_popup,
+                                reservations_instructions,
                                 blockface_reservations_confirmation_page,
                                 blockface)
 
@@ -18,6 +19,9 @@ urlpatterns = patterns(
     url(r'^$', reservations, name='reservations'),
 
     url(r'^reserve/$', reserve_blockface_page, name='reserve_blockface_page'),
+
+    url(r'^reservations-instructions/$', reservations_instructions,
+        name='reservations_instructions'),
 
     url(r'^(?P<blockface_id>\d+)/cancel-reservation/$', cancel_reservation,
         name='cancel_reservation'),

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -172,3 +172,7 @@ def admin_extend_blockface_reservation(request, blockface_id):
 def admin_blockface_available(request, blockface_id):
     # TODO: implement
     pass
+
+
+def reservations_instructions(request):
+    pass

--- a/src/nyc_trees/nyc_trees/context_processors.py
+++ b/src/nyc_trees/nyc_trees/context_processors.py
@@ -34,13 +34,6 @@ def user_settings_privacy_url(request):
     return {'user_settings_privacy_url': full_url}
 
 
-def show_reservations(request):
-    return {
-        'show_reservations': (request.user.is_authenticated()
-                              and request.user.individual_mapper)
-    }
-
-
 def config(request):
     # At the time this function was written, the generated context was
     # only used in the base.html template, and our AJAX requests all

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -160,7 +160,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'nyc_trees.context_processors.config',
     'nyc_trees.context_processors.my_events_now',
     'nyc_trees.context_processors.soft_launch',
-    'nyc_trees.context_processors.show_reservations',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders


### PR DESCRIPTION
Add "Reservations" link back to the side nav and also adds some instructions on how to become an individual mapper.

How to test this:
1. Login as a non-individual mapper user
2. Go go Reservations page
3. Click New (should go to instructions page)
4. Grant user individual mapping status
5. Go go Reservations page
6. Click New (should go to reserve blockface page)