### PR TITLE
Remove is_census_admin in favor of using builtin is_superuser.

### DIFF
--- a/src/nyc_trees/apps/core/helpers.py
+++ b/src/nyc_trees/apps/core/helpers.py
@@ -7,11 +7,11 @@ from apps.users.models import TrustedMapper
 
 
 def user_is_census_admin(user):
-    return user.is_authenticated() and user.is_census_admin
+    return user.is_authenticated() and user.is_superuser
 
 
 def user_is_group_admin(user, group):
-    return user.is_authenticated() and (user.is_census_admin or
+    return user.is_authenticated() and (user.is_superuser or
                                         group.admin == user)
 
 

--- a/src/nyc_trees/apps/core/migrations/0016_remove_user_is_census_admin.py
+++ b/src/nyc_trees/apps/core/migrations/0016_remove_user_is_census_admin.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0015_auto_20150213_1321'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='user',
+            name='is_census_admin',
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -46,7 +46,6 @@ class User(NycModel, AbstractUser):
 
     is_flagged = models.BooleanField(default=False)
     is_banned = models.BooleanField(default=False)
-    is_census_admin = models.BooleanField(default=False)
     is_ambassador = models.BooleanField(default=False)
     is_minor = models.BooleanField(default=False)
 

--- a/src/nyc_trees/apps/users/tests.py
+++ b/src/nyc_trees/apps/users/tests.py
@@ -302,7 +302,7 @@ class GroupAccessTests(UsersTestCase):
             email='ca@rat.com',
             first_name='Census',
             last_name='Admin',
-            is_census_admin=True
+            is_superuser=True
         )
 
     def test_group_admin_can_get_group_edit_form(self):

--- a/src/nyc_trees/apps/users/uitests.py
+++ b/src/nyc_trees/apps/users/uitests.py
@@ -24,7 +24,7 @@ class BaseGroupUITest(NycTreesSeleniumTestCase):
         self.census_admin_user = User.objects.create(
             username='census_admin_user',
             email='census_admin_user@foo.com',
-            is_census_admin=True
+            is_superuser=True
         )
         self.census_admin_user.set_password('password')
         self.census_admin_user.clean_and_save()


### PR DESCRIPTION
Since Census Admins will need to have access to the Django Admin
site anyways, it makes sense to consolidate these flags into 1.

Fixes #75