### PR TITLE
Fix metric name used by Tasseo for e-mail graphs

### DIFF
--- a/deployment/ansible/roles/nyc-trees.tasseo/templates/nyc-trees.js.j2
+++ b/deployment/ansible/roles/nyc-trees.tasseo/templates/nyc-trees.js.j2
@@ -18,18 +18,18 @@ var metrics = [
     {% if ['packer'] | is_in(group_names) -%}
     {
         "alias": "email.percent-error",
-        "target": "scale(divideSeries(transformNull(sumSeries(statsite.counts.email.message.failure),0),transformNull(sumSeries(statsite.counts.email.message.success),0)),100)",
+        "target": "scale(divideSeries(transformNull(sumSeries(statsite.counts.django.email.message.failure),0),transformNull(sumSeries(statsite.counts.django.email.message.success),0)),100)",
         "unit": "%",
         "warning": 10,
         "critical": 15
     },
     {
         "alias": "email.success",
-        "target": "transformNull(statsite.counts.email.message.success,0)"
+        "target": "transformNull(statsite.counts.django.email.message.success,0)"
     },
     {
         "alias": "email.failure",
-        "target": "transformNull(statsite.counts.email.message.failure,0)"
+        "target": "transformNull(statsite.counts.django.email.message.failure,0)"
     },
     {% endif %}
     {


### PR DESCRIPTION
This changeset fixes the metric name used by Tasseo for e-mail graphs. Because `django-statsd` handles the StatsD client setup, all metrics that come through the following import get tucked under the `django` metric namespace:

```python
from django_statsd.clients import statsd
```

Attempts to resolve #636.