### PR TITLE
Add updated Amazon RDS certificate bundle to all instances

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -28,3 +28,4 @@ azavea.swapfile,0.1.0
 azavea.build-essential,0.1.0
 azavea.tasseo,0.1.1
 azavea.phantomjs,0.1.0
+azavea.rds-ca-bundle,0.1.0

--- a/deployment/ansible/roles/nyc-trees.common/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.common/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - { role: "azavea.ntp" }
+  - { role: "azavea.rds-ca-bundle", when: "['packer'] | is_in(group_names)" }
   - { role: "azavea.git" }
   - { role: "nyc-trees.nginx", when: "['monitoring-servers'] | is_not_in(group_names)" }
   - { role: "azavea.daemontools", when: "['monitoring-servers'] | is_not_in(group_names)" }


### PR DESCRIPTION
This changeset adds the updated Amazon RDS certificate bundle to all instances so that they can securely communicate with RDS after 23 Mar 2015.

See also: https://forums.aws.amazon.com/ann.jspa?annID=2889