### PR TITLE
Only show available blocks on survey layer

### DIFF
--- a/src/tiler/sql/user_reservations.sql
+++ b/src/tiler/sql/user_reservations.sql
@@ -2,7 +2,7 @@
   <% if (is_utf_grid) { %>
   ST_AsGeoJSON(block.geom) AS geojson,
   <% } %>
-  block.geom, block.id, CASE WHEN reservation.user_id = <%= user_id %> THEN  'reserved' ELSE 'unavailable' END as survey_type
+  block.geom, block.id, CASE WHEN block.is_available AND reservation.user_id = <%= user_id %> THEN  'reserved' ELSE 'unavailable' END as survey_type
   FROM survey_blockface AS block
   LEFT OUTER JOIN survey_blockfacereservation AS reservation
     ON (block.id = reservation.blockface_id


### PR DESCRIPTION
Once a block is surveyed we flip ``is_available`` to false. The layer we use to show mappers their options should show completed blocks as unavailable.
Fixes #723 
Fixes #764 