### PR TITLE
Update blockface fixture and add scripts for blockface management

### DIFF
--- a/scripts/dump_blockfaces.sh
+++ b/scripts/dump_blockfaces.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -x
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+FIXTURE="$DIR/../src/nyc_trees/apps/survey/fixtures/blockface.json"
+
+vagrant ssh app -c "cd /opt/app && envdir /etc/nyc-trees.d/env ./manage.py dumpdata survey.Blockface" > $FIXTURE

--- a/src/nyc_trees/apps/survey/management/commands/assign_expert_blocks.py
+++ b/src/nyc_trees/apps/survey/management/commands/assign_expert_blocks.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from apps.core.models import Group
+from apps.survey.models import Blockface, Territory
+
+
+class Command(BaseCommand):
+    """
+    Assign all expert_required blockfaces to a specified group
+
+    Usage:
+
+    ./manage.py assign_expert_blocks some-group-slug
+    """
+    @transaction.atomic
+    def handle(self, *args, **options):
+        group_slug = args[0]
+        group = Group.objects.get(slug=group_slug)
+        print("Assigning expert blocks to %s" % group.name)
+
+        already_assigned_ids = Territory.objects.filter(group=group)\
+                                                .values_list('blockface_id',
+                                                             flat=True)
+        print("Skipping %d blocks already assigned" %
+              already_assigned_ids.count())
+
+        new_expert_blocks = Blockface.objects\
+                                     .filter(expert_required=True)\
+                                     .exclude(id__in=already_assigned_ids)
+
+        assigned_to_others = Territory.objects\
+                                      .filter(blockface__in=new_expert_blocks)
+        print("Removing %d assignments to groups other than %s" %
+              (assigned_to_others.count(), group.name))
+        assigned_to_others.delete()
+
+        print("Assigning %d blocks to %s" %
+              (new_expert_blocks.count(), group.name))
+        for blockface in new_expert_blocks:
+            Territory.objects.create(group=group, blockface=blockface)

--- a/src/nyc_trees/apps/survey/management/commands/assign_expert_blocks.py
+++ b/src/nyc_trees/apps/survey/management/commands/assign_expert_blocks.py
@@ -7,7 +7,8 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from apps.core.models import Group
-from apps.survey.models import Blockface, Territory
+from apps.survey.models import (Blockface, Territory,
+                                BlockfaceReservation)
 
 
 class Command(BaseCommand):
@@ -39,6 +40,13 @@ class Command(BaseCommand):
         print("Removing %d assignments to groups other than %s" %
               (assigned_to_others.count(), group.name))
         assigned_to_others.delete()
+
+        old_reservations =\
+            BlockfaceReservation.objects\
+                                .filter(blockface__in=new_expert_blocks)
+        print("Removing %d reservations on blocks that are being reassigned" %
+              old_reservations.count())
+        old_reservations.delete()
 
         print("Assigning %d blocks to %s" %
               (new_expert_blocks.count(), group.name))


### PR DESCRIPTION
We are receiving the production blockface data in chunks. I have updated the fixture with the production Manhattan blockfaces.

``dump_blockfaces.sh`` serves to document the process of dumping the content of the survey_blockface table into a known file which is loaded by setupdb.sh

Parks wants to assign all the "difficult" blocks to a group so that only skilled users can reserve and map them. This command idempotently assigns any blockface with ``expert_required == True`` to a specified group, possibly deleting a previous assignment to another group.

![screen shot 2015-03-05 at 9 45 19 am](https://cloud.githubusercontent.com/assets/17363/6510085/f3b4dbd4-c320-11e4-977f-8ab421e789d0.png)