### PR TITLE
Allow a view to return a PDF version of a webpage

### DIFF
--- a/src/nyc_trees/apps/event/routes.py
+++ b/src/nyc_trees/apps/event/routes.py
@@ -62,9 +62,9 @@ event_registration = do(login_required,
                         route(POST=v.register_for_event,
                               DELETE=v.cancel_event_registration))
 
-start_event_map_print_job = do(group_request,
-                               user_must_have_online_training,
-                               route(POST=v.start_event_map_print_job))
+printable_event_map = do(group_request,
+                         user_must_have_online_training,
+                         route(GET=v.printable_event_map))
 
 event_admin_check_in_page = group_admin_do(
     route(GET=do(render_template('event/admin_checkin.html'),

--- a/src/nyc_trees/apps/event/urls/group.py
+++ b/src/nyc_trees/apps/event/urls/group.py
@@ -7,7 +7,7 @@ from django.conf.urls import patterns, url
 
 from apps.event.routes import (add_event, event_detail,
                                event_edit, event_popup_partial,
-                               event_registration, start_event_map_print_job,
+                               event_registration, printable_event_map,
                                event_admin_check_in_page,
                                check_in_user_to_event,
                                email_event_registered_users, event_email,
@@ -36,8 +36,8 @@ urlpatterns = patterns(
         event_registration, name='event_registration'),
 
     url(r'^(?P<group_slug>[\w-]+)/event/'
-        r'(?P<event_slug>[\w-]+)/printable-map/$',
-        start_event_map_print_job, name='start_event_map_print_job'),
+        '(?P<event_slug>[\w-]+)/printable-map/$',
+        printable_event_map, name='printable_event_map'),
 
     url(r'^(?P<group_slug>[\w-]+)/event/(?P<event_slug>[\w-]+)/checkin/$',
         event_admin_check_in_page, name='event_admin_check_in_page'),

--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -7,7 +7,7 @@ from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.http import (HttpResponseRedirect, HttpResponseForbidden,
-                         HttpResponseNotAllowed)
+                         HttpResponseNotAllowed, HttpResponse)
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.timezone import get_current_timezone, now
 
@@ -23,6 +23,8 @@ from apps.event.event_list import (EventList, immediate_events, all_events)
 from apps.core.helpers import user_is_group_admin
 from apps.event.helpers import (user_is_rsvped_for_event,
                                 user_is_checked_in_to_event)
+
+from libs.phantomjs import url_to_pdf
 
 
 def add_event(request):
@@ -241,9 +243,11 @@ def cancel_event_registration(request, event_slug):
     return event_detail(request, event_slug)
 
 
-def start_event_map_print_job(request, event_slug):
-    # TODO: implement
-    pass
+def printable_event_map(request, event_slug):
+    # TODO: use URL of a page designed to show a printable event map
+    url = 'http://localhost/blockface/progress/'
+    pdf_bytes = url_to_pdf(url)
+    return HttpResponse(pdf_bytes, content_type="application/pdf")
 
 
 def event_admin_check_in_page(request, event_slug):

--- a/src/nyc_trees/js/backend/url2pdf.js
+++ b/src/nyc_trees/js/backend/url2pdf.js
@@ -1,0 +1,43 @@
+// Based on https://github.com/ariya/phantomjs/blob/master/examples/rasterize.js
+
+var page = require('webpage').create(),
+    system = require('system');
+
+if (system.args.length !== 3) {
+    console.log('Usage: url2pdf.js url zoomFactor');
+    phantom.exit(1);
+}
+
+var url = system.args[1],
+    zoomFactor = system.args[2];
+
+// The PhantomJS documentation doesn't explain the relationship between
+// viewportSize and paperSize for PDF output. One would imagine that
+// the page is rendered to a bitmap whose size is the viewportSize,
+// and the bitmap is then rendered to the PDF at some DPI resolution.
+// It doesn't appear to be that simple, at least when rendering Leaflet maps.
+// However, using 96 DPI gives a reasonable result.
+
+var DPI = 96;
+page.viewportSize = {
+    width: 7.5 * DPI,  // 8.5in with .5in margins
+    height: 10 * DPI   //  11in with .5in margins
+};
+page.paperSize = {
+    format: 'letter',
+    orientation: 'portrait',
+    margin: '0.5in'
+};
+page.zoomFactor = zoomFactor;
+
+page.open(url, function (status) {
+    if (status !== 'success') {
+        console.log('Unable to load given URL.');
+        phantom.exit(2);
+    } else {
+        window.setTimeout(function () {
+            page.render('/dev/stdout', { format: 'pdf' });
+            phantom.exit();
+        }, 200);
+    }
+});

--- a/src/nyc_trees/libs/phantomjs.py
+++ b/src/nyc_trees/libs/phantomjs.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def url_to_pdf(url, zoom_factor=0.75):
+    # The default zoom was chosen so that labels on map tiles
+    # will be a readable size when printed.
+    pdf_bytes = subprocess.check_output(
+        ['phantomjs', 'js/backend/url2pdf.js', url, str(zoom_factor)])
+    return pdf_bytes


### PR DESCRIPTION
To test, browse to an event detail page and append "/printable-map/" to the URL
(e.g. `/group/east-side-mappers/event/map-a-maple/printable-map/`).

Currently as a proof of concept the test endpoint returns a PDF showing the progress page.
That page has some problems (image doesn't fill the page; scrollbar shown),
but those problems go away when rendering a map which fills the entire page.

We will need to design print-oriented views for the maps we want to print.