### PR TITLE
Allow saving updated group territory

### DIFF
--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -42,10 +42,10 @@ def get_context_for_territory_survey_layer(request, group_id):
     return _get_context_for_layer("territory_survey", models, request, params)
 
 
-def get_context_for_territory_admin_layer(request):
+def get_context_for_territory_admin_layer(request, group_id):
     models = [Blockface, Territory, BlockfaceReservation]
-    return _get_context_for_layer("territory_admin", models, request, '?')
-    # Note: client will add group=<group_id>
+    params = '?group=%s' % group_id
+    return _get_context_for_layer("territory_admin", models, request, params)
 
 
 def _get_context_for_layer(layer_name, models, request, params=''):

--- a/src/nyc_trees/apps/survey/templates/survey/admin_territory.html
+++ b/src/nyc_trees/apps/survey/templates/survey/admin_territory.html
@@ -44,9 +44,7 @@
 
 {% block main %}
 
-<div id="map" class="map-event"
-     data-tile-url="{{ layer.tile_url }}"
-     data-grid-url="{{ layer.grid_url }}"></div>
+<div id="map" class="map-event"></div>
 
 {% endblock main %}
 

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -31,8 +31,7 @@ from apps.survey.models import (BlockfaceReservation, Blockface, Territory,
 from apps.survey.layer_context import (get_context_for_reservations_layer,
                                        get_context_for_reservable_layer,
                                        get_context_for_progress_layer,
-                                       get_context_for_territory_survey_layer,
-                                       get_context_for_territory_admin_layer)
+                                       get_context_for_territory_survey_layer)
 from apps.survey.helpers import (teammates_for_event,
                                  teammates_for_individual_mapping)
 
@@ -345,8 +344,9 @@ def survey_detail(request, survey_id):
 
 
 def admin_territory_page(request):
+    groups = Group.objects.all().order_by('name')
     context = {
-        'groups': Group.objects.all().order_by('name'),
+        'groups': groups,
         'legend_entries': [
             {'css_class': 'available', 'label': 'Available'},
             {'css_class': 'reserved',
@@ -357,7 +357,6 @@ def admin_territory_page(request):
             {'css_class': 'surveyed-by-others', 'label': 'Mapped by others'},
         ]
     }
-    context['layer'] = get_context_for_territory_admin_layer(request)
     return context
 
 

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -56,3 +56,7 @@ request_mapper_status = do(
 group_unmapped_territory_geojson = route(
     POST=census_admin_do(json_api_call,
                          v.group_unmapped_territory_geojson))
+
+group_update_territory = route(
+    POST=census_admin_do(json_api_call,
+                         v.group_update_territory))

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -45,4 +45,8 @@ urlpatterns = patterns(
     url(r'^(?P<group_id>\d+)/territory.json/$',
         r.group_unmapped_territory_geojson,
         name='group_unmapped_territory_geojson'),
+
+    url(r'^(?P<group_id>\d+)/update-territory/$',
+        r.group_update_territory,
+        name='group_update_territory'),
 )

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -128,9 +128,8 @@ function initCrosshairs(domId) {
     $map.append([$hHair, $vHair]);
 }
 
-function addTileLayer(map, queryString) {
-    var query = queryString || '',
-        tileUrl = getDomMapAttribute('tile-url') + query,
+function addTileLayer(map, url) {
+    var tileUrl = url || getDomMapAttribute('tile-url'),
         layer = L.tileLayer(tileUrl, {
             minZoom: zoom.MIN,
             maxZoom: zoom.MAX
@@ -138,9 +137,8 @@ function addTileLayer(map, queryString) {
     return layer;
 }
 
-function addGridLayer(map, queryString) {
-    var query = queryString || '',
-        gridUrl = getDomMapAttribute('grid-url') + query,
+function addGridLayer(map, url) {
+    var gridUrl = url || getDomMapAttribute('grid-url'),
         layer = L.utfGrid(gridUrl, {
             minZoom: zoom.MIN,
             maxZoom: zoom.MAX,


### PR DESCRIPTION
* "Save" button posts currently-selected blockface ids to `group_update_territory` endpoint,
  which adds/removes appropriate `Territory` records.
* We need new tiler URLs after saving. So, change to return full tiler URLs along with
  Ajax data instead of stashing them on the map object.
* "Are you sure?" confirmation if user reverts, changes group, or leaves page.
* Disable controls (save, revert, change group, click blockface) during Ajax requests
* Refactor and simplify `adminTerritoryPage.js`