### PR TITLE
Add search and filters to survey admin

### DIFF
--- a/src/nyc_trees/apps/survey/admin.py
+++ b/src/nyc_trees/apps/survey/admin.py
@@ -14,6 +14,10 @@ class TreeInline(admin.TabularInline):
 
 class SurveyAdmin(admin.ModelAdmin):
     inlines = [TreeInline]
+    search_fields = ('id', 'quit_reason', 'user__username')
+    list_display = ('blockface', 'user', 'has_trees',
+                    'is_flagged', 'teammate', 'quit_reason')
+    list_filter = ('is_flagged', 'has_trees')
 
 admin.site.register(m.Blockface)
 admin.site.register(m.Territory)


### PR DESCRIPTION
fixes #963 on github

this adds search and filters as pictured:
![screenshot from 2015-03-29 16 18 36](https://cloud.githubusercontent.com/assets/1699455/6887501/318ab87c-d62f-11e4-9869-4e148a3a7b8a.png)

It's clear that these filters would be useful, but I'm not sure what we're looking for as far as search fields. Anything that is walkable in standard orm style (ie. `user__username`, as included) is readily available.

@dboyer thoughts?