### PR TITLE
Align staging and production environments

### DIFF
--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -21,6 +21,11 @@ hosted_zone_name_param = t.add_parameter(Parameter(
     Description='Hosted zone name for public DNS'
 ))
 
+private_hosted_zone_id_param = t.add_parameter(Parameter(
+    'PrivateHostedZoneId', Type='String',
+    Description='Hosted zone ID for private record set'
+))
+
 vpc_param = t.add_parameter(Parameter(
     'VpcId', Type='String', Description='Name of an existing VPC'
 ))
@@ -211,7 +216,6 @@ database_server_instance = t.add_resource(rds.DBInstance(
     AutoMinorVersionUpgrade=True,
     BackupRetentionPeriod=30,
     DBInstanceClass=Ref(database_server_instance_type_param),
-    DBInstanceIdentifier='nyctrees-nyc-trees-database-server',
     DBName='nyc_trees',
     DBParameterGroupName=Ref(database_server_parameter_group),
     DBSubnetGroupName=Ref(database_server_subnet_group),
@@ -331,7 +335,6 @@ cache_cluster = t.add_resource(ec.CacheCluster(
     CacheNodeType=Ref(cache_cluster_instance_type_param),
     CacheParameterGroupName=Ref(cache_cluster_parameter_group),
     CacheSubnetGroupName=Ref(cache_cluster_subnet_group),
-    ClusterName='nyctrees',
     Engine='redis',
     EngineVersion='2.8.6',
     NotificationTopicArn=Ref(notification_arn_param),
@@ -399,7 +402,7 @@ public_dns_records_sets = t.add_resource(r53.RecordSetGroup(
 
 private_dns_records_sets = t.add_resource(r53.RecordSetGroup(
     'dnsPrivateRecords',
-    HostedZoneName='nyc-trees.internal.',
+    HostedZoneId=Ref(private_hosted_zone_id_param),
     RecordSets=[
         r53.RecordSet(
             'dnsBastionHost',

--- a/deployment/troposphere/template_utils.py
+++ b/deployment/troposphere/template_utils.py
@@ -11,20 +11,21 @@ EC2_REGIONS = [
     'us-east-1'
 ]
 EC2_AVAILABILITY_ZONES = [
-    'b',
+    'a',
     'd'
 ]
 EC2_INSTANCE_TYPES = [
-    't1.micro',
     't2.micro',
     't2.medium',
-    'm3.medium'
+    'm3.medium',
+    'm3.large'
 ]
 RDS_INSTANCE_TYPES = [
     'db.t2.micro',
     'db.m3.large'
 ]
 ELASTICACHE_INSTANCE_TYPES = [
+    'cache.t2.small',
     'cache.m1.small'
 ]
 

--- a/deployment/troposphere/tiler_hosted_zone_template.py
+++ b/deployment/troposphere/tiler_hosted_zone_template.py
@@ -12,15 +12,14 @@ t.add_description('Tiler hosted zone records for the nyc-trees project.')
 #
 # Parameters
 #
-hosted_zone_name_param = t.add_parameter(Parameter(
-    'PublicHostedZone', Type='String',
-    Default='treescount.azavea.com',
-    Description='Hosted zone name for public DNS'
-))
-
 tile_server_hosted_zone_alias_target_param = t.add_parameter(Parameter(
     'TileServerAliasTarget', Type='String',
     Description='Alias target for the hosted zone record set'
+))
+
+private_hosted_zone_id_param = t.add_parameter(Parameter(
+    'PrivateHostedZoneId', Type='String',
+    Description='Hosted zone ID for private record set'
 ))
 
 #
@@ -52,7 +51,7 @@ cloudfront_tile_distribution = t.add_resource(cf.Distribution(
 #
 private_dns_records_sets = t.add_resource(r53.RecordSetGroup(
     'dnsPrivateRecords',
-    HostedZoneName='nyc-trees.internal.',
+    HostedZoneId=Ref(private_hosted_zone_id_param),
     RecordSets=[
         r53.RecordSet(
             'dnsTileServers',


### PR DESCRIPTION
The following changes are aimed at aligning the staging and production environments:

- Use private hosted zone IDs vs. private hosted zone names
- Add additional instances types
- Label Route 53 hosted zones with VPC ID
- Remove specific data store names
- Switch VPC availability zones

AWS availability zones names don't translate across accounts, so in this case all we're doing is using the same labels.