### PR TITLE
Add support for a Redis backed cache

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,4 +1,4 @@
-azavea.apache2,0.2.1
+azavea.apache2,0.2.2
 azavea.ntp,0.1.0
 azavea.pip,0.1.0
 azavea.nodejs,0.3.0

--- a/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/defaults/main.yml
@@ -11,6 +11,8 @@ app_config:
   - { file: "NYC_TREES_DB_PORT", content: "{{ postgresql_port }}" }
   - { file: "NYC_TREES_TEST_DB_NAME", content: "{{ django_test_database }}" }
   - { file: "NYC_TREES_STATSD_HOST", content: "{{ statsite_host }}" }
+  - { file: "NYC_TREES_CACHE_HOST", content: "{{ redis_host }}" }
+  - { file: "NYC_TREES_CACHE_PORT", content: "{{ redis_port }}" }
   - { file: "DJANGO_SETTINGS_MODULE", content: "{{ django_settings_module }}" }
   - { file: "DJANGO_STATIC_ROOT", content: "{{ app_static_root }}" }
   - { file: "DJANGO_MEDIA_ROOT", content: "{{ app_media_root }}" }

--- a/deployment/ansible/roles/nyc-trees.tiler/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/defaults/main.yml
@@ -9,8 +9,8 @@ tiler_config:
   - { file: "NYC_TREES_DB_HOST", content: "{{ postgresql_host }}" }
   - { file: "NYC_TREES_DB_PORT", content: "{{ postgresql_port }}" }
   - { file: "NYC_TREES_STATSD_HOST", content: "{{ statsite_host }}" }
-  - { file: "NYC_TREES_REDIS_HOST", content: "{{ redis_host }}" }
-  - { file: "NYC_TREES_REDIS_PORT", content: "{{ redis_port }}" }
+  - { file: "NYC_TREES_CACHE_HOST", content: "{{ redis_host }}" }
+  - { file: "NYC_TREES_CACHE_PORT", content: "{{ redis_port }}" }
 
 tiler_log: /var/log/nyc-trees-tiler.log
 tiler_log_rotate_count: 5

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -40,6 +40,7 @@ STATSD_PREFIX = 'django'
 STATSD_HOST = environ.get('NYC_TREES_STATSD_HOST', 'localhost')
 # END STATSD CONFIGURATION
 
+
 # EMAIL CONFIGURATION
 DEFAULT_FROM_EMAIL = 'treescount.help@parks.nyc.gov'
 # END EMAIL CONFIGURATION
@@ -47,6 +48,27 @@ DEFAULT_FROM_EMAIL = 'treescount.help@parks.nyc.gov'
 # FILE STORAGE CONFIGURATION
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 # END FILE STORAGE CONFIGURATION
+
+# CACHE CONFIGURATION
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        # The Redis database at index 0 is used by Logstash/Beaver
+        'LOCATION': 'redis://{0}:{1}/1'.format(
+            environ.get('NYC_TREES_CACHE_HOST', 'localhost'),
+            environ.get('NYC_TREES_CACHE_PORT', 6379)),
+        'OPTIONS': {
+            'PARSER_CLASS': 'redis.connection.HiredisParser',
+            'SOCKET_TIMEOUT': 3,
+        }
+    }
+}
+
+# Don't throw exceptions if Redis is down.
+DJANGO_REDIS_IGNORE_EXCEPTIONS = True
+# END CACHE CONFIGURATION
+
 
 # DATABASE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases

--- a/src/nyc_trees/nyc_trees/settings/development.py
+++ b/src/nyc_trees/nyc_trees/settings/development.py
@@ -18,16 +18,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # END EMAIL CONFIGURATION
 
 
-# CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-# END CACHE CONFIGURATION
-
-
 # TOOLBAR CONFIGURATION
 # See https://github.com/django-debug-toolbar/django-debug-toolbar#installation
 INSTALLED_APPS += (

--- a/src/nyc_trees/nyc_trees/settings/production.py
+++ b/src/nyc_trees/nyc_trees/settings/production.py
@@ -47,16 +47,6 @@ EMAIL_BOTO_CHECK_QUOTA = False
 # END EMAIL CONFIGURATION
 
 
-# CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-# END CACHE CONFIGURATION
-
-
 # SECRET CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = get_env_setting('DJANGO_SECRET_KEY')

--- a/src/nyc_trees/nyc_trees/settings/test.py
+++ b/src/nyc_trees/nyc_trees/settings/test.py
@@ -9,6 +9,12 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
 SELENIUM_DEFAULT_BROWSER = 'firefox'
 SELENIUM_TEST_COMMAND_OPTIONS = {'pattern': 'uitest*.py'}
 

--- a/src/nyc_trees/requirements/base.txt
+++ b/src/nyc_trees/requirements/base.txt
@@ -13,3 +13,5 @@ python-omgeo==1.7.1
 pytz==2014.10
 django-waffle==0.10.1
 django-watchman==0.5.0
+django-redis==3.8.3
+hiredis==0.1.6

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -11,8 +11,8 @@ var Windshaft = require('windshaft'),
     dbHost = process.env.NYC_TREES_DB_HOST || 'localhost',
     dbPort = process.env.NYC_TREES_DB_PORT || 5432,
 
-    redisHost = process.env.NYC_TREES_REDIS_HOST || 'localhost',
-    redisPort = process.env.NYC_TREES_REDIS_PORT || 6379,
+    redisHost = process.env.NYC_TREES_CACHE_HOST || 'localhost',
+    redisPort = process.env.NYC_TREES_CACHE_PORT || 6379,
 
     statsdHost = process.env.NYC_TREES_STATSD_HOST || 'localhost',
     statsdPort = process.env.NYC_TREES_STATSD_PORT || 8125,


### PR DESCRIPTION
This changeset adds a Redis backed cache to all environments other than testing. Non-default settings include:

- The Hiredis parser is being used
- Socket timeout is explicitly set to 3
- Connection failure exceptions are suppressed
- The Redis database at index 1 is being used

Attempts to resolve #169.