### PR TITLE
Add a popup for exiting a survey without mapping

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -36,7 +36,7 @@
         </div>
 
         <button class="btn btn-primary" id="another-tree">+ Another Tree</button>
-        <button class="btn btn-secondary" id="cant-map">I cannot map this block</button>
+        <a class="btn btn-secondary" id="cant-map" href="#quit-popup" data-toggle="modal">I cannot map this block</a>
 
         <form autocomplete="off">
             <!-- We need a clickable submit button in order to trigger browser error validation popups -->
@@ -58,6 +58,37 @@
     {% include "survey/partials/tree_form.html" with tree_number="{{ tree_number }}" %}
 </script>
 {% endblock content %}
+
+{% block extra_content %}
+
+{# popups should always be in the extra_content block so that they #}
+{# are direct children of the body tag and avoid z-order conflicts #}
+{# that may arise when there are changes to the base template #}
+
+<div class="modal fade" id="quit-popup" tabindex="-1" role="dialog" aria-labelledby="quit-popup-title" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close btn btn-plain pull-right" data-dismiss="modal">
+                    <span aria-hidden="true">×</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title" id="quit-popup-title">Stop Mapping This Block</h4>
+            </div>
+            <div class="modal-body">
+                <div>I can no longer map because</div>
+                <form id="quit-form" method="POST">
+                    <textarea id="quit-reason" style="width: 100%;"
+                              placeholder="Offset tree bed, bad sidewalks, etc."></textarea>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button id="quit" type="submit" class="btn btn-primary">Stop Mapping</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock extra_content %}
 
 {# No footer on the survey pages, they have their own footer #}
 {% block footer %}

--- a/src/nyc_trees/js/src/lib/valIsEmpty.js
+++ b/src/nyc_trees/js/src/lib/valIsEmpty.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var $ = require('jquery');
+
+module.exports = function valIsEmpty(selector) {
+    return !$.trim($(selector).val());
+};

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -6,7 +6,8 @@ var $ = require('jquery'),
     toastr = require('toastr'),
     mapModule = require('./map'),
     mapUtil = require('./lib/mapUtil'),
-    SelectableBlockfaceLayer = require('./lib/SelectableBlockfaceLayer');
+    SelectableBlockfaceLayer = require('./lib/SelectableBlockfaceLayer'),
+    valIsEmpty = require('./lib/valIsEmpty');
 
 // Extends the leaflet object
 require('leaflet-utfgrid');
@@ -28,7 +29,12 @@ var dom = {
         distanceToEnd: '#distance_to_end',
 
         addTree: '#another-tree',
-        submitSurvey: '#submit-survey'
+        submitSurvey: '#submit-survey',
+
+        quitPopup: '#quit-popup',
+        quitShowPopup: '#cant-map',
+        quitReason: '#quit-reason',
+        quit: '#quit'
     },
 
     formTemplate = Handlebars.compile($(dom.treeFormTemplate).html()),
@@ -241,6 +247,19 @@ function getTreeData(i, form) {
 
 $(dom.submitSurvey).on('click', submitSurveyWithTrees);
 
+function createSurveyData() {
+    return {
+        survey: {
+            blockface_id: blockfaceId,
+            is_left_side: $(dom.leftButton).is('active'),
+            is_mapped_in_blockface_polyline_direction: isMappedFromStartOfLine,
+            has_trees: undefined,
+            quit_reason: undefined
+        },
+        trees: undefined
+    };
+}
+
 function submitSurveyWithTrees() {
     var $forms = $(dom.surveyPage).find('form'),
         $treeForms = $forms.filter('[data-class="tree-form"]');
@@ -254,15 +273,9 @@ function submitSurveyWithTrees() {
         // Only the last tree has "distance_to_end", so it gets special handling
         treeData[treeData.length - 1].distance_to_end = $(dom.distanceToEnd).val();
 
-        var data = {
-            survey: {
-                blockface_id: blockfaceId,
-                has_trees: true,
-                is_mapped_in_blockface_polyline_direction: isMappedFromStartOfLine,
-                is_left_side: $(dom.leftButton).is('active')
-            },
-            trees: treeData
-        };
+        var data = createSurveyData();
+        data.survey.has_trees = true;
+        data.trees = treeData;
 
         // There are two views we could POST to, 'survey' and
         // 'survey_from_event', depending on how we got to this page.
@@ -288,3 +301,55 @@ function submitSurveyWithTrees() {
         });
     }
 }
+
+$(dom.quit).on('click', quitSurvey);
+
+function quitSurvey() {
+    // Disable submit button to prevent double POSTs
+    $(dom.quit).off('click', quitSurvey);
+
+    var data = createSurveyData();
+    data.survey.has_trees = false;
+    data.survey.quit_reason = $(dom.quitReason).val();
+
+    // There are two views we could POST to, 'survey' and
+    // 'survey_from_event', depending on how we got to this page.
+    //
+    // Both share the same route as the view for this page, so we should be
+    // able to POST to our current URL, whatever it may be (which is the
+    // $.ajax default).
+    $.ajax({
+        type: 'POST',
+        dataType: 'json',
+        data: JSON.stringify(data)
+    })
+    .done(function(content) {
+        $(dom.quitPopup).modal('hide');
+        window.alert('Empty survey saved with quit reason - TODO: show options for what to do next');
+    })
+    .fail(function(jqXHR, textStatus, errorThrown) {
+        toastr.warning('Sorry, there was a problem stopping the survey. Please try again.', 'Something went wrong...');
+    })
+    .always(function() {
+        // Re-enable the submit button
+        $(dom.quit).on('click', quitSurvey);
+    });
+}
+
+$(dom.quitShowPopup).on('click', function(e) {
+    // Bootstrap will handle showing the modal, but the
+    // hidden class, applied by other code, needs to be
+    // removed.
+    $(dom.quitPopup).removeClass('hidden');
+});
+
+// The quit button is not enabled until a quit reason is entered
+$(dom.quit).prop('disabled', true);
+
+$(dom.quitReason).on('change keyup paste', function() {
+    $(dom.quit).prop('disabled', valIsEmpty(dom.quitReason));
+});
+
+$(dom.quitPopup).on('shown.bs.modal', function () {
+    $(dom.quitReason).focus();
+});


### PR DESCRIPTION
This change set allows a mapper to "bail out" of a survey, and forces them to leave an explanation as to why they are quitting. I have opted to not post any tree data because it could be invalid, and it could be frustrating to a person who is trying to stop mapping if we force them to make data corrections first.

What happens after the quit has been POSTed is left as a TODO because that part of the workflow is in progress.

To test:

1. Log in as an individual mapper
1. Reserve a block face
1. Start mapping, select the block, end, and side of the street.
1. Scroll to the bottom of the survey form and click "I cannot map this block"

There should be a popup with a text area. You should not be able to click "Stop Mapping" until there is non-whitespace content in the text area.