### PR TITLE
Add navlink to main site from admin

### DIFF
--- a/src/nyc_trees/templates/admin/base_site.html
+++ b/src/nyc_trees/templates/admin/base_site.html
@@ -1,0 +1,12 @@
+{% extends "admin/base.html" %}
+
+{% block title %}TreesCount! 2015 admin{% endblock %}
+
+{% block branding %}
+<h1 id="site-name">
+  TreesCount! 2015 | 
+  (<a href="{% url 'admin:index' %}">administration</a> / <a href="{% url 'home_page' %}">home</a>)
+</h1>
+{% endblock %}
+
+{% block nav-global %}{% endblock %}


### PR DESCRIPTION
This is very useful during development and can only improve the end user
experience. You can use this link to get back to the site, from the admin.

![screenshot from 2015-03-20 15 54 41](https://cloud.githubusercontent.com/assets/1699455/6759804/6e874438-cf19-11e4-9263-6c8cb328de04.png)