### PR TITLE
Fix Gunicorn lost file handles caused by logrotate

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/templates/logrotate-nyc-trees-app.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/logrotate-nyc-trees-app.j2
@@ -3,5 +3,8 @@
   {{ app_log_rotate_interval }}
   compress
   missingok
+  postrotate
+    restart nyc-trees-app
+  endscript
   notifempty
 }

--- a/deployment/ansible/roles/nyc-trees.app/templates/logrotate-nyc-trees-gunicorn.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/logrotate-nyc-trees-gunicorn.j2
@@ -3,5 +3,8 @@
   {{ app_gunicorn_log_rotate_internal }}
   compress
   missingok
+  postrotate
+    restart nyc-trees-app
+  endscript
   notifempty
 }


### PR DESCRIPTION
`logrotate` runs daily to rotate the application server logs in a way that causes Gunicorn to think that they've been deleted. In order to resolve this issue, after a rotate occurs, an application server restart is triggered to force Gunicorn to reestablish a handle to the file.