### PR TITLE
Try to send reservation reminder emails daily

### DIFF
--- a/src/nyc_trees/apps/mail/templates/mail/reservation_reminder.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/reservation_reminder.txt
@@ -1,0 +1,8 @@
+The following blockface reservations for user '{{ user.username }}' will expire soon:
+{% for reservation in reservations %}
+* 'id: {{ reservation.blockface.id }}' at {{ reservation.expires_at }}
+{% endfor %}
+
+Please visit the reservations page to start mapping:
+
+{{ reservations_url }}

--- a/src/nyc_trees/apps/mail/templates/mail/reservation_reminder_subject.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/reservation_reminder_subject.txt
@@ -1,0 +1,1 @@
+Your blockface reservations will expire soon

--- a/src/nyc_trees/apps/survey/management/commands/send_reminder_emails.py
+++ b/src/nyc_trees/apps/survey/management/commands/send_reminder_emails.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import operator
+import smtplib
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from django.db import transaction, connection
+
+from django.utils.timezone import now
+
+from apps.core.models import TaskRun
+from apps.survey.models import BlockfaceReservation
+from apps.mail.views import send_reservation_reminder
+
+_COMMAND_NAME = 'apps.survey.management.commands.send_reminder_emails'
+_ALREADY_SENT_MESSAGE = ('WARNING: Reservation emails sent already today. '
+                         'Doing nothing!')
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        today = now().date()
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute('LOCK TABLE %s IN EXCLUSIVE MODE'
+                               % TaskRun._meta.db_table)
+
+            _, unlocked = (TaskRun
+                           .objects
+                           .get_or_create(name=_COMMAND_NAME,
+                                          date_started=today))
+
+        if not unlocked:
+            self.stdout.write(_ALREADY_SENT_MESSAGE)
+            return
+
+        soon = now() + timedelta(days=settings.RESERVATION_REMINDER_WINDOW)
+        expiring_soon = (BlockfaceReservation
+                         .objects
+                         .filter(reminder_sent_at__isnull=True,
+                                 canceled_at__isnull=True,
+                                 expires_at__lte=soon))
+
+        user_reservations = {}
+
+        for reservation in expiring_soon:
+            user_data = user_reservations.get(reservation.user_id, [])
+            user_data.append(reservation)
+            user_reservations[reservation.user_id] = user_data
+
+        if not user_reservations:
+            self.stdout.write("no emails sent")
+            return
+
+        for user_id, reservations in user_reservations.items():
+            try:
+                send_reservation_reminder(user_id, reservations=reservations)
+            except smtplib.SMTPException:
+                continue
+            self.stdout.write("Email sent to user_id: '%s'" % user_id)
+            ids = map(operator.attrgetter('id'), reservations)
+            (BlockfaceReservation
+             .objects
+             .filter(id__in=ids)
+             .update(reminder_sent_at=now()))

--- a/src/nyc_trees/apps/survey/migrations/0014_blockfacereservation_reminder_sent_at.py
+++ b/src/nyc_trees/apps/survey/migrations/0014_blockfacereservation_reminder_sent_at.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0013_auto_20150309_1712'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='blockfacereservation',
+            name='reminder_sent_at',
+            field=models.DateTimeField(null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -247,6 +247,7 @@ class BlockfaceReservation(NycModel, models.Model):
     is_mapping_with_paper = models.BooleanField(default=False)
     expires_at = models.DateTimeField()
     canceled_at = models.DateTimeField(null=True, blank=True)
+    reminder_sent_at = models.DateTimeField(null=True, blank=True)
 
     objects = ReservationsQuerySet.as_manager()
 

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -353,3 +353,5 @@ SOFT_LAUNCH_REGEXES = [
     r'^/admin/',
     r'^/health-check/',
 ]
+
+RESERVATION_REMINDER_WINDOW = 4


### PR DESCRIPTION
This changeset introduces a management command to be executed via cron
for emailing users about their blockface reservations that will expire
soon. It has a configurable window of time for sending requests and will
keep trying to send notifications once daily for until it succeeds. Can
only be run once daily.