### PR TITLE
Show geolocation button on the survey page.

### DIFF
--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -36,7 +36,8 @@ var dom = {
     blockfaceId = mapUtil.getBlockfaceIdFromUrl(),
     blockfaceMap = mapModule.create({
         legend: false,
-        search: false
+        search: false,
+        geolocation: true
     }),
 
     endPointLayers = new L.FeatureGroup(),


### PR DESCRIPTION
Should be very useful when mapping blocks at an event.