### PR TITLE
Add log shipping support for Celery

### DIFF
--- a/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/tasks/main.yml
@@ -7,6 +7,7 @@
     - django
     - gunicorn
     - windshaft
+    - celery
   notify:
     - Restart Beaver
 

--- a/deployment/ansible/roles/nyc-trees.beaver/templates/celery.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.beaver/templates/celery.conf.j2
@@ -1,0 +1,5 @@
+[/var/log/{upstart/celery.log,celery.log}]
+multiline_regex_after = (^\s+File.*, line \d+, in)
+multiline_regex_before = (^Traceback \(most recent call last\):)|(^\s+File.*, line \d+, in)|(^\w+Error: )
+type: celery
+tags: celery,beaver


### PR DESCRIPTION
These changes wire up log shipping for the Celery logs into Logstash/Kibana.