### PR TITLE
Style training instructions page

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/training_instructions.html
+++ b/src/nyc_trees/apps/home/templates/home/training_instructions.html
@@ -1,25 +1,42 @@
-{% extends "base.html" %}
+{% extends "base_two_frames.html" %}
 
-{% block content %}
+{% block aside %}
+    <h2>Training</h2>
+    <p class="pageheading-description-detail">
+        Before you're able to RSVP to mapping events you'll need to do the following.
+    </p>
+{% endblock aside %}
 
-{# TODO: Design #}
+{% block main %}
+    <a href="{% url "training_summary_pure" %}" class="training block item">
+        <div class="row">
+            <div class="col-xs-8">
+                <h5>Complete your online training</h5>
+                <div class="h6"></div>
+            </div>
+            <div class="col-xs-4 text-right">
+                {% if step1_complete %}
+                    <i class="icon-check h4"></i>
+                {% else %}
+                    <button class="btn-primary btn">Start</button>
+                {% endif %}
+            </div>
+        </div>
+    </a>
 
-<h2>Training</h2>
-<p>
-Before you're able to RSVP to mapping events you'll need to do the following:
-</p>
-
-<h3>Step #1</h3>
-<p>
-{% if user.online_training_complete %}<s>{% endif %}
-Complete your <a href="{% url "training_summary_pure" %}">online training</a>.
-{% if user.online_training_complete %}</s>{% endif %}
-</p>
-
-<h3>Step #2</h3>
-<p>
-{% if user.field_training_complete %}<s>{% endif %}
-Attend a <a href="{% url "events_list_page" %}?active_filter=training">training event</a>.
-{% if user.field_training_complete %}</s>{% endif %}
-</p>
-{% endblock %}
+    <a href="{% url "events_list_page" %}?active_filter=training" class="training block item{% if not step1_complete %} inactive{% endif %}">
+        <div class="row">
+            <div class="col-xs-8">
+                <h5>Attend a first training event</h5>
+                <div class="h6"></div>
+            </div>
+            <div class="col-xs-4 text-right">
+                {% if step2_complete %}
+                    <i class="icon-check h4"></i>
+                {% elif step1_complete %}
+                    <button class="btn-primary btn">Start</button>
+                {% endif %}
+            </div>
+        </div>
+    </a>
+{% endblock main %}

--- a/src/nyc_trees/apps/home/training/views.py
+++ b/src/nyc_trees/apps/home/training/views.py
@@ -80,4 +80,10 @@ def _quiz_summary(quiz, submitted_answers):
 
 
 def training_instructions(request):
-    return {}
+    user = request.user
+    step1_complete = user.online_training_complete
+    step2_complete = step1_complete and user.field_training_complete
+    return {
+        'step1_complete': step1_complete,
+        'step2_complete': step2_complete,
+    }

--- a/src/nyc_trees/apps/survey/templates/survey/reservations_instructions.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reservations_instructions.html
@@ -18,7 +18,7 @@
                 <div class="h6"></div>
             </div>
             <div class="col-xs-4 text-right">
-                {% if user.online_training_complete %}
+                {% if step1_complete %}
                     <i class="icon-check h4"></i>
                 {% else %}
                     <button class="btn-primary btn">Start</button>
@@ -27,32 +27,32 @@
         </div>
     </a>
 
-    <a href="{% url "events_list_page" %}?active_filter=training" class="training block item{% if not step2_enabled %} inactive{% endif %}">
+    <a href="{% url "events_list_page" %}?active_filter=training" class="training block item{% if not step1_complete %} inactive{% endif %}">
         <div class="row">
             <div class="col-xs-8">
                 <h5>Attend a first training event</h5>
                 <div class="h6"></div>
             </div>
             <div class="col-xs-4 text-right">
-                {% if user.field_training_complete %}
+                {% if step2_complete %}
                     <i class="icon-check h4"></i>
-                {% elif step2_enabled %}
+                {% elif step1_complete %}
                     <button class="btn-primary btn">Start</button>
                 {% endif %}
             </div>
         </div>
     </a>
 
-    <a href="{% url "events_list_page" %}?active_filter=training" class="training block item{% if not step3_enabled %} inactive{% endif %}">
+    <a href="{% url "events_list_page" %}?active_filter=training" class="training block item{% if not step2_complete %} inactive{% endif %}">
         <div class="row">
             <div class="col-xs-8">
                 <h5>Attend a second training event</h5>
                 <div class="h6"></div>
             </div>
             <div class="col-xs-4 text-right">
-                {% if user.attended_at_least_two_events %}
+                {% if step3_complete %}
                     <i class="icon-check h4"></i>
-                {% elif step3_enabled %}
+                {% elif step2_complete %}
                     <button class="btn-primary btn">Start</button>
                 {% endif %}
             </div>
@@ -61,19 +61,17 @@
 
     <form method="POST" action="{% url "request_individual_mapper_status" username=user.username %}">
         {% csrf_token %}
-        <a href="javascript:;" onclick="form.submit()" class="training block item{% if not step4_enabled %} inactive{% endif %}">
+        <a href="javascript:;" onclick="form.submit()" class="training block item{% if not step3_complete %} inactive{% endif %}">
             <div class="row">
                 <div class="col-xs-8">
                     <h5>Request individual mapper status</h5>
                     <div class="h6"></div>
                 </div>
                 <div class="col-xs-4 text-right">
-                    {% if step4_enabled %}
-                        {% if step4_complete %}
-                            <i class="icon-check h4"></i>
-                        {% elif step4_enabled %}
-                            <button class="btn-primary btn">Start</button>
-                        {% endif %}
+                    {% if step4_complete %}
+                        <i class="icon-check h4"></i>
+                    {% elif step3_complete %}
+                        <button class="btn-primary btn">Start</button>
                     {% endif %}
                 </div>
             </div>

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -408,21 +408,14 @@ def admin_blockface_available(request, blockface_id):
 
 
 def reservations_instructions(request):
-    from apps.users import user_profile_context
     user = request.user
-    step1_enabled = not user.online_training_complete
-    step2_enabled = user.online_training_complete
-    step3_enabled = user.online_training_complete and \
-        user.field_training_complete
-    step4_enabled = user.online_training_complete and \
-        user.field_training_complete and \
-        user.attended_at_least_two_events and \
-        user.individual_mapper is None
-    context = user_profile_context(user, user.is_authenticated).copy()
-    context.update({
-        'step1_enabled': step1_enabled,
-        'step2_enabled': step2_enabled,
-        'step3_enabled': step3_enabled,
-        'step4_enabled': step4_enabled,
-    })
-    return context
+    step1_complete = user.online_training_complete
+    step2_complete = step1_complete and user.field_training_complete
+    step3_complete = step2_complete and user.attended_at_least_two_events
+    step4_complete = step3_complete and user.individual_mapper is not None
+    return {
+        'step1_complete': step1_complete,
+        'step2_complete': step2_complete,
+        'step3_complete': step3_complete,
+        'step4_complete': step4_complete,
+    }


### PR DESCRIPTION
This displays the first 2 steps of reservations instructions on the
training instructions page.

Also adds changes from #767 which did not get merged in previously.

Fixes #448

How to test this:
1. Login as a user with no training
2. Click RSVP button on any mapping event