### PR TITLE
Remove reference to removed user field is_census_admin.

### DIFF
--- a/src/nyc_trees/apps/core/admin.py
+++ b/src/nyc_trees/apps/core/admin.py
@@ -56,7 +56,6 @@ class NycUserAdmin(UserAdmin):
                                     'achievements_are_public',
                                     'is_flagged',
                                     'is_banned',
-                                    'is_census_admin',
                                     'is_ambassador',
                                     'is_minor')}),
 


### PR DESCRIPTION
This was causing the Django Admin pages to crash.
Fixes #731