### PR TITLE
Allow editing past or in progress events.

### DIFF
--- a/src/nyc_trees/apps/event/models.py
+++ b/src/nyc_trees/apps/event/models.py
@@ -54,10 +54,6 @@ class Event(NycModel, models.Model):
     objects = models.GeoManager()
 
     @staticmethod
-    def raise_date_past(field_name):
-        raise ValidationError({field_name: ['Event must not begin in past']})
-
-    @staticmethod
     def raise_invalid_bounds(field_name):
         raise ValidationError({field_name: ["Must occur before end time"]})
 


### PR DESCRIPTION
Switches to testing against 'ends_at' instead of 'begins_at', to allow
editing events that are in progress.

Also allows editing past events, provided that the times have not been
changed.

Fixes #564