### PR TITLE
Add Celery support to application server

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -3,6 +3,8 @@ django_settings_module: "nyc_trees.settings.development"
 
 redis_bind_address: "0.0.0.0"
 
+celery_log_level: "debug"
+
 postgresql_listen_addresses: "*"
 postgresql_username: nyc_trees
 postgresql_password: nyc_trees

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -4,6 +4,7 @@ django_settings_module: "nyc_trees.settings.development"
 redis_bind_address: "0.0.0.0"
 
 celery_log_level: "debug"
+celery_start_on: "vagrant-mounted"
 
 postgresql_listen_addresses: "*"
 postgresql_username: nyc_trees

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -29,3 +29,4 @@ azavea.build-essential,0.1.0
 azavea.tasseo,0.1.1
 azavea.phantomjs,0.1.0
 azavea.rds-ca-bundle,0.1.0
+azavea.celery,0.1.0

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -29,4 +29,4 @@ azavea.build-essential,0.1.0
 azavea.tasseo,0.1.1
 azavea.phantomjs,0.1.0
 azavea.rds-ca-bundle,0.1.0
-azavea.celery,0.1.0
+azavea.celery,0.1.1

--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -7,3 +7,4 @@ dependencies:
   - { role: "azavea.phantomjs" }
   - { role: "azavea.sauce-connect", when: sauce_labs_api_key_is_defined }
   - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.app.", when: "['test'] | is_not_in(group_names)" }
+  - { role: "nyc-trees.celery" }

--- a/deployment/ansible/roles/nyc-trees.app/tasks/configuration.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/configuration.yml
@@ -20,6 +20,12 @@
         state=present
   when: "['packer'] | is_in(group_names)"
 
+- name: Add Celery user to nyc-trees group
+  user: name=celery
+        append=yes
+        groups=nyc-trees
+        state=present
+
 - name: Create configuration file directory
   file: path={{ app_config_home }}
         owner=root

--- a/deployment/ansible/roles/nyc-trees.celery/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.celery/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.celery" }

--- a/deployment/ansible/roles/nyc-trees.celery/vars/main.yml
+++ b/deployment/ansible/roles/nyc-trees.celery/vars/main.yml
@@ -1,0 +1,5 @@
+---
+celery_dir: "{{ app_home }}"
+celery_bin: "envdir /etc/nyc-trees.d/env celery"
+celery_app: "nyc_trees.celery:app"
+celery_broker_url: "redis://{{ redis_host }}:{{ redis_port }}/2"

--- a/scripts/debugcelery.sh
+++ b/scripts/debugcelery.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Run a celery worker interactively with debug output
+
+set -e
+
+STOP_SERVICE="(sudo service nyc-trees-celery stop || /bin/true)"
+CHANGE_DIR="cd /opt/app/"
+RUN_CELERY="envdir /etc/nyc-trees.d/env celery -A 'nyc_trees.celery:app' worker -l debug"
+
+vagrant ssh app -c "$STOP_SERVICE && $CHANGE_DIR && $RUN_CELERY"

--- a/src/nyc_trees/nyc_trees/__init__.py
+++ b/src/nyc_trees/nyc_trees/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app

--- a/src/nyc_trees/nyc_trees/celery.py
+++ b/src/nyc_trees/nyc_trees/celery.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+
+import os
+
+from celery import Celery
+
+from django.conf import settings
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+                      'nyc_trees.settings.production')
+
+app = Celery('nyc_trees')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -45,9 +45,11 @@ STATSD_HOST = environ.get('NYC_TREES_STATSD_HOST', 'localhost')
 DEFAULT_FROM_EMAIL = 'treescount.help@parks.nyc.gov'
 # END EMAIL CONFIGURATION
 
+
 # FILE STORAGE CONFIGURATION
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 # END FILE STORAGE CONFIGURATION
+
 
 # CACHE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
@@ -68,6 +70,19 @@ CACHES = {
 # Don't throw exceptions if Redis is down.
 DJANGO_REDIS_IGNORE_EXCEPTIONS = True
 # END CACHE CONFIGURATION
+
+
+# CELERY CONFIGURATION
+BROKER_URL = 'redis://{0}:{1}/2'.format(
+    environ.get('NYC_TREES_CACHE_HOST', 'localhost'),
+    environ.get('NYC_TREES_CACHE_PORT', 6379))
+
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+
+STATSD_CELERY_SIGNALS = True
+# END CELERY CONFIGURATION
 
 
 # DATABASE CONFIGURATION


### PR DESCRIPTION
This changeset adds Celery support to the application servers by wiring up a Redis broker and launching a Celery worker on each application server. The workers aren't tied to the application server they colocate with; tasks still flow through a broker that attempts to evenly distribute work.

In addition, Celery signals are configured to emit metrics about job count and duration to Graphite via StatsD/Statsite.

Attempts to resolve #851.