### PR TITLE
Fix log level DEBUG messages emitted by management commands

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/development.py
+++ b/src/nyc_trees/nyc_trees/settings/development.py
@@ -32,6 +32,11 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'DEBUG',
         },
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
     }
 }
 # END LOGGING CONFIGURATION


### PR DESCRIPTION
Management commands inherit the same logging settings supplied to the Django application. In development, database related logging settings were set to `DEBUG`, which allowed SQL debugging output to leak into management command execution. This change sets the database backends back to log level `INFO`.