### PR TITLE
Ensure that FileSystemStorage is the default

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -44,6 +44,10 @@ STATSD_HOST = environ.get('NYC_TREES_STATSD_HOST', 'localhost')
 DEFAULT_FROM_EMAIL = 'treescount.help@parks.nyc.gov'
 # END EMAIL CONFIGURATION
 
+# FILE STORAGE CONFIGURATION
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+# END FILE STORAGE CONFIGURATION
+
 # DATABASE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {


### PR DESCRIPTION
This changeset explicitly sets the default file storage backend to the file system. Mostly doing this so that we're careful about how we introduce S3 storage support.