### PR TITLE
"Soft launch" version of "register complete" text

### DIFF
--- a/src/nyc_trees/apps/login/templates/login/forgot_username.html
+++ b/src/nyc_trees/apps/login/templates/login/forgot_username.html
@@ -12,7 +12,7 @@
         {% csrf_token %}
         <p>
             Forgot your username? Enter the Email address you used to register
-            with Trees Count! and click the “Find” button below.
+            with TreesCount! and click the “Find” button below.
         </p>
         {{ form.non_field_errors }}
         <div class="fieldWrapper">

--- a/src/nyc_trees/templates/registration/activation_email.html
+++ b/src/nyc_trees/templates/registration/activation_email.html
@@ -10,7 +10,7 @@
 <body>
 
 <p>
-    Thank you for signing up for Trees Count!
+    Thank you for signing up for TreesCount!
 </p>
 <p>
     Your username is {{ user.username }}<br />

--- a/src/nyc_trees/templates/registration/activation_email.txt
+++ b/src/nyc_trees/templates/registration/activation_email.txt
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load url from future %}
-Thank you for signing up for Trees Count!
+Thank you for signing up for TreesCount!
 
 Your username is {{ user.username }}
 

--- a/src/nyc_trees/templates/registration/password_reset_form.html
+++ b/src/nyc_trees/templates/registration/password_reset_form.html
@@ -5,7 +5,7 @@
 
 {% block registration_content %}
 <p>
-    Forgot your password? Enter your Trees Count! username or email address and click the "Reset" button below.
+    Forgot your password? Enter your TreesCount! username or email address and click the "Reset" button below.
 </p>
 <form method="post" action="">
     {% csrf_token %}

--- a/src/nyc_trees/templates/registration/registration_complete.html
+++ b/src/nyc_trees/templates/registration/registration_complete.html
@@ -1,5 +1,6 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
+{% load waffle_tags %}
 
 {% block title %}{% trans "Activation email sent" %}{% endblock %}
 
@@ -9,12 +10,14 @@
 
 {% block registration_content %}
 <p>
-    Thank you for signing up as a volun<em>treer</em> with Trees Count! 2015.
+    Thank you for signing up as a volun<em>treer</em> with TreesCount! 2015.
     Please check your email inbox to confirm your account details.
 </p>
 <p>
-    Once confirmed, visit our Trees Count! <a href="{% url 'training_summary_pure' %}">census training</a>
+    {% flag full_access %}
+    Once confirmed, visit our TreesCount! <a href="{% url 'training_summary_pure' %}">census training</a>
     page to get started.
+    {% endflag %}
 </p>
 {% endblock %}
 


### PR DESCRIPTION
* Only show sentence with link to census training page when `full_access` enabled
* Also fix spelling of "TreesCount!" in several templates

Fixes #962 

Test using `/admin/waffle/flag/`-- check `full_access` and choose "Disable selected flags for everyone"
