### PR TITLE
Add custom admin for User model

### DIFF
--- a/src/nyc_trees/apps/core/admin.py
+++ b/src/nyc_trees/apps/core/admin.py
@@ -3,7 +3,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django.core.exceptions import ValidationError
+
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 
 from apps.core.models import User, Group
 
@@ -13,4 +17,66 @@ class GroupAdmin(admin.ModelAdmin):
     prepopulated_fields = {"slug": ("name",)}
 
 
-admin.site.register(User)
+class NycUserChangeForm(UserChangeForm):
+    class Meta(UserChangeForm.Meta):
+        model = User
+
+
+class NycUserCreationForm(UserCreationForm):
+    class Meta(UserCreationForm.Meta):
+        model = User
+
+    # Django auth has hard-coded references to the default `User` model so
+    # we have to reimplement this function with the correct references.
+    # Source: http://stackoverflow.com/questions/16953302/django-custom-user-model-in-admin-relation-auth-user-does-not-exist  # NOQA
+    def clean_username(self):
+        username = self.cleaned_data['username']
+        try:
+            User.objects.get(username=username)
+        except User.DoesNotExist:
+            return username
+        raise ValidationError(self.error_messages['duplicate_username'])
+
+
+@admin.register(User)
+class NycUserAdmin(UserAdmin):
+    form = NycUserChangeForm
+    add_form = NycUserCreationForm
+
+    fieldsets = UserAdmin.fieldsets + (
+        ('Custom Fields', {'fields': ('zip_code',
+                                      'opt_in_stewardship_info',
+                                      'individual_mapper',
+                                      'requested_individual_mapping_at')}),
+
+        ('Permissions', {'fields': ('profile_is_public',
+                                    'real_name_is_public',
+                                    'group_follows_are_public',
+                                    'contributions_are_public',
+                                    'achievements_are_public',
+                                    'is_flagged',
+                                    'is_banned',
+                                    'is_census_admin',
+                                    'is_ambassador',
+                                    'is_minor')}),
+
+        ('Referrer', {'fields': ('referrer_parks',
+                                 'referrer_group',
+                                 'referrer_ad',
+                                 'referrer_social_media',
+                                 'referrer_friend',
+                                 'referrer_311',
+                                 'referrer_other')}),
+
+        ('Training', {'fields': ('field_training_complete',
+                                 'training_finished_getting_started',
+                                 'training_finished_the_mapping_method',
+                                 'training_finished_tree_data',
+                                 'training_finished_tree_surroundings',
+                                 'training_finished_intro_quiz',
+                                 'training_finished_groups_to_follow')})
+    )
+
+    add_fieldsets = UserAdmin.add_fieldsets + (
+        (None, {'fields': ('email',)}),
+    )

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -27,6 +27,12 @@ REFERRER_AD = (
 )
 
 
+#######################################
+# When adding new fields to the User model, please take care to add these
+# fields to the NycUserAdmin class as well, so that we may administer these
+# fields in the Django super admin.
+# Ref: src/nyc_trees/apps/core.admin.py
+#######################################
 class User(NycModel, AbstractUser):
     individual_mapper = models.NullBooleanField()
     requested_individual_mapping_at = models.DateTimeField(null=True,


### PR DESCRIPTION
This fixes an issue where you are unable to modify user passwords via
the Django admin.

Reference:
http://stackoverflow.com/questions/15012235/using-django-auth-useradmin-for-a-custom-user-model

Fixes #130

Not a priority for sprint review.