### PR TITLE
Remove device settings from Collectd df plugin

### DIFF
--- a/deployment/ansible/roles/nyc-trees.collectd/templates/df.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.collectd/templates/df.conf.j2
@@ -1,4 +1,3 @@
 <Plugin df>
-	Device "/dev/sda1"
 	ReportInodes true
 </Plugin>

--- a/deployment/ansible/roles/nyc-trees.graphite/templates/df.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.graphite/templates/df.conf.j2
@@ -1,4 +1,3 @@
 <Plugin df>
-	Device "/dev/sda1"
 	ReportInodes true
 </Plugin>


### PR DESCRIPTION
This changeset removes the `Device` setting from the Collectd plugin because Collectd intelligently collects metrics from all mounted devices automatically.