### PR TITLE
Bump default version of Kibana to 4.0.1

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -10,7 +10,7 @@ azavea.nginx,0.2.0
 azavea.mapnik,0.1.0
 azavea.logstash,0.1.0
 azavea.relp,0.1.1
-azavea.kibana,0.2.1
+azavea.kibana,0.3.1
 azavea.unzip,0.1.0
 azavea.graphite,0.4.0
 azavea.statsite,0.1.1
@@ -18,7 +18,7 @@ azavea.daemontools,0.1.0
 azavea.collectd,0.2.0
 azavea.git,0.1.0
 azavea.pgweb,0.1.1
-azavea.elasticsearch,0.1.0
+azavea.elasticsearch,0.2.0
 azavea.java,0.1.1
 azavea.curator,0.1.0
 azavea.ruby,0.3.0


### PR DESCRIPTION
See also: https://github.com/azavea/ansible-kibana/pull/5