### PR TITLE
Add Bronx data to blockface fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,64 @@ In order to speed up things up, you may want to consider using a local caching p
 $ VAGRANT_PROXYCONF_ENDPOINT="http://192.168.96.10:8123/" vagrant up
 ```
 
+## Data
+
+The blockface data is being provided in borough-level
+shapefiles. These shapefiles are in a state plane projection that is
+not installed in PostGIS by default. The projection can be installed
+with the following SQL:
+
+```sql
+-- Reference: http://spatialreference.org/ref/esri/nad-1983-stateplane-new-york-long-island-fips-3104-feet/postgis/
+DELETE from spatial_ref_sys WHERE srid = 102718;
+INSERT into spatial_ref_sys (srid, auth_name, auth_srid, proj4text,
+srtext) values ( 102718, 'esri', 102718, '+proj=lcc
++lat_1=40.66666666666666 +lat_2=41.03333333333333
++lat_0=40.16666666666666 +lon_0=-74 +x_0=300000 +y_0=0 +ellps=GRS80
++datum=NAD83 +to_meter=0.3048006096012192 +no_defs ',
+'PROJCS["NAD_1983_StatePlane_New_York_Long_Island_FIPS_3104_Feet",GEOGCS["GCS_North_American_1983",DATUM["North_American_Datum_1983",SPHEROID["GRS_1980",6378137,298.257222101]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["False_Easting",984249.9999999999],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-74],PARAMETER["Standard_Parallel_1",40.66666666666666],PARAMETER["Standard_Parallel_2",41.03333333333333],PARAMETER["Latitude_Of_Origin",40.16666666666666],UNIT["Foot_US",0.30480060960121924],AUTHORITY["EPSG","102718"]]');
+
+```
+
+The borough shapefiles can be loaded into the database with ``shp2pgsql``:
+
+```
+shp2pgsql -s 102718:4326 -g geom ManhattanSegments_Compiled.shp > psql -d nyc_trees
+```
+
+The borough blockfaces can be appended to the ``survey_blockface`` table with the following SQL:
+
+```sql
+
+INSERT INTO survey_blockface (
+  is_available,
+  created_at,
+  updated_at,
+  expert_required,
+  geom
+)
+(
+SELECT
+  TRUE,
+  now() at time zone 'utc',
+  now() at time zone 'utc',
+  CASE WHEN expertmapp = 1 THEN TRUE ELSE FALSE END,
+  geom
+FROM bronx_compiled
+WHERE geom IS NOT NULL
+);
+
+```
+
+On deployment the blockfaces are loaded from the
+``src/nyc_trees/apps/survey/fixtures/blockface.json`` fixture. This fixture is maintained by filling the ``survey_blockface`` table with
+the appropriate data, then exporting the fixture:
+
+```
+./scripts/manage.sh dumpdata survey.Blockface > src/nyc_trees/apps/survey/fixtures/blockface.json
+```
+
+
 ## Testing
 
 In order to simulate the testing environment used in CI, bring up the testing environment with:


### PR DESCRIPTION
Includes an update to README.md explaining the data processing steps.

To test, wipe and reload your survey data with ``./scripts/manage.sh reload_dev_data`` then verify that the Bronx blockfaces are now visible on the progress map.