### PR TITLE
Use S3 for persistent file storage on production.

### DIFF
--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -136,6 +136,10 @@ class User(NycModel, AbstractUser):
             not user_is_trusted_mapper(self, group)
 
 
+def _generate_image_filename(group, filename):
+    return 'group_images/{}/{}'.format(group.slug, filename)
+
+
 class Group(NycModel, models.Model):
     name = models.CharField(max_length=255, unique=True)
     # blank=True is valid for 'slug', because we'll automatically create slugs
@@ -149,7 +153,8 @@ class Group(NycModel, models.Model):
     # delete is allowed.
     admin = models.ForeignKey(User, null=True, blank=True,
                               on_delete=models.PROTECT)
-    image = models.ImageField(null=True, blank=True)
+    image = models.ImageField(null=True, blank=True,
+                              upload_to=_generate_image_filename)
     is_active = models.BooleanField(default=True)
     allows_individual_mappers = models.BooleanField(default=False)
     affiliation = models.CharField(max_length=255, default='', blank=True)

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -256,6 +256,13 @@ THIRD_PARTY_APPS = (
 ACCOUNT_ACTIVATION_DAYS = 7
 REGISTRATION_AUTO_LOGIN = True
 
+# django-watchman
+# Disable Storage checking, to avoid creating files on S3 on every health check
+WATCHMAN_CHECKS = (
+    'watchman.checks.caches',
+    'watchman.checks.databases',
+)
+
 # END THIRD-PARTY CONFIGURATION
 
 # Apps specific for this project go here.

--- a/src/nyc_trees/requirements/production.txt
+++ b/src/nyc_trees/requirements/production.txt
@@ -2,3 +2,4 @@
 
 boto==2.34.0
 dnspython>=1.12.0
+django-storages-redux==1.2.2


### PR DESCRIPTION
The VPC id is pulled from the instance metadata and used as the S3 bucket
name, which ensures that staging and production use different S3 buckets
but have identical settings files.

Since we can set the default file storage separately from the storage used
for static assets (JS, CSS, etc.), I decided to make S3 storage the
default storage mechanism for production.

Fixes #352