### PR TITLE
Add HTTPS support for the application server stack

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -12,6 +12,7 @@ $ export AWS_PROFILE=nyc-trees-stg
 $ export AWS_DEFAULT_OUTPUT=text
 $ export AWS_DEFAULT_REGION=us-east-1
 $ export AWS_SNS_TOPIC=arn:aws:sns:us-east-1...
+$ export AWS_SSL_CERTIFICATE=arn:aws:iam...
 $ export AWS_PUBLIC_HOSTED_ZONE=treescount.nycgovparks.org
 ```
 

--- a/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
@@ -36,10 +36,27 @@ server {
     alias {{ app_media_root }};
   }
 
+  location /health-check {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+
+    proxy_pass http://127.0.0.1:8000/;
+
+    break;
+  }
+
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;
+
+    {% if ['packer'] | is_in(group_names) -%}
+    if ($http_x_forwarded_proto != "https") {
+      return 301 https://$host$request_uri;
+    }
+    {% endif %}
+
     proxy_pass http://127.0.0.1:8000;
   }
 }

--- a/deployment/deployment-helper.sh
+++ b/deployment/deployment-helper.sh
@@ -292,6 +292,7 @@ case "$1" in
     AWS_STACK_PARAMS="ParameterKey=KeyName,ParameterValue=${AWS_KEY_NAME}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=StackColor,ParameterValue=${AWS_APP_STACK_COLOR}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=GlobalNotificationsARN,ParameterValue=${AWS_SNS_TOPIC}"
+    AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=AppSSLCertificateARN,ParameterValue=${AWS_SSL_CERTIFICATE}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=VpcId,ParameterValue=${AWS_VPC_ID}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=AppServerAMI,ParameterValue=${AWS_APP_SERVER_AMI}"
     AWS_STACK_PARAMS="${AWS_STACK_PARAMS} ParameterKey=PublicSubnets,ParameterValue='${AWS_PUBLIC_SUBNETS}'"


### PR DESCRIPTION
This changeset adds HTTPS support to the application server stack by:

- Associating a certificate ARN with the load balancer
- Accepting connections on load balancer port 443
- Ensuring Nginx redirects inbound HTTP requests to HTTPS
- Add health-check endpoint as an exception to the line item above