### PR TITLE
Add expert_required to survey_blockface

### DIFF
--- a/src/nyc_trees/apps/survey/migrations/0009_blockface_expert_required.py
+++ b/src/nyc_trees/apps/survey/migrations/0009_blockface_expert_required.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0008_auto_20150225_0959'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='blockface',
+            name='expert_required',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -15,6 +15,7 @@ from libs.mixins import NycModel
 class Blockface(NycModel, models.Model):
     geom = models.MultiLineStringField()
     is_available = models.BooleanField(default=True)
+    expert_required = models.BooleanField(default=False)
 
     objects = models.GeoManager()
 


### PR DESCRIPTION
The block faces we will be importing include a flag that indicates when the block face may be too difficult to be mapped accurately by the general public. We will not be using this flag at "runtime" but adding it to our blockface model makes it easy to bulk-assign these blocks as territory owned by the NYC Parks group.