### PR TITLE
Add PhantomJS to application server

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -27,3 +27,4 @@ azavea.beaver,0.1.2
 azavea.swapfile,0.1.0
 azavea.build-essential,0.1.0
 azavea.tasseo,0.1.1
+azavea.phantomjs,0.1.0

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -4,5 +4,6 @@ dependencies:
   - { role: "azavea.pip" }
   - { role: "azavea.postgresql-support" }
   - { role: "azavea.ruby" }
+  - { role: "azavea.phantomjs" }
   - { role: "azavea.sauce-connect", when: sauce_labs_api_key_is_defined }
   - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.app.", when: "['test'] | is_not_in(group_names)" }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,7 @@ vagrant ssh app -c "cd /opt/app && npm run lint"
 
 # Run JS unit tests.
 vagrant ssh app -c "cd /var/www/nyc-trees/static &&
-    xvfb-run /opt/app/node_modules/.bin/testem -f /opt/app/testem.json ci Firefox $*"
+    xvfb-run /opt/app/node_modules/.bin/testem -f /opt/app/testem.json ci"
 
 # Check for tiler JS lint.
 vagrant ssh tiler -c "cd /opt/tiler && npm run lint"


### PR DESCRIPTION
This changeset adds PhantomJS to the application server via the PhantomJS Ansible role.

See also: https://github.com/azavea/ansible-phantomjs