### PR TITLE
Admin page for managing group territory

### DIFF
--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -37,9 +37,15 @@ def get_context_for_territory_layer(request, group_id):
 
 
 def get_context_for_territory_survey_layer(request, group_id):
-    models = [Blockface, Territory]
+    models = [Blockface, Territory, BlockfaceReservation]
     params = '?group=%s' % group_id
     return _get_context_for_layer("territory_survey", models, request, params)
+
+
+def get_context_for_territory_admin_layer(request):
+    models = [Blockface, Territory, BlockfaceReservation]
+    return _get_context_for_layer("territory_admin", models, request, '?')
+    # Note: client will add group=<group_id>
 
 
 def _get_context_for_layer(layer_name, models, request, params=''):

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -8,7 +8,8 @@ from django.contrib.auth.decorators import login_required
 from django_tinsel.decorators import route, render_template, json_api_call
 from django_tinsel.utils import decorate as do
 
-from apps.core.decorators import individual_mapper_do, group_request
+from apps.core.decorators import (individual_mapper_do, group_request,
+                                  census_admin_do)
 from apps.survey import views as v
 
 #####################################
@@ -89,8 +90,9 @@ blockface = route(GET=do(json_api_call, v.blockface))
 # ADMIN ROUTES
 #####################################
 
-admin_blockface_page = route(
-    GET=v.admin_blockface_page)
+admin_territory_page = route(GET=census_admin_do(
+    render_template('survey/admin_territory.html'),
+    v.admin_territory_page))
 
 admin_blockface_partial = route(
     GET=v.admin_blockface_partial)

--- a/src/nyc_trees/apps/survey/templates/survey/admin_territory.html
+++ b/src/nyc_trees/apps/survey/templates/survey/admin_territory.html
@@ -1,0 +1,34 @@
+{% extends "base_reservation.html" %}
+{% load utils %}
+
+{% block aside %}
+
+    <div class="map-sidebar">
+        <h2>Group Territory</h2>
+        <p class="pageheading-description-detail hidden-xs">
+            Select a group to modify its territory.
+        </p>
+        <select id="select-group">
+            {% for group in groups %}
+                <option value="{{ group.id }}">{{ group.name }}</option>
+            {% endfor %}
+        </select>
+        {% include 'home/partials/legend.html' %}
+        <div class="action-bar h4" id="action-bar"></div>
+    </div>
+
+    {% include 'home/partials/location_search.html' %}
+
+{% endblock aside %}
+
+{% block main %}
+
+<div id="map" class="map-event"
+     data-tile-url="{{ layer.tile_url }}"
+     data-grid-url="{{ layer.grid_url }}"></div>
+
+{% endblock main %}
+
+{% block page_js %}
+    <script type="text/javascript" src="{{ "js/adminTerritoryPage.js"|static_url }}"></script>
+{% endblock page_js %}

--- a/src/nyc_trees/apps/survey/urls/census_admin.py
+++ b/src/nyc_trees/apps/survey/urls/census_admin.py
@@ -8,8 +8,9 @@ from django.conf.urls import patterns, url
 from django_tinsel.decorators import route
 
 from apps.core.decorators import census_admin_do
-from apps.survey.views import (admin_blockface_page,
-                               admin_blockface_partial,
+from apps.survey import routes as r
+
+from apps.survey.views import (admin_blockface_partial,
                                admin_blockface_detail_page,
                                admin_extend_blockface_reservation,
                                admin_blockface_available)
@@ -18,9 +19,8 @@ from apps.survey.views import (admin_blockface_page,
 # These URLs have the prefix 'census_admin/'
 urlpatterns = patterns(
     '',
-    url(r'^blockface/$',
-        census_admin_do(route(GET=admin_blockface_page)),
-        name='admin_blockface_page'),
+    url(r'^territory/$', r.admin_territory_page,
+        name='admin_territory_page'),
 
     url(r'^blockface-partial/$',
         census_admin_do(route(GET=admin_blockface_partial)),

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -28,7 +28,8 @@ from apps.survey.models import (BlockfaceReservation, Blockface, Territory,
 from apps.survey.layer_context import (get_context_for_reservations_layer,
                                        get_context_for_reservable_layer,
                                        get_context_for_progress_layer,
-                                       get_context_for_territory_survey_layer)
+                                       get_context_for_territory_survey_layer,
+                                       get_context_for_territory_admin_layer)
 
 
 def progress_page(request):
@@ -299,6 +300,22 @@ def flag_survey(request, survey_id):
 def species_autocomplete_list(request):
     # TODO: implement
     pass
+
+
+def admin_territory_page(request):
+    context = {
+        'groups': Group.objects.all(),
+        'legend_entries': [
+            {'css_class': 'available', 'label': 'Available'},
+            {'css_class': 'reserved', 'label': "This group's territory"},
+            {'css_class': 'unavailable',
+             'label': "Others' territory/reservations"},
+            {'css_class': 'surveyed-by-me', 'label': 'Mapped by this group'},
+            {'css_class': 'surveyed-by-others', 'label': 'Mapped by others'},
+        ]
+    }
+    context['layer'] = get_context_for_territory_admin_layer(request)
+    return context
 
 
 def admin_blockface_page(request):

--- a/src/nyc_trees/gulpfile.js
+++ b/src/nyc_trees/gulpfile.js
@@ -31,6 +31,7 @@ var args = minimist(process.argv.slice(2),
 
     entries = [
         'activation_form.js',
+        'adminTerritoryPage.js',
         'base.js',
         'datetimepicker_polyfill.js',
         'event.js',

--- a/src/nyc_trees/js/src/adminTerritoryPage.js
+++ b/src/nyc_trees/js/src/adminTerritoryPage.js
@@ -1,0 +1,46 @@
+"use strict";
+
+var $ = require('jquery'),
+    L = require('leaflet'),
+    mapModule = require('./map'),
+    mapUtil = require('./lib/mapUtil'),
+    zoom = require('./lib/mapUtil').ZOOM,
+    SelectableBlockfaceLayer = require('./lib/SelectableBlockfaceLayer');
+
+// Extends the leaflet object
+require('leaflet-utfgrid');
+
+var dom = {
+        selectGroup: '#select-group',
+        actionBar: '#action-bar'
+    },
+    $actionBar = $(dom.actionBar),
+
+    territoryMap = mapModule.create({
+        legend: true,
+        search: true
+    }),
+    tileLayer = null,
+    grid = null,
+    selectedLayer = null;
+
+$(dom.selectGroup).on('change', updateTileLayer);
+
+function updateTileLayer(e) {
+    var group_id = $(e.target).val(),
+        query = 'group=' + group_id;
+    if (tileLayer) {
+        territoryMap.removeLayer(tileLayer);
+        territoryMap.removeLayer(grid);
+        territoryMap.removeLayer(selectedLayer);
+    }
+    tileLayer = mapModule.addTileLayer(territoryMap, query);
+    grid = mapModule.addGridLayer(territoryMap, query);
+    selectedLayer = new SelectableBlockfaceLayer(territoryMap, grid, {
+        onAdd: function (gridData) {
+            selectedLayer.clearLayers();
+            return true;
+        }
+    });
+    territoryMap.addLayer(selectedLayer);
+}

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -125,8 +125,9 @@ function initCrosshairs(domId) {
     $map.append([$hHair, $vHair]);
 }
 
-function addTileLayer(map, domId) {
-    var tileUrl = getDomMapAttribute('tile-url', domId),
+function addTileLayer(map, queryString) {
+    var query = queryString || '',
+        tileUrl = getDomMapAttribute('tile-url') + query,
         layer = L.tileLayer(tileUrl, {
             minZoom: zoom.MIN,
             maxZoom: zoom.MAX
@@ -134,8 +135,9 @@ function addTileLayer(map, domId) {
     return layer;
 }
 
-function addGridLayer(map, domId) {
-    var gridUrl = getDomMapAttribute('grid-url', domId),
+function addGridLayer(map, queryString) {
+    var query = queryString || '',
+        gridUrl = getDomMapAttribute('grid-url') + query,
         layer = L.utfGrid(gridUrl, {
             minZoom: zoom.MIN,
             maxZoom: zoom.MAX,

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -22,6 +22,7 @@ var Windshaft = require('windshaft'),
 
     interactivity = {
         territory_survey: 'id,survey_type,restriction,geojson',
+        territory_admin: 'id,survey_type,turf_group_id,geojson',
         progress: 'id,group_id,survey_type,geojson',
         reservable: 'id,group_id,group_slug,survey_type,restriction,geojson',
         reservations: 'id,geojson'

--- a/src/tiler/sql/group_territory_admin.sql
+++ b/src/tiler/sql/group_territory_admin.sql
@@ -1,0 +1,30 @@
+(SELECT
+  block.id,
+  block.geom,
+  turf.group_id AS turf_group_id,
+  <% if (is_utf_grid) { %>
+  ST_AsGeoJSON(block.geom) AS geojson,
+  <% } %>
+  CASE
+    WHEN block.is_available THEN
+      CASE
+        WHEN turf.group_id = <%= group_id %> THEN 'reserved'
+        WHEN turf.group_id IS NOT NULL
+          OR reservation.id IS NOT NULL THEN 'unavailable'
+        ELSE 'available'
+      END
+    ELSE
+      CASE
+        WHEN turf.group_id = <%= group_id %> THEN 'surveyed-by-me'
+        ELSE 'surveyed-by-others'
+      END
+  END AS survey_type
+
+  FROM survey_blockface AS block
+  LEFT OUTER JOIN survey_territory AS turf
+    ON block.id = turf.blockface_id
+  LEFT OUTER JOIN survey_blockfacereservation AS reservation
+    ON (block.id = reservation.blockface_id
+        AND reservation.canceled_at IS NULL
+        AND reservation.expires_at > now() at time zone 'utc')
+) AS query


### PR DESCRIPTION
Show these categories of blockface:
* Available
* Reserved by this group
* Reserved by others
* Mapped by this group
* Mapped by others

These are essentially the same categories as shown on the "Reservations" page.

Initially we thought all of the following should be shown as "unavailable":
* Reserved by others
* Mapped by this group
* Mapped by others

I wanted to
* distinguish "Mapped by this group" to give context when working on a group,
  for example if you want to grow territory contiguously.
* distinguish "Reserved by others" from "Mapped by others" to allow seeing
  what yet needs to be mapped in a reapportioning situation.

With good coloring I think these will be useful and not distracting.
And it's easy to go back to 3 categories if we prefer.

Also:
* Fix omission of `BlockfaceReservation` in `get_context_for_territory_survey_layer`
* In `mapModule.addTileLayer` and `addGridLayer`, replace the unused `domId` argument with
  a `queryString` argument so the client can add query arguments to tiler URLs