### PR TITLE
removed unnecessary classes - fixed 1px gap in btn-groups - fixes #832

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
@@ -1,7 +1,7 @@
 <legend>{{ label }}</legend>
 <div class="field">
 
-    <div class="btn-group btn-group-{{ choices|length }}">
+    <div class="btn-group btn-group-toggles">
         {% for value, label in choices %}
             {# NOTE: For the styling to work correctly, the label must come directly after the radio #}
             <input id="{{ field }}-{{ value }}-{{ tree_number }}" required type="radio" name="{{ field }}" value="{{ value }}" />

--- a/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
@@ -97,7 +97,7 @@
             <div class="field">
                 {% for group_label, group_choices in choices.problem_groups %}
                     <label>{{ group_label }}</label>
-                    <div class="btn-group btn-group-3">
+                    <div class="btn-group btn-group-toggles">
                         {% for value, label in group_choices %}
                             <input id="problems-{{ value }}-{{ tree_number }}" required type="checkbox" name="problems" value="{{ value }}" />
                             <label class="btn btn-switch" for="problems-{{ value }}-{{ tree_number }}">

--- a/src/nyc_trees/sass/partials/_buttons.scss
+++ b/src/nyc_trees/sass/partials/_buttons.scss
@@ -5,22 +5,20 @@
   }
 }
 
-@for $i from 2 through 4 {
-  .btn-group-#{$i}, .btn-group-toggles {
-    vertical-align: middle;
-    display: table;
-    width: 100%;
-    table-layout: fixed;
-    border-collapse: separate;
-    min-height: 45px;
+.btn-group-toggles {
+  vertical-align: middle;
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+  min-height: 45px;
 
-    .btn {
-      display: table-cell;
-      float: none;
-      vertical-align: middle;
-      padding: 8px;
-      width: 100%;
-    }
+  .btn {
+    display: table-cell;
+    float: none;
+    vertical-align: middle;
+    padding: 8px;
+    width: 100%;
   }
 }
 

--- a/src/nyc_trees/sass/partials/_buttons.scss
+++ b/src/nyc_trees/sass/partials/_buttons.scss
@@ -6,7 +6,7 @@
 }
 
 @for $i from 2 through 4 {
-  .btn-group-#{$i} {
+  .btn-group-#{$i}, .btn-group-toggles {
     vertical-align: middle;
     display: table;
     width: 100%;
@@ -19,25 +19,8 @@
       float: none;
       vertical-align: middle;
       padding: 8px;
+      width: 100%;
     }
-  }
-}
-
-.btn-group-2 {
-  .btn {
-    width: 50%;
-  }
-}
-
-.btn-group-3 {
-  .btn {
-    width: 33.334%;
-  }
-}
-
-.btn-group-4 {
-  .btn {
-    width: 25%;
   }
 }
 


### PR DESCRIPTION
Apparently by adding a width of 100% the pixel gap is removed and the buttons still retain appropriate width. This is expected behavior, but was not working initially when first working through the issue.