### PR TITLE
Change database storage type to SSD

### DIFF
--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -222,6 +222,7 @@ database_server_instance = t.add_resource(rds.DBInstance(
     MultiAZ=True,
     PreferredBackupWindow='01:00-01:30',  # 9:00-9:30PM ET
     PreferredMaintenanceWindow='mon:01:30-mon:02:30',  # 9:30PM-10:30PM ET
+    StorageType='gp2',
     VPCSecurityGroups=[Ref(database_server_security_group)],
     Tags=Tags(Name='DatabaseServer')
 ))


### PR DESCRIPTION
This changes the database storage type to SSD (`gp2` for general purpose SSD storage).

Before applying this to staging:

- [x] Take a `pg_dump` of the staging database
- [x] Pull database backup down locally