### PR TITLE
Update default application from e-mail address

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -43,6 +43,7 @@ STATSD_HOST = environ.get('NYC_TREES_STATSD_HOST', 'localhost')
 
 # EMAIL CONFIGURATION
 DEFAULT_FROM_EMAIL = 'noreply@treescount.nycgovparks.org'
+DEFAULT_HELP_EMAIL = 'treescount.help@parks.nyc.gov'
 # END EMAIL CONFIGURATION
 
 

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -42,7 +42,7 @@ STATSD_HOST = environ.get('NYC_TREES_STATSD_HOST', 'localhost')
 
 
 # EMAIL CONFIGURATION
-DEFAULT_FROM_EMAIL = 'treescount.help@parks.nyc.gov'
+DEFAULT_FROM_EMAIL = 'noreply@treescount.nycgovparks.org'
 # END EMAIL CONFIGURATION
 
 


### PR DESCRIPTION
Changing to `noreply@treescount.nycgovparks.org`.

Required to resolve #724.