### PR TITLE
Fix bounds and location in map module

### DIFF
--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -33,8 +33,8 @@ function create(options) {
     var map = L.map(options.domId, mapOptions),
         zoomControl = L.control.zoom({position: 'bottomleft'}).addTo(map),
         $controlsContainer = $(zoomControl.getContainer()),
-        bounds = getDomMapAttribute('bounds'),
-        mapLocation = getDomMapAttribute('location');
+        bounds = getDomMapAttribute('bounds', options.domId),
+        mapLocation = getDomMapAttribute('location', options.domId);
 
     if (bounds) {
         fitBounds(map, bounds);


### PR DESCRIPTION
Prior to this fix, bounds and location were failing for maps that didn't
have the standard dom id of 'map'.