### PR TITLE
Group admin should always be able to reserve blockfaces

### DIFF
--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from django.conf import settings
 from django.utils.timezone import make_aware, utc
 
-from models import (Blockface, Survey, Territory, BlockfaceReservation)
+from models import (Group, Blockface, Survey, Territory, BlockfaceReservation)
 from apps.users.models import TrustedMapper
 
 
@@ -21,7 +21,7 @@ def get_context_for_progress_layer(request):
 
 
 def get_context_for_reservable_layer(request):
-    models = [Blockface, Territory, BlockfaceReservation, TrustedMapper]
+    models = [Group, Blockface, Territory, BlockfaceReservation, TrustedMapper]
     return _get_context_for_layer("reservable", models, request)
 
 

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -124,6 +124,10 @@ def confirm_blockface_reservations(request):
         .filter(user=request.user, is_approved=True) \
         .values_list('group_id', flat=True)
 
+    user_admin_group_ids = Group.objects \
+        .filter(admin=request.user) \
+        .values_list('id', flat=True)
+
     already_reserved_blockface_ids = BlockfaceReservation.objects \
         .filter(blockface__id__in=ids) \
         .current() \
@@ -141,7 +145,8 @@ def confirm_blockface_reservations(request):
         if ((blockface.is_available and
              blockface.id not in already_reserved_blockface_ids and
              (territory is None or
-              territory.group_id in user_trusted_group_ids))):
+              territory.group_id in user_trusted_group_ids or
+              territory.group_id in user_admin_group_ids))):
             reservations.append(BlockfaceReservation(
                 blockface=blockface,
                 user=request.user,

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -10,24 +10,28 @@
       block.geom,
       block.id,
       turf.group_id,
-      grp.slug AS group_slug,
+      core_group.slug AS group_slug,
       CASE
         WHEN (block.is_available AND reservation.id IS NULL
-              AND (turf.id IS NULL OR trustedmapper.id IS NOT NULL)) THEN 'available'
+              AND (turf.id IS NULL
+                   OR trustedmapper.id IS NOT NULL
+                   OR core_group.admin_id = <%= user_id %>)) THEN 'available'
         ELSE 'unavailable'
       END AS survey_type,
       CASE
         WHEN reservation.id IS NOT NULL THEN 'reserved'
-        WHEN grp.id IS NOT NULL AND NOT grp.allows_individual_mappers THEN 'unavailable'
+        WHEN (core_group.id IS NOT NULL
+              AND NOT core_group.allows_individual_mappers) THEN 'unavailable'
         WHEN NOT block.is_available THEN 'unavailable'
-        WHEN turf.id IS NOT NULL AND trustedmapper.id IS NULL THEN 'group_territory'
+        WHEN (turf.id IS NOT NULL
+              AND NOT (trustedmapper.id IS NOT NULL
+                       OR core_group.admin_id = <%= user_id %>)) THEN 'group_territory'
         ELSE 'none'
       END AS restriction
       FROM survey_blockface AS block
       LEFT OUTER JOIN survey_territory AS turf
         ON block.id = turf.blockface_id
-      LEFT JOIN core_group AS grp
-        ON grp.id = turf.group_id
+      LEFT JOIN core_group ON core_group.id = turf.group_id
       LEFT OUTER JOIN survey_blockfacereservation AS reservation
         ON (block.id = reservation.blockface_id
             AND reservation.canceled_at IS NULL


### PR DESCRIPTION
Group admins should not have to go through the trusted mapper workflow
in order to reserve blockfaces in their own territory.