### PR TITLE
Prevent selecting unavailable blocks on survey

### DIFF
--- a/src/tiler/sql/user_reservations.sql
+++ b/src/tiler/sql/user_reservations.sql
@@ -10,6 +10,6 @@
         AND reservation.user_id = <%= user_id %>
         AND reservation.expires_at > now() at time zone 'utc')
   <% if (is_utf_grid) { %>
-    WHERE reservation.user_id = <%= user_id %>
+    WHERE block.is_available AND reservation.user_id = <%= user_id %>
   <% } %>
 ) AS query


### PR DESCRIPTION
In a previous commit I changed the color of the block but forgot to extend the filtering to the UTF grid.

Fixes #776 