### PR TITLE
Centralize Nginx log_format directive

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
@@ -4,18 +4,6 @@ server {
 
   root {{ app_home }}/static;
 
-  log_format logstash_json '{ "@timestamp": "$time_iso8601", '
-                          '"@fields": { '
-                          '"remote_addr": "$remote_addr", '
-                          '"remote_user": "$remote_user", '
-                          '"body_bytes_sent": "$body_bytes_sent", '
-                          '"request_time": "$request_time", '
-                          '"status": "$status", '
-                          '"request": "$request", '
-                          '"request_method": "$request_method", '
-                          '"http_referrer": "$http_referer", '
-                          '"http_user_agent": "$http_user_agent" } }';
-
   access_log /var/log/nginx/nyc-trees-app.access.log logstash_json;
 
   location /static/ {

--- a/deployment/ansible/roles/nyc-trees.common/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.common/meta/main.yml
@@ -2,6 +2,6 @@
 dependencies:
   - { role: "azavea.ntp" }
   - { role: "azavea.git" }
-  - { role: "azavea.nginx", nginx_delete_default_site: True, when: "['monitoring-servers'] | is_not_in(group_names)" }
+  - { role: "nyc-trees.nginx", when: "['monitoring-servers'] | is_not_in(group_names)" }
   - { role: "azavea.daemontools", when: "['monitoring-servers'] | is_not_in(group_names)" }
   - { role: "azavea.nodejs", when: "['monitoring-servers'] | is_not_in(group_names)" }

--- a/deployment/ansible/roles/nyc-trees.nginx/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.nginx/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.nginx", nginx_delete_default_site: True }

--- a/deployment/ansible/roles/nyc-trees.nginx/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.nginx/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure Nginx log format
+  template: src=log-format.conf.j2
+            dest=/etc/nginx/conf.d/log-format.conf
+  notify:
+    - Restart Nginx

--- a/deployment/ansible/roles/nyc-trees.nginx/templates/log-format.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.nginx/templates/log-format.conf.j2
@@ -1,0 +1,11 @@
+log_format logstash_json '{ "@timestamp": "$time_iso8601", '
+                           '"@fields": { '
+                           '"remote_addr": "$remote_addr", '
+                           '"remote_user": "$remote_user", '
+                           '"body_bytes_sent": "$body_bytes_sent", '
+                           '"request_time": "$request_time", '
+                           '"status": "$status", '
+                           '"request": "$request", '
+                           '"request_method": "$request_method", '
+                           '"http_referrer": "$http_referer", '
+                           '"http_user_agent": "$http_user_agent" } }';

--- a/deployment/ansible/roles/nyc-trees.tiler/templates/nginx-nyc-trees-tiler.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.tiler/templates/nginx-nyc-trees-tiler.conf.j2
@@ -2,18 +2,6 @@ server {
   listen *:80;
   server_name _;
 
-  log_format logstash_json '{ "@timestamp": "$time_iso8601", '
-                          '"@fields": { '
-                          '"remote_addr": "$remote_addr", '
-                          '"remote_user": "$remote_user", '
-                          '"body_bytes_sent": "$body_bytes_sent", '
-                          '"request_time": "$request_time", '
-                          '"status": "$status", '
-                          '"request": "$request", '
-                          '"request_method": "$request_method", '
-                          '"http_referrer": "$http_referer", '
-                          '"http_user_agent": "$http_user_agent" } }';
-
   access_log /var/log/nginx/nyc-trees-tiler.access.log logstash_json;
 
   location / {


### PR DESCRIPTION
This changeset moves the Nginx `log_format` directive into the `http` block (via an include). The newly created `nyc-trees.nginx` role handles providing the `logstash_json` format for application server and tiler `server` blocks to use.

This also prevents Nginx errors citing that `log_format` must be defined in the `http` block.