### PR TITLE
Add support for setting Django site domain

### DIFF
--- a/deployment/MIGRATIONS.md
+++ b/deployment/MIGRATIONS.md
@@ -63,7 +63,7 @@ $ ssh 10.0.1.191
 After successfully connecting to an application server, run `setupdb.sh`:
 
 ```bash
-$ /opt/nyc-trees/scripts/aws/setupdb.sh
+$ DJANGO_SITE_DOMAIN="treescount.foo.com" /opt/nyc-trees/scripts/aws/setupdb.sh
 ```
 
 This script will:

--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -28,3 +28,11 @@ fi
 
 # Create training flatpages
 envdir /etc/nyc-trees.d/env /opt/app/manage.py make_training_flatpages || true
+
+# If a domain is not provided, default to treescount.nycgovparks.org
+DJANGO_SITE_DOMAIN=${DJANGO_SITE_DOMAIN:-treescount.nycgovparks.org}
+
+# Set django_sites name and domain
+envdir /etc/nyc-trees.d/env /opt/app/manage.py set_django_site_domain \
+    --django-site-name="${DJANGO_SITE_DOMAIN}" \
+    --django-site-domain="${DJANGO_SITE_DOMAIN}"

--- a/src/nyc_trees/apps/home/management/commands/set_django_site_domain.py
+++ b/src/nyc_trees/apps/home/management/commands/set_django_site_domain.py
@@ -1,0 +1,29 @@
+from optparse import make_option
+
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Used to set django_site domain and name'
+
+    option_list = BaseCommand.option_list + (
+        make_option('--django-site-name',
+                    action='store',
+                    dest='django_site_name',
+                    default='treescount.nycgovparks.org',
+                    help='Sets the default site name. Defaults to '
+                         '"treescount.nycgovparks.org"'),
+        make_option('--django-site-domain',
+                    action='store',
+                    dest='django_site_domain',
+                    default='treescount.nycgovparks.org',
+                    help='Sets the default site domain. Defaults to '
+                         '"treescount.nycgovparks.org"'),
+        )
+
+    def handle(self, *args, **options):
+        site = Site.objects.get_current()
+        site.name = options.get('django_site_name')
+        site.domain = options.get('django_site_domain')
+        site.save()


### PR DESCRIPTION
This change adds support for setting the `name` and `domain` of the default site in `django_site`. Support has been added via `setupdb.sh`, which depends on the existence of a Django management command called `set_django_site_domain`.

If no name or domain is passed to `setupdb.sh` or the Django management command, then it defaults to `treescount.nycgovparks.org`.

A codified solution to https://github.com/azavea/nyc-trees/issues/393.