### PR TITLE
Fix Django application logs; add Gunicorn specific log

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
@@ -34,6 +34,10 @@ app_log: /var/log/nyc-trees-app.log
 app_log_rotate_count: 5
 app_log_rotate_interval: daily
 
+app_gunicorn_log: /var/log/nyc-trees-gunicorn.log
+app_gunicorn_log_rotate_count: 5
+app_gunicorn_log_rotate_internal: daily
+
 app_static_root: /var/www/nyc-trees/static/
 app_media_root: /var/www/nyc-trees/media/
 

--- a/deployment/ansible/roles/nyc-trees.app/tasks/log-rotation.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/log-rotation.yml
@@ -1,10 +1,29 @@
 ---
-- name: Touch log file if it does not exist
+- name: Touch application log file if it does not exist
   command: touch {{ app_log }}
            creates={{ app_log }}
 
-- name: Set log file permissions
-  file: path={{ app_log }} owner=nyc-trees group=nyc-trees mode=0664
+- name: Set application log file permissions
+  file: path={{ app_log }}
+        owner=nyc-trees
+        group=nyc-trees
+        mode=0664
+
+- name: Configure application log rotation
+  template: src=logrotate-nyc-trees-app.j2
+            dest=/etc/logrotate.d/nyc-trees-app
+
+- name: Touch Gunicorn log file if it does not exist
+  command: touch {{ app_gunicorn_log }}
+           creates={{ app_gunicorn_log }}
+
+- name: Set Gunicorn log file permissions
+  file: path={{ app_gunicorn_log }}
+        owner=nyc-trees
+        group=nyc-trees
+        mode=0664
 
 - name: Configure Gunicorn log rotation
-  template: src=logrotate-nyc-trees-app.j2 dest=/etc/logrotate.d/nyc-trees-app
+  template: src=logrotate-nyc-trees-gunicorn.j2
+            dest=/etc/logrotate.d/nyc-trees-gunicorn
+

--- a/deployment/ansible/roles/nyc-trees.app/templates/gunicorn-nyc-trees.py.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/gunicorn-nyc-trees.py.j2
@@ -10,7 +10,7 @@ timeout = 1800
 workers = 1
 {% else %}
 accesslog = None
-errorlog = "{{ app_log }}"
+errorlog = "{{ app_gunicorn_log }}"
 loglevel = 'info'
 preload_app = True
 reload = False

--- a/deployment/ansible/roles/nyc-trees.app/templates/logrotate-nyc-trees-gunicorn.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/logrotate-nyc-trees-gunicorn.j2
@@ -1,0 +1,7 @@
+{{ app_gunicorn_log }} {
+  rotate {{ app_gunicorn_log_rotate_count }}
+  {{ app_gunicorn_log_rotate_internal }}
+  compress
+  missingok
+  notifempty
+}

--- a/deployment/ansible/roles/nyc-trees.app/templates/upstart-nyc-trees-app.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/upstart-nyc-trees-app.conf.j2
@@ -11,4 +11,4 @@ respawn
 setuid nyc-trees
 chdir {{ app_home }}
 
-exec envdir /etc/nyc-trees.d/env gunicorn --config /etc/nyc-trees.d/gunicorn.py nyc_trees.wsgi
+exec envdir /etc/nyc-trees.d/env gunicorn --config /etc/nyc-trees.d/gunicorn.py nyc_trees.wsgi >> {{ app_log }} 2>&1

--- a/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
@@ -5,6 +5,7 @@
   with_items:
     - nginx
     - django
+    - gunicorn
     - windshaft
   notify:
     - Restart Beaver

--- a/deployment/ansible/roles/nyc-trees.beaver/templates/gunicorn.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.beaver/templates/gunicorn.conf.j2
@@ -1,0 +1,3 @@
+[/var/log/nyc-trees-gunicorn.log]
+type: gunicorn
+tags: gunicorn,beaver


### PR DESCRIPTION
This changeset ensures that the Django specific logs go into `/var/log/nyc-trees-app.log`, while the Gunicorn specific logs go into `/var/log/nyc-trees-gunicorn.log`. Log shipping and rotation for the new logs was also added.

Previously, Django application logs were leaking out of the Upstart job, which got redirected automatically to `/var/log/upstart/nyc-trees-app.log`. Now those logs are in `/var/log/nyc-trees-app.log`.