### PR TITLE
Send email when trusted mapper is approved

### DIFF
--- a/src/nyc_trees/apps/mail/templates/mail/group_mapping_approved.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/group_mapping_approved.txt
@@ -1,0 +1,6 @@
+Congratulations! Your request to map the blocks managed by
+{{ group.name }} was approved.
+
+You can now reserve some blocks and start mapping.
+
+{{ reservations_url }}

--- a/src/nyc_trees/apps/mail/templates/mail/group_mapping_approved_subject.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/group_mapping_approved_subject.txt
@@ -1,0 +1,1 @@
+Your request to map for {{group.name}} was approved

--- a/src/nyc_trees/apps/mail/views.py
+++ b/src/nyc_trees/apps/mail/views.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+from django.core.urlresolvers import reverse
+from django.shortcuts import get_object_or_404
+from django.template.loader import get_template
+from django.template import Context
+from django.utils.timezone import now
+
+from django_statsd.clients import statsd
+
+from apps.core.models import User
+
+# Message Types
+GROUP_MAPPING_APPROVED = 'group_mapping_approved'
+
+
+def _send_to(user, message_type, *args, **kwargs):
+    """
+    Send a templated email to a single, registered user. The
+    message_type argument is the string prefix of the subject and body
+    templates to be used (e.g. a message_type of 'welcome' will send an
+    email using the subject template 'mail/welcome_subject.txt' and body
+    template 'mail/welcome.txt'
+    """
+    kwargs['user'] = user
+    context = Context(kwargs)
+
+    body_text_template = get_template('mail/%s.txt' % message_type)
+    body_text = body_text_template.render(context)
+
+    subject_template = get_template('mail/%s_subject.txt' % message_type)
+    # Use rstrip to ensure that the subject does not end with \n
+    subject = subject_template.render(context).rstrip()
+
+    from_email = settings.DEFAULT_FROM_EMAIL
+    to = user.email
+
+    msg = EmailMessage(subject, body_text, from_email, [to])
+    msg.send()
+    statsd.incr('email.message.types.%s' % message_type)
+    return {
+        'to': to,
+        'from_email': from_email,
+        'subject': subject,
+        'body_text': body_text,
+        'sent_at': now()
+    }
+
+
+def notify_group_mapping_approved(request, group, username):
+    user = get_object_or_404(User, username=username)
+    reservations_url = request.build_absolute_uri(reverse('reservations'))
+    return _send_to(user,
+                    GROUP_MAPPING_APPROVED,
+                    group=group,
+                    reservations_url=reservations_url)

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -14,6 +14,7 @@ from django.http import HttpResponseRedirect, HttpResponseForbidden, Http404
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 
+from libs.data import merge
 from libs.formatters import humanize_bytes
 from libs.sql import get_group_tree_count
 
@@ -21,6 +22,8 @@ from apps.core.helpers import (user_is_group_admin,
                                user_is_eligible_to_become_trusted_mapper)
 from apps.core.decorators import group_request
 from apps.core.models import Group
+
+from apps.mail.views import notify_group_mapping_approved
 
 from apps.users.models import Follow, TrustedMapper
 from apps.users.forms import GroupSettingsForm
@@ -208,7 +211,11 @@ def start_group_map_print_job(request):
 
 
 def give_user_mapping_priveleges(request, username):
-    return _grant_mapping_access(request.group, username, is_approved=True)
+    mapper_context = _grant_mapping_access(request.group, username,
+                                           is_approved=True)
+    mail_context = notify_group_mapping_approved(request, request.group,
+                                                 username)
+    return merge(mapper_context, mail_context)
 
 
 def remove_user_mapping_priveleges(request, username):

--- a/src/nyc_trees/libs/data.py
+++ b/src/nyc_trees/libs/data.py
@@ -1,0 +1,16 @@
+# Attribution: http://stackoverflow.com/a/7205107
+def merge(a, b, path=None):
+    "merges b into a"
+    if path is None:
+        path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge(a[key], b[key], path + [str(key)])
+            elif a[key] == b[key]:
+                pass  # same leaf value
+            else:
+                raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+        else:
+            a[key] = b[key]
+    return a

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -268,6 +268,7 @@ LOCAL_APPS = (
     'apps.survey',
     'apps.users',
     'apps.geocode',
+    'apps.mail'
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps


### PR DESCRIPTION
Individual mappers request access to map in a group's territory. If a group admin approves that request, we notify the user and send a link to the reservation page.

Because we are going to have several message types, some on demand, some scheduled, I opted to put as keep much of the email logic as possible, along with the message templates, in a new "mail" app rather than start scattering them around the application.

Fixes #854 