### PR TITLE
Fix base template reference in activate.html

### DIFF
--- a/src/nyc_trees/templates/registration/activate.html
+++ b/src/nyc_trees/templates/registration/activate.html
@@ -1,8 +1,11 @@
-{% extends "registration_base.html" %}
+{% extends "registration/registration_base.html" %}
 {% load i18n %}
 
 {% block registration_content %}
-<p>{% trans "Account activation failed." %}</p>
+<p>Sorry, there was a problem activating your account.</p>
+<p>It may already be active. Please try to log in.</p>
+
+<p><a class="btn btn-primary btn-mobile--max" href="{% url 'auth_login' %}">Log In</a></p>
 {% endblock %}
 
 


### PR DESCRIPTION
This page is shown when activation fails, which most often occurs when clicking the link in the registration confirmation email twice. To cover that case, I also added some copy prompting the person to try to log in.

![screen shot 2015-03-27 at 3 50 08 pm](https://cloud.githubusercontent.com/assets/17363/6878293/fbb58ea8-d498-11e4-8f6e-2a0e38a92472.png)

Fixes #910