### PR TITLE
Selectable layer for unmapped group territory

### DIFF
--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -310,12 +310,13 @@ def species_autocomplete_list(request):
 
 def admin_territory_page(request):
     context = {
-        'groups': Group.objects.all(),
+        'groups': Group.objects.all().order_by('name'),
         'legend_entries': [
             {'css_class': 'available', 'label': 'Available'},
-            {'css_class': 'reserved', 'label': "This group's territory"},
+            {'css_class': 'reserved',
+             'label': "This group's unmapped territory"},
             {'css_class': 'unavailable',
-             'label': "Others' territory/reservations"},
+             'label': "Others' unmapped territory/reservations"},
             {'css_class': 'surveyed-by-me', 'label': 'Mapped by this group'},
             {'css_class': 'surveyed-by-others', 'label': 'Mapped by others'},
         ]

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -8,7 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django_tinsel.decorators import route, render_template, json_api_call
 from django_tinsel.utils import decorate as do
 
-from apps.core.decorators import group_request, group_admin_do
+from apps.core.decorators import group_request, group_admin_do, census_admin_do
 
 from apps.users.views import group as v
 
@@ -52,3 +52,7 @@ request_mapper_status = do(
     group_request,
     json_api_call,
     route(POST=v.request_mapper_status))
+
+group_unmapped_territory_geojson = route(
+    GET=census_admin_do(json_api_call,
+                        v.group_unmapped_territory_geojson))

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -41,4 +41,8 @@ urlpatterns = patterns(
 
     url(r'^(?P<group_slug>[\w-]+)/events/$',
         group_detail_events.endpoint, name=group_detail_events.url_name()),
+
+    url(r'^(?P<group_id>\d+)/territory.json/$',
+        r.group_unmapped_territory_geojson,
+        name='group_unmapped_territory_geojson'),
 )

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -224,3 +224,13 @@ def request_mapper_status(request):
     return {
         'success': True
     }
+
+
+def group_unmapped_territory_geojson(request, group_id):
+    blockfaces = Blockface.objects.filter(
+        is_available=True,
+        territory__group_id=group_id
+    )
+    blockfaceData = [{'id': bf.id, 'geojson': bf.geom.json}
+                     for bf in blockfaces]
+    return blockfaceData


### PR DESCRIPTION
* Endpoint `group_unmapped_territory_geojson`
* Click blockfaces to select/deselect individually
* Explain unselectable blockfaces via toast

Also:
* Sort groups by name in drop-down
* Show the first group's territory on page load