### PR TITLE
Add management command to dump tables to CSVs

### DIFF
--- a/src/nyc_trees/apps/core/management/commands/dump_models.py
+++ b/src/nyc_trees/apps/core/management/commands/dump_models.py
@@ -4,12 +4,36 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.core.management.base import BaseCommand
+from django.db import transaction, connection
+from django.utils.timezone import now
 
+from apps.core.models import TaskRun
 from apps.core.tasks import dump_models
+
+TASK_NAME = 'dump_models'
 
 
 class Command(BaseCommand):
+
+    @transaction.atomic
     def handle(self, *args, **kwargs):
+
+        today = now().date()
+
+        # Attempt to acquire a lock to the taskrun table, blocking if another
+        # transaction already has a lock.
+        # Since we create new rows to indicate when a task has been run, we
+        # need to lock the entire taskrun table, not just a subset of rows.
+        # This prevents us from using the builtin 'select_for_update'
+        with connection.cursor() as cursor:
+            cursor.execute('LOCK TABLE core_taskrun IN EXCLUSIVE MODE')
+
+        if TaskRun.objects.filter(name=TASK_NAME, date_started=today).exists():
+            self.stdout.write(
+                'Task {} has already been started today, skipping'.format(
+                    TASK_NAME))
+            return
+
         if len(args) > 0:
             dump_id = args[0]
         else:
@@ -17,3 +41,9 @@ class Command(BaseCommand):
         file_paths = dump_models(dump_id=dump_id)
         for path in file_paths:
             print(path)
+
+        # Using 0 as a task_result_id because this is currently not
+        # a celery task
+        TaskRun.objects.create(name=TASK_NAME,
+                               date_started=today,
+                               task_result_id=0)

--- a/src/nyc_trees/apps/core/management/commands/dump_models.py
+++ b/src/nyc_trees/apps/core/management/commands/dump_models.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.core.management.base import BaseCommand
+
+from apps.core.tasks import dump_models
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        if len(args) > 0:
+            dump_id = args[0]
+        else:
+            dump_id = None
+        file_paths = dump_models(dump_id=dump_id)
+        for path in file_paths:
+            print(path)

--- a/src/nyc_trees/apps/core/tasks.py
+++ b/src/nyc_trees/apps/core/tasks.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+
+import os
+import uuid
+import importlib
+import tempfile
+
+from djqscsv import write_csv
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+
+from libs.custom_storages import PrivateS3BotoStorage
+
+# Using strings so we can easily transition to async tasks, which need
+# serializable arguments
+MODELS = ['apps.core.models.User',
+          'apps.core.models.Group',
+          'apps.event.models.Event',
+          'apps.event.models.EventRegistration',
+          'apps.survey.models.BlockfaceReservation',
+          'apps.survey.models.Species',
+          'apps.survey.models.Survey',
+          'apps.survey.models.Territory',
+          'apps.users.models.Achievement',
+          'apps.users.models.Follow',
+          'apps.users.models.TrainingResult',
+          'apps.users.models.TrustedMapper']
+
+
+if getattr(settings, 'PRIVATE_AWS_STORAGE_BUCKET_NAME', None):
+    _storage = PrivateS3BotoStorage()
+else:
+    _storage = default_storage
+
+
+def dump_model(fq_name, dump_id):
+    _, temp_file_path = tempfile.mkstemp()
+    Model = _model_from_fq_name(fq_name)
+    with open(temp_file_path, 'w') as f:
+        write_csv(Model.objects.all(), f)
+
+    model_name = Model.__name__.lower()
+    file_name = os.path.join(dump_id, model_name + '.csv')
+
+    with open(temp_file_path, 'r') as f:
+        destination_path = _storage.save(file_name, f)
+    os.remove(temp_file_path)
+
+    return destination_path
+
+
+def dump_models(dump_id=None):
+    if not dump_id:
+        dump_id = str(uuid.uuid4())
+    return map(lambda fqn: dump_model(fqn, dump_id), MODELS)
+
+
+def _class_for_name(module_name, class_name):
+    m = importlib.import_module(module_name)
+    return getattr(m, class_name)
+
+
+def _model_from_fq_name(fq_name):
+    module_name, class_name = fq_name.rsplit('.', 1)
+    return _class_for_name(module_name, class_name)

--- a/src/nyc_trees/libs/custom_storages.py
+++ b/src/nyc_trees/libs/custom_storages.py
@@ -6,6 +6,8 @@ from __future__ import division
 import urllib
 import urlparse
 
+from django.conf import settings
+
 from storages.backends.s3boto import S3BotoStorage
 
 
@@ -36,3 +38,16 @@ class PublicS3BotoStorage(S3BotoStorage):
         query = urllib.urlencode(params)
         return urlparse.urlunparse((scheme, netloc, path, params, query,
                                     fragment))
+
+
+class PrivateS3BotoStorage(S3BotoStorage):
+    def __init__(self, *a, **k):
+        kwargs = dict(
+            bucket_name=settings.PRIVATE_AWS_STORAGE_BUCKET_NAME,
+            auto_create_bucket=settings.PRIVATE_AWS_STORAGE_AUTO_CREATE_BUCKET,
+            default_acl=settings.PRIVATE_AWS_STORAGE_DEFAULT_ACL,
+            querystring_expire=settings.PRIVATE_AWS_STORAGE_QUERYSTRING_EXPIRE,
+            url_protocol=settings.PRIVATE_AWS_STORAGE_URL_PROTOCOL
+        )
+        kwargs.update(k)
+        super(PrivateS3BotoStorage, self).__init__(*a, **kwargs)

--- a/src/nyc_trees/nyc_trees/settings/production.py
+++ b/src/nyc_trees/nyc_trees/settings/production.py
@@ -85,6 +85,16 @@ AWS_STORAGE_BUCKET_NAME = 'django-storages-{}'.format(vpc_id)
 AWS_AUTO_CREATE_BUCKET = True
 DEFAULT_FILE_STORAGE = 'libs.custom_storages.PublicS3BotoStorage'
 
+# The PRIVATE_AWS_STORAGE_* settings configure the S3 bucket
+# used for files only accessible by census admins (e.g. data dumps)
+PRIVATE_AWS_STORAGE_BUCKET_NAME = 'django-storages-private-{}'.format(vpc_id)
+PRIVATE_AWS_STORAGE_AUTO_CREATE_BUCKET = True
+# The number of seconds that a generated link to a file in the private
+# bucket is active.
+PRIVATE_AWS_STORAGE_QUERYSTRING_EXPIRE = 30
+PRIVATE_AWS_STORAGE_DEFAULT_ACL = 'private'
+PRIVATE_AWS_STORAGE_URL_PROTOCOL = 'https:'
+
 # There is no need to specify access key or secret key
 # They are pulled from the instance metadata by Boto
 

--- a/src/nyc_trees/requirements/base.txt
+++ b/src/nyc_trees/requirements/base.txt
@@ -15,3 +15,4 @@ django-waffle==0.10.1
 django-watchman==0.5.0
 django-redis==3.8.3
 hiredis==0.1.6
+django-queryset-csv==0.3.0


### PR DESCRIPTION
The command takes an optional argument, which will be the name of the directory, under the default Django storage backend, into which the CSV files will be written.

I wrote the export as a plain function call, but ensured that all the arguments are serializable, so that if the need for async processing arises we can easy switch to celery.

To test, run ``./scripts/manage.sh dump_tables foo`` then verify that the CSV files are dumped to ``/var/www/nyc-trees/media/foo``

Fixes #865