### PR TITLE
Set PostgreSQL log_min_duration_statement setting

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -7,6 +7,7 @@ postgresql_listen_addresses: "*"
 postgresql_username: nyc_trees
 postgresql_password: nyc_trees
 postgresql_database: nyc_trees
+postgresql_log_min_duration_statement: 500
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "33.33.33.1/24", method: "md5" }
   - { type: "host", database: "all", user: "all", address: "10.0.2.0/24", method: "md5" }

--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -195,6 +195,15 @@ database_server_subnet_group = t.add_resource(rds.DBSubnetGroup(
     Tags=Tags(Name='dbsngDatabaseServer')
 ))
 
+database_server_parameter_group = t.add_resource(rds.DBParameterGroup(
+    'dbpgDatabaseServer',
+    Family='postgres9.3',
+    Description='Parameter group for the RDS instances',
+    Parameters={
+        'log_min_duration_statement': '500'
+    }
+))
+
 database_server_instance = t.add_resource(rds.DBInstance(
     "DatabaseServer",
     AllocatedStorage=20,
@@ -204,6 +213,7 @@ database_server_instance = t.add_resource(rds.DBInstance(
     DBInstanceClass=Ref(database_server_instance_type_param),
     DBInstanceIdentifier='nyctrees-nyc-trees-database-server',
     DBName='nyc_trees',
+    DBParameterGroupName=Ref(database_server_parameter_group),
     DBSubnetGroupName=Ref(database_server_subnet_group),
     Engine='postgres',
     EngineVersion='9.3.5',


### PR DESCRIPTION
This changeset sets the `log_min_duration_statement` to `500` milliseconds within the PostgreSQL instance on Vagrant and RDS.