### PR TITLE
Add celery tasks for dumping tree and blockfaces tables to shapefiles

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dependencies.yml
@@ -5,6 +5,7 @@
     - "binutils=2.24*"
     - "libproj-dev=4.8.0*"
     - "gdal-bin=1.10.1*"
+    - "libgdal1-dev=1.10.1*"
 
 - name: Configure the main PostgreSQL APT repository
   apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release}}-pgdg main"

--- a/src/nyc_trees/apps/census_admin/tasks.py
+++ b/src/nyc_trees/apps/census_admin/tasks.py
@@ -11,10 +11,19 @@ import shutil
 import fiona
 from celery import task
 
+from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db import connection
 
+from libs.custom_storages import PrivateS3BotoStorage
+
 from apps.survey.models import Blockface
+
+
+if getattr(settings, 'PRIVATE_AWS_STORAGE_BUCKET_NAME', None):
+    _storage = PrivateS3BotoStorage()
+else:
+    _storage = default_storage
 
 
 TREES_QUERY_FILE = os.path.join(os.path.dirname(__file__), 'trees.sql')
@@ -89,22 +98,20 @@ def dump_trees_to_shapefile():
                 }
                 shp.write(rec)
 
-    # TODO: This should *not* go to the default storage, as it should not
-    # be publicly readable
     with open(shp_file, 'r') as f:
-        default_storage.save('dump/trees.shp', f)
+        _storage.save('dump/trees.shp', f)
 
     with open(os.path.join(tmp_dir, 'trees.dbf'), 'r') as f:
-        default_storage.save('dump/trees.dbf', f)
+        _storage.save('dump/trees.dbf', f)
 
     with open(os.path.join(tmp_dir, 'trees.prj'), 'r') as f:
-        default_storage.save('dump/trees.prj', f)
+        _storage.save('dump/trees.prj', f)
 
     with open(os.path.join(tmp_dir, 'trees.cpg'), 'r') as f:
-        default_storage.save('dump/trees.cpg', f)
+        _storage.save('dump/trees.cpg', f)
 
     with open(os.path.join(tmp_dir, 'trees.shx'), 'r') as f:
-        default_storage.save('dump/trees.shx', f)
+        _storage.save('dump/trees.shx', f)
 
     shutil.rmtree(tmp_dir)
 
@@ -149,21 +156,19 @@ def dump_blockface_to_shapefile():
             }
             shp.write(rec)
 
-    # TODO: This should *not* go to the default storage, as it should not
-    # be publicly readable
     with open(shp_file, 'r') as f:
-        default_storage.save('dump/blockface.shp', f)
+        _storage.save('dump/blockface.shp', f)
 
     with open(os.path.join(tmp_dir, 'blockface.dbf'), 'r') as f:
-        default_storage.save('dump/blockface.dbf', f)
+        _storage.save('dump/blockface.dbf', f)
 
     with open(os.path.join(tmp_dir, 'blockface.prj'), 'r') as f:
-        default_storage.save('dump/blockface.prj', f)
+        _storage.save('dump/blockface.prj', f)
 
     with open(os.path.join(tmp_dir, 'blockface.cpg'), 'r') as f:
-        default_storage.save('dump/blockface.cpg', f)
+        _storage.save('dump/blockface.cpg', f)
 
     with open(os.path.join(tmp_dir, 'blockface.shx'), 'r') as f:
-        default_storage.save('dump/blockface.shx', f)
+        _storage.save('dump/blockface.shx', f)
 
     shutil.rmtree(tmp_dir)

--- a/src/nyc_trees/apps/census_admin/tasks.py
+++ b/src/nyc_trees/apps/census_admin/tasks.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import os
+import tempfile
+import json
+import shutil
+
+import fiona
+from celery import task
+
+from django.core.files.storage import default_storage
+from django.db import connection
+
+from apps.survey.models import Blockface
+
+
+TREES_QUERY_FILE = os.path.join(os.path.dirname(__file__), 'trees.sql')
+
+with open(TREES_QUERY_FILE, 'r') as f:
+    TREES_QUERY = f.read()
+
+
+@task
+def dump_trees_to_shapefile():
+    tmp_dir = tempfile.mkdtemp()
+    shp_file = os.path.join(tmp_dir, 'trees.shp')
+
+    with connection.cursor() as cursor:
+        cursor.execute(TREES_QUERY)
+
+        crs = {'no_defs': True,
+               'ellps': 'WGS84',
+               'datum': 'WGS84',
+               'proj': 'longlat'}
+
+        schema = {
+            'geometry': 'Point',
+            'properties': [
+                ('tree_id', 'int'),
+                ('survey_id', 'int'),
+                ('species_id', 'int'),
+                ('dist_tree', 'float'),
+                ('dist_end', 'float'),
+                ('tree_circ', 'int'),
+                ('stump_diam', 'int'),
+                ('curb_loc', 'str'),
+                ('status', 'str'),
+                ('speci_cert', 'str'),
+                ('health', 'str'),
+                ('steward', 'str'),
+                ('guards', 'str'),
+                ('sidewalk', 'str'),
+                ('problems', 'str:130'),
+                ('created_at', 'str'),
+                ('updated_at', 'str'),
+            ]
+        }
+
+        with fiona.open(shp_file, 'w', driver='ESRI Shapefile', crs=crs,
+                        schema=schema) as shp:
+
+            for row in cursor.fetchall():
+                # Note: The column order here needs to match the column order
+                # specified in trees.sql
+                rec = {
+                    'geometry': json.loads(row[0]),
+                    'properties': {
+                        'tree_id': row[1],
+                        'survey_id': row[2],
+                        'species_id': row[3],
+                        'dist_tree': row[4],
+                        'dist_end': row[5],
+                        'tree_circ': row[6],
+                        'stump_diam': row[7],
+                        'curb_loc': row[8],
+                        'status': row[9],
+                        'speci_cert': row[10],
+                        'health': row[11],
+                        'steward': row[12],
+                        'guards': row[13],
+                        'sidewalk': row[14],
+                        'problems': row[15],
+                        'created_at': row[16].strftime('%Y-%m-%d %H:%M:%S'),
+                        'updated_at': row[17].strftime('%Y-%m-%d %H:%M:%S'),
+                    }
+                }
+                shp.write(rec)
+
+    # TODO: This should *not* go to the default storage, as it should not
+    # be publicly readable
+    with open(shp_file, 'r') as f:
+        default_storage.save('dump/trees.shp', f)
+
+    with open(os.path.join(tmp_dir, 'trees.dbf'), 'r') as f:
+        default_storage.save('dump/trees.dbf', f)
+
+    with open(os.path.join(tmp_dir, 'trees.prj'), 'r') as f:
+        default_storage.save('dump/trees.prj', f)
+
+    with open(os.path.join(tmp_dir, 'trees.cpg'), 'r') as f:
+        default_storage.save('dump/trees.cpg', f)
+
+    with open(os.path.join(tmp_dir, 'trees.shx'), 'r') as f:
+        default_storage.save('dump/trees.shx', f)
+
+    shutil.rmtree(tmp_dir)
+
+
+@task
+def dump_blockface_to_shapefile():
+    tmp_dir = tempfile.mkdtemp()
+    shp_file = os.path.join(tmp_dir, 'blockface.shp')
+
+    blockfaces = Blockface.objects.all().values(
+        'id', 'geom', 'is_available', 'expert_required', 'updated_at'
+    )
+
+    crs = {'no_defs': True,
+           'ellps': 'WGS84',
+           'datum': 'WGS84',
+           'proj': 'longlat'}
+
+    schema = {
+        'geometry': 'MultiLineString',
+        'properties': [
+            ('block_id', 'int'),
+            ('is_avail', 'str'),
+            ('expert_req', 'str'),
+            ('updated_at', 'str'),
+        ]
+    }
+
+    with fiona.open(shp_file, 'w', driver='ESRI Shapefile', crs=crs,
+                    schema=schema) as shp:
+
+        for row in blockfaces:
+            rec = {
+                'geometry': json.loads(row['geom'].json),
+                'properties': {
+                    'block_id': row['id'],
+                    'is_avail': 'T' if row['is_available'] else 'F',
+                    'expert_req': 'T' if row['expert_required'] else 'F',
+                    'updated_at': row['updated_at'].strftime(
+                        '%Y-%m-%d %H:%M:%S'),
+                }
+            }
+            shp.write(rec)
+
+    # TODO: This should *not* go to the default storage, as it should not
+    # be publicly readable
+    with open(shp_file, 'r') as f:
+        default_storage.save('dump/blockface.shp', f)
+
+    with open(os.path.join(tmp_dir, 'blockface.dbf'), 'r') as f:
+        default_storage.save('dump/blockface.dbf', f)
+
+    with open(os.path.join(tmp_dir, 'blockface.prj'), 'r') as f:
+        default_storage.save('dump/blockface.prj', f)
+
+    with open(os.path.join(tmp_dir, 'blockface.cpg'), 'r') as f:
+        default_storage.save('dump/blockface.cpg', f)
+
+    with open(os.path.join(tmp_dir, 'blockface.shx'), 'r') as f:
+        default_storage.save('dump/blockface.shx', f)
+
+    shutil.rmtree(tmp_dir)

--- a/src/nyc_trees/apps/census_admin/trees.sql
+++ b/src/nyc_trees/apps/census_admin/trees.sql
@@ -1,0 +1,52 @@
+WITH trees_for_this_survey AS(
+  SELECT
+    id,
+    survey_id,
+    .3408*(CASE WHEN curb_location='OnCurb' THEN 2.5 ELSE 12 END) curb_offset,
+    .3408*distance_to_tree dist
+  FROM survey_tree
+  ORDER BY id
+),
+aggregated_trees AS (
+  SELECT survey_id, array_agg(curb_offset) width,
+         array_agg(0) length, array_agg(dist) dist, array_agg(id) tree_ids
+  FROM trees_for_this_survey
+  GROUP BY survey_id
+),
+aggs AS (
+  SELECT
+    s.blockface_id,
+    s.is_mapped_in_blockface_polyline_direction,
+    s.is_left_side as left_side,
+    s.user_id, b.geom,
+    r.survey_id, width, length, dist,
+    r.tree_ids
+  FROM
+    aggregated_trees r, survey_survey s, survey_blockface b
+  WHERE
+    r.survey_id = s.id AND b.id = s.blockface_id
+),
+layed AS (
+  SELECT survey_id,
+         tree_ids,
+         layoutBoxes(ST_Transform(
+             CASE WHEN is_mapped_in_blockface_polyline_direction
+             THEN st_geometryn(geom,1)
+             ELSE ST_Reverse(st_geometryn(geom,1)) END,
+             _ST_BestSRID(geom::geometry)),
+         left_side, dist, length, width) as tbeds
+  FROM aggs
+),
+tree_geoms AS (
+  SELECT
+    ST_AsGeoJSON(ST_Transform(unnest(tbeds),4326)) as geom, unnest(tree_ids) as tree_id
+  FROM layed
+)
+SELECT
+  geom,
+  t.id, t.survey_id, t.species_id, t.distance_to_tree, t.distance_to_end,
+  t.circumference, t.stump_diameter, t.curb_location, t.status,
+  t.species_certainty, t.health, t.stewardship, t.guards, t.sidewalk_damage,
+  t.problems, t.created_at, t.updated_at
+FROM tree_geoms, survey_tree t
+WHERE t.id = tree_geoms.tree_id

--- a/src/nyc_trees/apps/census_admin/trees.sql
+++ b/src/nyc_trees/apps/census_admin/trees.sql
@@ -1,3 +1,4 @@
+-- Note: This was adapted from survey_detail.sql.  Try to keep changes in sync
 WITH trees_for_this_survey AS(
   SELECT
     id,

--- a/src/nyc_trees/apps/core/management/commands/start_daily_celery_task.py
+++ b/src/nyc_trees/apps/core/management/commands/start_daily_celery_task.py
@@ -10,10 +10,14 @@ from django.utils.timezone import now
 from nyc_trees.celery import debug_task
 
 from apps.core.models import TaskRun
+from apps.census_admin.tasks import (dump_trees_to_shapefile,
+                                     dump_blockface_to_shapefile)
 
 
 tasks = {
-    'debug_task': debug_task
+    'debug_task': debug_task,
+    'dump_trees': dump_trees_to_shapefile,
+    'dump_blockfaces': dump_blockface_to_shapefile
 }
 
 

--- a/src/nyc_trees/apps/survey/survey_detail.sql
+++ b/src/nyc_trees/apps/survey/survey_detail.sql
@@ -1,3 +1,4 @@
+-- Note: This was adapted into trees.sql.  Try to keep changes in sync
 WITH trees_for_this_survey AS(
   SELECT
     id,

--- a/src/nyc_trees/requirements/base.txt
+++ b/src/nyc_trees/requirements/base.txt
@@ -16,3 +16,4 @@ django-watchman==0.5.0
 django-redis==3.8.3
 hiredis==0.1.6
 django-queryset-csv==0.3.0
+fiona==1.5.1


### PR DESCRIPTION
To test, run `./scripts/manage.sh start_daily_celery_task dump_trees` and `./scripts/manage.sh start_daily_celery_task dump_blockfaces` then verify that the shapefiles files are dumped to `/var/www/nyc-trees/media/dump`

This is a preview PR, since it still needs some additional work to ensure the dumps are stored in a secure fashion when storing on S3.

Fixes #864 