### PR TITLE
Setup Watchman framework for application health check endpoint

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/nginx-nyc-trees-app.conf.j2
@@ -24,12 +24,12 @@ server {
     alias {{ app_media_root }};
   }
 
-  location /health-check {
+  location /health-check/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;
 
-    proxy_pass http://127.0.0.1:8000/;
+    proxy_pass http://127.0.0.1:8000/health-check/;
 
     break;
   }

--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -156,7 +156,7 @@ app_server_load_balancer = t.add_resource(elb.LoadBalancer(
         )
     ],
     HealthCheck=elb.HealthCheck(
-        Target="HTTP:80/health-check",
+        Target="HTTP:80/health-check/",
         HealthyThreshold="3",
         UnhealthyThreshold="2",
         Interval="30",

--- a/src/nyc_trees/apps/home/urls.py
+++ b/src/nyc_trees/apps/home/urls.py
@@ -19,6 +19,8 @@ urlpatterns = patterns(
     '',
     url(r'^$', r.home_page, name='home_page'),
 
+    url(r'^health-check/$', include('watchman.urls')),
+
     url(r'^individual-mapper-instructions/$',
         r.individual_mapper_instructions,
         name='individual_mapper_instructions'),

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -221,6 +221,7 @@ THIRD_PARTY_APPS = (
     'django_statsd',
     'floppyforms',
     'waffle',
+    'watchman',
 )
 
 # THIRD-PARTY CONFIGURATION
@@ -311,4 +312,5 @@ SOFT_LAUNCH_REGEXES = [
     r'^/user/',
     r'^/accounts/',
     r'^/admin/',
+    r'^/health-check/',
 ]

--- a/src/nyc_trees/requirements/base.txt
+++ b/src/nyc_trees/requirements/base.txt
@@ -12,3 +12,4 @@ django-statsd-mozilla==0.3.14
 python-omgeo==1.7.1
 pytz==2014.10
 django-waffle==0.10.1
+django-watchman==0.5.0


### PR DESCRIPTION
This changeset wires up [Watchman](http://django-watchman.readthedocs.org/en/latest/index.html) to the `/health-check/` application route. Nginx reverse proxies requests to `/health-check/` directly to it, bypassing HTTPS redirects. The application Elastic Load Balancer (ELB) is also setup to use this new endpoint.

In addition, the default Watchman route was also added to `SOFT_LAUNCH_REGEXES` so that it can bypass feature flags.

First pass at resolving #232.