### PR TITLE
Send email on RSVP

### DIFF
--- a/src/nyc_trees/apps/mail/templates/mail/rsvp.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/rsvp.txt
@@ -1,0 +1,8 @@
+We have received your RSVP to {{ event.title }}, hosted by {{ event.group.name }}. Here are the details:
+
+When: {{ event.begins_at|date:"l, F jS fA" }} to {{ event.ends_at|date:"fA" }}
+Where: {{ event.address }}{% if event.location_description %} — {{event.location_description }}{% endif %}
+Contact: {{ event.contact_name }} {{ event.contact_email }}
+
+You can view the full details of the event, cancel your reservation, or
+check-in when the event starts by following this link: {{ event_url }}

--- a/src/nyc_trees/apps/mail/templates/mail/rsvp_subject.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/rsvp_subject.txt
@@ -1,0 +1,1 @@
+You are registered for {{ event.title }} on {{ event.begins_at|date:"l, F jS" }}

--- a/src/nyc_trees/apps/mail/views.py
+++ b/src/nyc_trees/apps/mail/views.py
@@ -17,6 +17,7 @@ from apps.core.models import User
 
 # Message Types
 GROUP_MAPPING_APPROVED = 'group_mapping_approved'
+RSVP = 'rsvp'
 
 
 def _send_to(user, message_type, *args, **kwargs):
@@ -59,3 +60,15 @@ def notify_group_mapping_approved(request, group, username):
                     GROUP_MAPPING_APPROVED,
                     group=group,
                     reservations_url=reservations_url)
+
+
+def notify_rsvp(request, user, event):
+    relative_event_url = reverse('event_detail', kwargs={
+        'group_slug': event.group.slug,
+        'event_slug': event.slug
+    })
+    event_url = request.build_absolute_uri(relative_event_url)
+    return _send_to(user,
+                    RSVP,
+                    event=event,
+                    event_url=event_url)

--- a/src/nyc_trees/apps/users/tests.py
+++ b/src/nyc_trees/apps/users/tests.py
@@ -396,9 +396,11 @@ class IndividualMapperTests(UsersTestCase):
         self.assertIs(type(response), HttpResponseRedirect)
 
     def _rsvp_to_event(self, event):
+        mail.outbox = []
         request = make_request(user=self.user, method='POST')
         response = event_registration(request, group_slug=self.group.slug,
                                       event_slug=event.slug)
+        self.assertEqual(1, len(mail.outbox), "Expected RSVP to send an email")
         self.assertTrue('data-verb="DELETE"' in response.content)
 
     def _checkin_to_event(self, event):


### PR DESCRIPTION
When registering for an event the details are emailed to the user.

The text of the email is draft and subject to change and approval.

Fixes #856