### PR TITLE
Fix old events appearing where they shouldn't

### DIFF
--- a/src/nyc_trees/apps/event/event_list.py
+++ b/src/nyc_trees/apps/event/event_list.py
@@ -236,8 +236,8 @@ def immediate_events(request):
     seven_days = relativedelta(days=7)
     nowish = (Event.objects
               .filter(is_private=False,
-                      begins_at__gte=now() - seven_days,
-                      begins_at__lte=now() + seven_days)
+                      ends_at__gt=now(),
+                      ends_at__lte=now() + seven_days)
               .order_by('begins_at'))
 
     if user.is_authenticated():
@@ -252,4 +252,5 @@ def immediate_events(request):
 
 @EventList
 def all_events(request):
-    return Event.objects.filter(is_private=False).order_by('begins_at')
+    return Event.objects.filter(is_private=False,
+                                ends_at__gt=now()).order_by('begins_at')

--- a/src/nyc_trees/apps/event/templates/event/event_list_page.html
+++ b/src/nyc_trees/apps/event/templates/event/event_list_page.html
@@ -35,20 +35,20 @@
     <div class="tab-pane active" id="list">
       <section>
         {# TODO: make event_list return a totally empty context to avoid introspection #}
+        <h4>Your Events this week</h4>
+        <div data-class="event-list-container">
         {% if immediate_events.event_infos %}
-          <h4>Your Events this week</h4>
-          <div data-class="event-list-container">
-              {% include "event/partials/event_list.html" with event_list=immediate_events %}
-          </div>
+          {% include "event/partials/event_list.html" with event_list=immediate_events %}
+        {% else %}
+          <p>You haven't RSVPed to any events yet.</p>
         {% endif %}
+        </div>
 
         {# TODO: make event_list return a totally empty context to avoid introspection #}
-        {% if all_events.event_infos %}
-          <h4>Browse events</h4>
-          <div data-class="event-list-container">
-              {% include "event/partials/event_list.html" with event_list=all_events %}
-          </div>
-        {% endif %}
+        <h4>Browse events</h4>
+        <div data-class="event-list-container">
+        {% include "event/partials/event_list.html" with event_list=all_events %}
+        </div>
       </section>
     </div>
     <div class="tab-pane map-container" id="map-tab">

--- a/src/nyc_trees/apps/event/templates/event/partials/event_list.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/event_list.html
@@ -16,6 +16,8 @@
 {% block event_list_loop %}
     {% for info in event_list.event_infos %}
         {% include "event/partials/event_section.html" %}
+    {% empty %}
+        <p>No events</p>
     {% endfor %}
 {% endblock event_list_loop %}
 


### PR DESCRIPTION
This prevents old events from appearing on the Dashboard and the Events page.

Fixes #622 and #673.