### PR TITLE
Add missing migrations for changed image field

### DIFF
--- a/src/nyc_trees/apps/core/migrations/0018_auto_20150318_1233.py
+++ b/src/nyc_trees/apps/core/migrations/0018_auto_20150318_1233.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import apps.core.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0017_group_affiliation'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='group',
+            name='image',
+            field=models.ImageField(null=True, upload_to=apps.core.models._generate_image_filename, blank=True),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
Commit fda90cf modified the image field of Group, but neglected to inlude
migrations.