### PR TITLE
Hide inactive groups from most users

### DIFF
--- a/src/nyc_trees/apps/event/event_list.py
+++ b/src/nyc_trees/apps/event/event_list.py
@@ -236,6 +236,7 @@ def immediate_events(request):
     seven_days = relativedelta(days=7)
     nowish = (Event.objects
               .filter(is_private=False,
+                      group__is_active=True,
                       ends_at__gt=now(),
                       ends_at__lte=now() + seven_days)
               .order_by('begins_at'))
@@ -253,4 +254,5 @@ def immediate_events(request):
 @EventList
 def all_events(request):
     return Event.objects.filter(is_private=False,
+                                group__is_active=True,
                                 ends_at__gt=now()).order_by('begins_at')

--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -143,8 +143,10 @@ def events_list_page(request):
 
 
 def future_events_geojson(request):
-    return [_event_geojson(e) for e
-            in Event.objects.filter(ends_at__gt=now()).select_related('group')]
+    events = Event.objects.filter(
+        ends_at__gt=now(), group__is_active=True).select_related('group')
+
+    return [_event_geojson(e) for e in events]
 
 
 def _event_geojson(event):
@@ -168,6 +170,8 @@ def events_list_page_partial(request):
 
 def events_list_feed(request):
     site_domain = Site.objects.get_current().domain
+    events = Event.objects.order_by('-begins_at').filter(is_private=False,
+                                                         group__is_active=True)
 
     return [{
         'id': e.id,
@@ -185,7 +189,7 @@ def events_list_feed(request):
             "address": e.address,
         }],
         'links': [{'link_url': site_domain + e.get_absolute_url()}],
-    } for e in Event.objects.order_by('-begins_at').filter(is_private=False)]
+    } for e in events]
 
 
 def delete_event(request, event_slug):

--- a/src/nyc_trees/apps/survey/templates/survey/partials/progress_page_blockface_popup.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/progress_page_blockface_popup.html
@@ -1,28 +1,31 @@
 <div class="row">
     <div class="col-xs-12">
         Blockface
-        {% if survey_type == "available" %}
+        {% if is_active and survey_type == "available" %}
             available.
             <a href="">Reserve it</a>.
         {% elif survey_type == "reserved" %}
             reserved by you.
         {% elif survey_type == "unavailable" %}
-            reserved by
+            reserved
         {% elif survey_type == "surveyed-by-me" %}
             mapped by you.
         {% elif survey_type == "surveyed-by-others" %}
-            mapped by
+            mapped
         {% else %}
             unavailable.
         {% endif %}
 
-        {% if survey_type == "surveyed-by-others" or survey_type == "unavailable" %}
-            {% if group.slug %}
-                <a class="btn btn-link" href="{% url 'group_detail' group_slug=group.slug %}">
-                    {{ group.name }}
-                </a>
-            {% else %}
-                an individual mapper.
+        {% if is_active %}
+            {% if survey_type == "surveyed-by-others" or survey_type == "unavailable" %}
+                by
+                {% if group.slug %}
+                    <a class="btn btn-link" href="{% url 'group_detail' group_slug=group.slug %}">
+                        {{ group.name }}
+                    </a>
+                {% else %}
+                    an individual mapper.
+                {% endif %}
             {% endif %}
         {% endif %}
     </div>

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -16,6 +16,7 @@ from django.utils.timezone import now
 
 from apps.core.models import Group
 from apps.core.views import map_legend
+from apps.core.helpers import user_is_group_admin
 
 from apps.event.models import Event
 from apps.event.helpers import user_is_checked_in_to_event
@@ -53,9 +54,14 @@ def progress_page_blockface_popup(request, blockface_id):
     survey_type = request.GET.get('survey_type')
     group_id = request.GET.get('group_id', None)
     group = get_object_or_404(Group, id=group_id) if group_id else None
+
+    is_active = (group is None or group.is_active or
+                 user_is_group_admin(request.user, group))
+
     return {
         'survey_type': survey_type,
-        'group': group
+        'group': group,
+        'is_active': is_active
     }
 
 


### PR DESCRIPTION
 - Hides inactive groups from the group listing page
 - Hides inactive group's events from the event list
 - Only allows group admins access to the group detail for inactive groups
 - Makes blockfaces appear unavailable on the progress and reservations
   maps unless the user is a trusted mapper or admin of the inactive group

Fixes #741