### PR TITLE
Show page descriptions on mobile

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/event_list_page.html
+++ b/src/nyc_trees/apps/event/templates/event/event_list_page.html
@@ -9,7 +9,7 @@
 
   <div class="map-sidebar">
     <h2>Events</h2>
-    <p class="pageheading-description-detail hidden-xs">
+    <p class="pageheading-description-detail">
       Take a look at upcoming events and find your next tree mapping project.
     </p>
     <div id="action-bar" class="action-bar">

--- a/src/nyc_trees/apps/home/templates/home/training.html
+++ b/src/nyc_trees/apps/home/templates/home/training.html
@@ -7,7 +7,7 @@
 {% block aside %}
 
   <h2>Training</h2>
-  <p class="pageheading-description-detail hidden-xs">
+  <p class="pageheading-description-detail">
     You're almost there! Continue your training to become a mapper.
   </p>
 

--- a/src/nyc_trees/apps/users/templates/groups/list.html
+++ b/src/nyc_trees/apps/users/templates/groups/list.html
@@ -10,7 +10,7 @@
     <div class="row">
         <div class="col-xs-12">
             <h2>Groups</h2>
-            <p class="pageheading-description-detail hidden-xs">
+            <p class="pageheading-description-detail">
                 Groups are the backbone of the census—they organize training and mapping events. Following a group is a great way to find out about upcoming events.
             </p>
         </div>

--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -255,6 +255,7 @@ input[type="checkbox"] + label {
   padding-top: .4rem;
   > li {
     display: inline-block;
+    background-color: #fff;
     &.active {
       & > a {
         font-weight: bold;

--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -145,13 +145,13 @@
   }
   .nav-tabs > li {
     .active & {
-      background-color: $brand-primary !important;
-      color: #fff !important;
+      background-color: transparent;
+      color: #fff;
     }
     & > .toggle-tab-button {
       border: 0 !important;
       border-radius: $border-radius-base !important;
-      background-color: transparent !important;
+      background-color: transparent;
     }
   }
   .nav-tabs-event {
@@ -160,6 +160,10 @@
     position: absolute;
     border: 0;
     background-color: transparent;
+    &.nav-tabs > li.active > a {
+      background-color: $brand-secondary;
+      color: #fff;
+    }
   }
   .tab-status-list {
     .map-sidebar {

--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -128,6 +128,14 @@
   }
 }
 
+@media (max-width: $screen-sm - 1) {
+  .pageheading-description-detail {
+    .tab-status-map-tab & {
+      display: none;
+    }
+  }
+}
+
 @media (min-width: $screen-sm) {
   .location-search-container {
     top: 1rem;
@@ -135,12 +143,15 @@
     width: 40rem;
     background-color: transparent;
   }
-  .toggle-tab-button {
-    border: 0 !important;
-    background-color: transparent !important;
+  .nav-tabs > li {
     .active & {
       background-color: $brand-primary !important;
       color: #fff !important;
+    }
+    & > .toggle-tab-button {
+      border: 0 !important;
+      border-radius: $border-radius-base !important;
+      background-color: transparent !important;
     }
   }
   .nav-tabs-event {


### PR DESCRIPTION
This brings back page mobile descriptions for the groups, events, and training pages.

More work is needed to do this on map-based pages.