### PR TITLE
Add IP address range for eth0 to PostgreSQL HBA

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -9,6 +9,7 @@ postgresql_password: nyc_trees
 postgresql_database: nyc_trees
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "33.33.33.1/24", method: "md5" }
+  - { type: "host", database: "all", user: "all", address: "10.0.2.0/24", method: "md5" }
 
 services_ip: "{{ lookup('env', 'NYC_TREES_SERVICES_IP') | default('33.33.33.30', true) }}"
 


### PR DESCRIPTION
This changeset allows Vagrant users to connect to the PostgreSQL database from the virtual machine host via the port forwarded `15432`.