### PR TITLE
Fix exception when viewing group detail page logged out

### DIFF
--- a/src/nyc_trees/apps/core/helpers.py
+++ b/src/nyc_trees/apps/core/helpers.py
@@ -32,3 +32,8 @@ def user_is_trusted_mapper(user, group):
         TrustedMapper.objects.filter(group=group,
                                      user=user,
                                      is_approved=True).exists()
+
+
+def user_is_eligible_to_become_trusted_mapper(user, group):
+    return user.is_authenticated() and \
+        user.eligible_to_become_trusted_mapper(group)

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -11,7 +11,8 @@ from django.utils.timezone import now
 from libs.formatters import humanize_bytes
 from libs.sql import get_group_tree_count
 
-from apps.core.helpers import user_is_group_admin
+from apps.core.helpers import (user_is_group_admin,
+                               user_is_eligible_to_become_trusted_mapper)
 from apps.core.decorators import group_request
 from apps.core.models import Group
 
@@ -65,6 +66,7 @@ group_edit_events = EventList(
 
 
 def group_detail(request):
+    user = request.user
     group = request.group
     event_list = (group_detail_events
                   .configure(chunk_size=2,
@@ -74,7 +76,8 @@ def group_detail(request):
     user_is_following = Follow.objects.filter(user_id=request.user.id,
                                               group=group).exists()
 
-    show_mapper_request = request.user.eligible_to_become_trusted_mapper(group)
+    show_mapper_request = user_is_eligible_to_become_trusted_mapper(user,
+                                                                    group)
 
     follow_count = Follow.objects.filter(group=group).count()
     tree_count = get_group_tree_count(group)


### PR DESCRIPTION
Fixes:

    Internal Server Error: /group/american-hornbeam-appreciation-society/
    Traceback (most recent call last):
    File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 111, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
    File "/usr/local/lib/python2.7/dist-packages/django_tinsel/decorators.py", line 33, in routed
    return req_method(request, *args2, **kwargs2)
    File "/opt/app/apps/core/decorators.py", line 32, in wrapper
    return view_fn(request, *args, **kwargs)
    File "/usr/local/lib/python2.7/dist-packages/django_tinsel/decorators.py", line 79, in wrapper
    params = callable_or_dict(request, *args, **wrapper_kwargs)
    File "/opt/app/apps/users/views/group.py", line 77, in group_detail
    show_mapper_request = request.user.eligible_to_become_trusted_mapper(group)
    File "/usr/local/lib/python2.7/dist-packages/django/utils/functional.py", line 225, in inner
    return func(self._wrapped, *args)
    AttributeError: 'AnonymousUser' object has no attribute 'eligible_to_become_trusted_mapper'