### PR TITLE
Fix error when saving user profile

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/partials/event_section.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/event_section.html
@@ -1,4 +1,6 @@
 {% with event=info.event %}
+{% block extra_markup %}
+{% endblock extra_markup %}
 <a href="{{ event.get_absolute_url }}" class="event block item rightarrow">
     <div class="row">
         {% include 'event/partials/event_calendar.html' %}


### PR DESCRIPTION
This restores hidden form fields needed on the user profile page.
Broken by 7c543f46e7f82557187e057e2c178090e46fd81c.

This is not a priority for user testing.

Fixes #633