### PR TITLE
Modify group territory by drawing a polygon

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/admin_territory.html
+++ b/src/nyc_trees/apps/survey/templates/survey/admin_territory.html
@@ -5,16 +5,37 @@
 
     <div class="map-sidebar">
         <h2>Group Territory</h2>
-        <p class="pageheading-description-detail hidden-xs">
-            Select a group to modify its territory.
-        </p>
+        <div>Select a group to modify its territory.</div>
         <select id="select-group">
             {% for group in groups %}
                 <option value="{{ group.id }}">{{ group.name }}</option>
             {% endfor %}
         </select>
+        <div style="margin:8px 0 12px 0">
+            <div>Add and remove blocks by clicking them, or by drawing an area:</div>
+            <button class="btn btn-default js-area js-area-add"
+                    title="Start drawing an area, enclosing blocks to add to group's territory">
+                Draw to add
+            </button>
+            <button class="btn btn-default js-area js-area-remove"
+                    title="Start drawing an area, enclosing blocks to remove from group's territory">
+                Draw to remove
+            </button>
+            <button class="btn btn-warning hidden js-area js-area-cancel">Cancel drawing</button>
+        </div>
         {% include 'home/partials/legend.html' %}
-        <div class="action-bar h4" id="action-bar"></div>
+        <div style="margin-top:12px">
+            <div class="pull-right">
+                <button class="btn btn-warning js-revert"
+                    title="Reset selection of blocks to match group's saved territory">
+                    Revert
+                </button>
+                <button class="btn btn-success js-save"
+                    title="Save currently-selected blocks as group's new territory">
+                    Save
+                </button>
+            </div>
+        </div>
     </div>
 
     {% include 'home/partials/location_search.html' %}

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -54,5 +54,5 @@ request_mapper_status = do(
     route(POST=v.request_mapper_status))
 
 group_unmapped_territory_geojson = route(
-    GET=census_admin_do(json_api_call,
-                        v.group_unmapped_territory_geojson))
+    POST=census_admin_do(json_api_call,
+                         v.group_unmapped_territory_geojson))

--- a/src/nyc_trees/css/leaflet.draw.css
+++ b/src/nyc_trees/css/leaflet.draw.css
@@ -1,0 +1,295 @@
+/* ================================================================== */
+/* Toolbars
+/* ================================================================== */
+
+.leaflet-draw-section {
+	position: relative;
+}
+
+.leaflet-draw-toolbar {
+	margin-top: 12px;
+}
+
+.leaflet-draw-toolbar-top {
+	margin-top: 0;
+}
+
+.leaflet-draw-toolbar-notop a:first-child {
+	border-top-right-radius: 0;
+}
+
+.leaflet-draw-toolbar-nobottom a:last-child {
+	border-bottom-right-radius: 0;
+}
+
+.leaflet-draw-toolbar a {
+	background-image: url('images/spritesheet.png');
+	background-repeat: no-repeat;
+}
+
+.leaflet-retina .leaflet-draw-toolbar a {
+	background-image: url('images/spritesheet-2x.png');
+	background-size: 270px 30px;
+}
+
+.leaflet-draw a {
+	display: block;
+	text-align: center;
+	text-decoration: none;
+}
+
+/* ================================================================== */
+/* Toolbar actions menu
+/* ================================================================== */
+
+.leaflet-draw-actions {
+	display: none;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	left: 26px; /* leaflet-draw-toolbar.left + leaflet-draw-toolbar.width */
+	top: 0;
+	white-space: nowrap;
+}
+
+.leaflet-right .leaflet-draw-actions {
+	right:26px;
+	left:auto;
+}
+
+.leaflet-draw-actions li {
+	display: inline-block;
+}
+
+.leaflet-draw-actions li:first-child a {
+	border-left: none;
+}
+
+.leaflet-draw-actions li:last-child a {
+	-webkit-border-radius: 0 4px 4px 0;
+	        border-radius: 0 4px 4px 0;
+}
+
+.leaflet-right .leaflet-draw-actions li:last-child a {
+	-webkit-border-radius: 0;
+	        border-radius: 0;
+}
+
+.leaflet-right .leaflet-draw-actions li:first-child a {
+	-webkit-border-radius: 4px 0 0 4px;
+	        border-radius: 4px 0 0 4px;
+}
+
+.leaflet-draw-actions a {
+	background-color: #919187;
+	border-left: 1px solid #AAA;
+	color: #FFF;
+	font: 11px/19px "Helvetica Neue", Arial, Helvetica, sans-serif;
+	line-height: 28px;
+	text-decoration: none;
+	padding-left: 10px;
+	padding-right: 10px;
+	height: 28px;
+}
+
+.leaflet-draw-actions-bottom {
+	margin-top: 0;
+}
+
+.leaflet-draw-actions-top {
+	margin-top: 1px;
+}
+
+.leaflet-draw-actions-top a,
+.leaflet-draw-actions-bottom a {
+	height: 27px;
+	line-height: 27px;
+}
+
+.leaflet-draw-actions a:hover {
+	background-color: #A0A098;
+}
+
+.leaflet-draw-actions-top.leaflet-draw-actions-bottom a {
+	height: 26px;
+	line-height: 26px;
+}
+
+/* ================================================================== */
+/* Draw toolbar
+/* ================================================================== */
+
+.leaflet-draw-toolbar .leaflet-draw-draw-polyline {
+	background-position: -2px -2px;
+}
+
+.leaflet-draw-toolbar .leaflet-draw-draw-polygon {
+	background-position: -31px -2px;
+}
+
+.leaflet-draw-toolbar .leaflet-draw-draw-rectangle {
+	background-position: -62px -2px;
+}
+
+.leaflet-draw-toolbar .leaflet-draw-draw-circle {
+	background-position: -92px -2px;
+}
+
+.leaflet-draw-toolbar .leaflet-draw-draw-marker {
+	background-position: -122px -2px;
+}
+
+/* ================================================================== */
+/* Edit toolbar
+/* ================================================================== */
+
+.leaflet-draw-toolbar .leaflet-draw-edit-edit {
+	background-position: -152px -2px;
+}
+
+.leaflet-draw-toolbar .leaflet-draw-edit-remove {
+	background-position: -182px -2px;
+}
+
+.leaflet-draw-toolbar .leaflet-draw-edit-edit.leaflet-disabled {
+	background-position: -212px -2px;
+}
+
+.leaflet-draw-toolbar .leaflet-draw-edit-remove.leaflet-disabled {
+	background-position: -242px -2px;
+}
+
+/* ================================================================== */
+/* Drawing styles
+/* ================================================================== */
+
+.leaflet-mouse-marker {
+	background-color: #fff;
+	cursor: crosshair;
+}
+
+.leaflet-draw-tooltip {
+	background: rgb(54, 54, 54);
+	background: rgba(0, 0, 0, 0.5);
+	border: 1px solid transparent;
+	-webkit-border-radius: 4px;
+	        border-radius: 4px;
+	color: #fff;
+	font: 12px/18px "Helvetica Neue", Arial, Helvetica, sans-serif;
+	margin-left: 20px;
+	margin-top: -21px;
+	padding: 4px 8px;
+	position: absolute;
+	visibility: hidden;
+	white-space: nowrap;
+	z-index: 6;
+}
+
+.leaflet-draw-tooltip:before {
+	border-right: 6px solid black;
+	border-right-color: rgba(0, 0, 0, 0.5);
+	border-top: 6px solid transparent;
+	border-bottom: 6px solid transparent;
+	content: "";
+	position: absolute;
+	top: 7px;
+	left: -7px;
+}
+
+.leaflet-error-draw-tooltip {
+	background-color: #F2DEDE;
+	border: 1px solid #E6B6BD;
+	color: #B94A48;
+}
+
+.leaflet-error-draw-tooltip:before {
+	border-right-color: #E6B6BD;
+}
+
+.leaflet-draw-tooltip-single {
+	margin-top: -12px
+}
+
+.leaflet-draw-tooltip-subtext {
+	color: #f8d5e4;
+}
+
+.leaflet-draw-guide-dash {
+	font-size: 1%;
+	opacity: 0.6;
+	position: absolute;
+	width: 5px;
+	height: 5px;
+}
+
+/* ================================================================== */
+/* Edit styles
+/* ================================================================== */
+
+.leaflet-edit-marker-selected {
+	background: rgba(254, 87, 161, 0.1);
+	border: 4px dashed rgba(254, 87, 161, 0.6);
+	-webkit-border-radius: 4px;
+	        border-radius: 4px;
+}
+
+.leaflet-edit-move {
+	cursor: move;
+}
+
+.leaflet-edit-resize {
+	cursor: pointer;
+}
+
+/* ================================================================== */
+/* Old IE styles
+/* ================================================================== */
+
+.leaflet-oldie .leaflet-draw-toolbar {
+	border: 3px solid #999;
+}
+
+.leaflet-oldie .leaflet-draw-toolbar a {
+	background-color: #eee;
+}
+
+.leaflet-oldie .leaflet-draw-toolbar a:hover {
+	background-color: #fff;
+}
+
+.leaflet-oldie .leaflet-draw-actions {
+	left: 32px;
+	margin-top: 3px;
+}
+
+.leaflet-oldie .leaflet-draw-actions li {
+	display: inline;
+	zoom: 1;
+}
+
+.leaflet-oldie .leaflet-edit-marker-selected {
+	border: 4px dashed #fe93c2;
+}
+
+.leaflet-oldie .leaflet-draw-actions a {
+	background-color: #999;
+}
+
+.leaflet-oldie .leaflet-draw-actions a:hover {
+	background-color: #a5a5a5;
+}
+
+.leaflet-oldie .leaflet-draw-actions-top a {
+	margin-top: 1px;
+}
+
+.leaflet-oldie .leaflet-draw-actions-bottom a {
+	height: 28px;
+	line-height: 28px;
+}
+
+.leaflet-oldie .leaflet-draw-actions-top.leaflet-draw-actions-bottom a {
+	height: 27px;
+	line-height: 27px;
+}

--- a/src/nyc_trees/js/src/adminTerritoryPage.js
+++ b/src/nyc_trees/js/src/adminTerritoryPage.js
@@ -3,19 +3,22 @@
 var $ = require('jquery'),
     L = require('leaflet'),
     mapModule = require('./map'),
-    mapUtil = require('./lib/mapUtil'),
     toastr = require('toastr'),
-    zoom = require('./lib/mapUtil').ZOOM,
     SelectableBlockfaceLayer = require('./lib/SelectableBlockfaceLayer');
 
 // Extends the leaflet object
 require('leaflet-utfgrid');
+require('leaflet-draw');
 
 var dom = {
         selectGroup: '#select-group',
-        actionBar: '#action-bar'
+        areaControls: '.js-area',
+        addAreaButton: '.js-area-add',
+        removeAreaButton: '.js-area-remove',
+        cancelAreaButton: '.js-area-cancel',
+        revertButton: '.js-revert',
+        saveButton: '.js-save'
     },
-    $actionBar = $(dom.actionBar),
 
     territoryMap = mapModule.create({
         legend: true,
@@ -23,51 +26,95 @@ var dom = {
     }),
     tileLayer = null,
     grid = null,
-    selectedLayer = null;
+    selectedLayer = null,
+    selectedBlockfaces = {};
 
 $(document).ready(showDataForChosenGroup);
 $(dom.selectGroup).on('change', showDataForChosenGroup);
 
+$(dom.addAreaButton).click(drawAreaToAdd);
+$(dom.removeAreaButton).click(drawAreaToRemove);
+$(dom.cancelAreaButton).click(stopDrawing);
+
+territoryMap.on('draw:created', onAreaComplete);
+
+$(dom.revertButton).click(revertTerritory);
+$(dom.saveButton).click(saveTerritory);
+
 function showDataForChosenGroup() {
-    var groupId = $(dom.selectGroup).val(),
-        query = 'group=' + groupId;
+    var query = 'group=' + currentGroupId();
     if (tileLayer) {
         territoryMap.removeLayer(tileLayer);
         territoryMap.removeLayer(grid);
         territoryMap.removeLayer(selectedLayer);
+        selectedBlockfaces = {};
     }
     tileLayer = mapModule.addTileLayer(territoryMap, query);
     grid = mapModule.addGridLayer(territoryMap, query);
+    selectBlockfacesInGroupTerritory();
+}
 
-    $.ajax({
+function selectBlockfacesInGroupTerritory() {
+    if (selectedLayer ) {
+        territoryMap.removeLayer(selectedLayer);
+        selectedBlockfaces = {};
+    }
+    selectedLayer = new SelectableBlockfaceLayer(territoryMap, grid, {
+        onAdd: onBlockfaceMaybeAdd,
+        onAdded: onBlockfaceAdded,
+        onRemove: onBlockfaceRemove
+    }).addTo(territoryMap);
+
+    getUnmappedTerritory(currentGroupId())
+        .done(addBlockfacesToSelection);
+}
+
+function currentGroupId() {
+    return $(dom.selectGroup).val();
+}
+
+function getUnmappedTerritory(groupId, polygon) {
+    var promise = $.ajax({
         // Keep this URL in sync with "group_territory_geojson"
         // in src/nyc_trees/apps/users/urls/group.py
         url: '/group/' + groupId + '/territory.json/',
-        type: 'GET',
-        success: initBlockfaceLayer,
+        type: 'POST',
+        dataType: 'json',
+        data: polygon,
         error: function () {
-            window.alert("Unable to load blockfaces for this group");
+            toastr.error("Failed to retrieve blockfaces");
+        }
+    });
+    return promise;
+}
+
+function addBlockfacesToSelection(blockDataList) {
+    $.each(blockDataList, function (__, blockData) {
+        if (!selectedBlockfaces[blockData.id]) {
+            selectedLayer.addData({
+                'type': 'Feature',
+                'geometry': JSON.parse(blockData.geojson),
+                'properties': {id: blockData.id}
+            });
         }
     });
 }
 
-function initBlockfaceLayer(data) {
-    selectedLayer = new SelectableBlockfaceLayer(territoryMap, grid, {
-        onAdd: onBlockfaceAdd,
-        onRemove: onBlockfaceRemove
+function removeBlockfacesFromSelection(blockDataList) {
+    $.each(blockDataList, function (__, blockData) {
+        var layer = selectedBlockfaces[blockData.id];
+        if (layer) {
+            selectedLayer.removeLayer(layer);
+            delete selectedBlockfaces[blockData.id];
+        }
     });
-    // Add group's unmapped territory to selectedLayer
-    $.each(data, function(__, blockData) {
-        selectedLayer.addData({
-            'type': 'Feature',
-            'geometry': JSON.parse(blockData.geojson),
-            'properties': {id: blockData.id}
-        });
-    });
-    territoryMap.addLayer(selectedLayer);
 }
 
-function onBlockfaceAdd(gridData) {
+function onBlockfaceAdded(feature, layer) {
+    selectedBlockfaces[feature.properties.id] = layer;
+}
+
+function onBlockfaceMaybeAdd(gridData) {
     var type = gridData.survey_type;
     if (type === 'available' || type === 'reserved') {
         return true;
@@ -86,5 +133,49 @@ function onBlockfaceAdd(gridData) {
 }
 
 function onBlockfaceRemove(feature) {
+    delete selectedBlockfaces[feature.properties.id];
     return true;
+}
+
+var drawer = null,
+    willAddBlocks = null;
+
+function drawAreaToAdd() { drawArea(true); }
+function drawAreaToRemove() { drawArea(false); }
+
+function drawArea(willAdd) {
+    willAddBlocks = willAdd;
+    toggleAreaControls();
+    selectedLayer.clicksEnabled = false;
+    drawer = new L.Draw.Polygon(territoryMap, {showArea: true});
+    drawer.enable();
+}
+
+function stopDrawing() {
+    toggleAreaControls();
+    drawer.disable();
+    selectedLayer.clicksEnabled = true;
+}
+
+function onAreaComplete(e) {
+    stopDrawing();
+
+    var polygonPoints = $.map(e.layer.getLatLngs(), function (p) {
+            return [[p.lng, p.lat]];
+        }),
+        polygonString = JSON.stringify(polygonPoints);
+
+    getUnmappedTerritory(currentGroupId(), polygonString)
+        .done(willAddBlocks ? addBlockfacesToSelection : removeBlockfacesFromSelection);
+}
+
+function toggleAreaControls() {
+    $(dom.areaControls).toggleClass('hidden');
+}
+
+function revertTerritory() {
+    selectBlockfacesInGroupTerritory();
+}
+
+function saveTerritory() {
 }

--- a/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
+++ b/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
@@ -24,8 +24,11 @@ var $ = require('jquery'),
 module.exports = L.GeoJSON.extend({
     options: {
         onAdd: $.noop,
-        onRemove: $.noop
+        onRemove: $.noop,
+        onAdded: $.noop
     },
+
+    clicksEnabled: true,
 
     initialize: function(map, grid, options) {
         L.GeoJSON.prototype.initialize.call(this, null, options);
@@ -37,15 +40,18 @@ module.exports = L.GeoJSON.extend({
         };
 
         this.options.onEachFeature = function(feature, layer) {
+            self.options.onAdded(feature, layer);
             layer.on('click', function() {
-                if (self.options.onRemove(feature)) {
+                if (self.clicksEnabled && self.options.onRemove(feature)) {
                     self.removeLayer(layer);
                 }
             });
         };
 
         grid.on('click', function(e) {
-            self.addBlockface(e.data);
+            if (self.clicksEnabled) {
+                self.addBlockface(e.data);
+            }
         });
 
         map.on('zoomend', function() {

--- a/src/nyc_trees/npm-shrinkwrap.json
+++ b/src/nyc_trees/npm-shrinkwrap.json
@@ -4542,6 +4542,11 @@
       "from": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
     },
+    "leaflet-draw": {
+      "version": "0.2.3",
+      "from": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-0.2.3.tgz"
+    },
     "merge-stream": {
       "version": "0.1.6",
       "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.6.tgz",

--- a/src/nyc_trees/package.json
+++ b/src/nyc_trees/package.json
@@ -39,6 +39,7 @@
     "handlebars": "^3.0.0",
     "jquery": "^2.1.1",
     "leaflet": "^0.7.3",
+    "leaflet-draw": "^0.2.3",
     "moment": "^2.8.4",
     "toastr": "^2.0.4"
   },


### PR DESCRIPTION
* Bring in `leaflet-draw`
* Add instructions, controls, and tool tips for polygon drawing
* If `group_unmapped_territory_geojson` endpoint gets an optional polygon, return
  both current and available territory contained in the polygon

Enhance `SelectableBlockfaceLayer.js`
* Allow specifying `onAdded` handler, called when a feature is actually added
* Add `clicksEnabled` property to enable/disable click handling

In `adminTerritoryPage.js`:
* Handle polygon drawing events
* Keep currently-selected blockfaces in `selectedBlockfaces` object
  (which maps a blockface ID to its displayed feature layer)
* While drawing a polygon, disable clicking on blockfaces
* When polygon complete, fetch contained blockfaces and update selection (add or remove)
* "Revert" button resets selection to group's saved territory
* Refactor to keep it DRY