### PR TITLE
Update watchify to 3.0, and explicitly use polling.

### DIFF
--- a/src/nyc_trees/gulpfile.js
+++ b/src/nyc_trees/gulpfile.js
@@ -149,7 +149,9 @@ gulp.task('watchify', function() {
         cache: {},
         packageCache: {},
         fullPaths: true
-    }));
+    }), {
+        poll: true
+    });
 
     bundler.on('update', function() {
         gutil.log("Rebundling JS");

--- a/src/nyc_trees/npm-shrinkwrap.json
+++ b/src/nyc_trees/npm-shrinkwrap.json
@@ -8,14 +8,14 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.1.tgz"
     },
     "browserify": {
-      "version": "8.1.1",
-      "from": "https://registry.npmjs.org/browserify/-/browserify-8.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-8.1.1.tgz",
+      "version": "9.0.4",
+      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.4.tgz",
       "dependencies": {
         "JSONStream": {
-          "version": "0.8.4",
-          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "version": "0.10.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
@@ -35,19 +35,50 @@
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
-          "version": "3.2.0",
-          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
           "dependencies": {
+            "JSONStream": {
+              "version": "0.8.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
             "combine-source-map": {
               "version": "0.3.0",
               "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
@@ -71,21 +102,33 @@
             "through2": {
               "version": "0.5.1",
               "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "umd": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
             }
           }
         },
         "browser-resolve": {
-          "version": "1.5.0",
-          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.5.0.tgz",
-          "dependencies": {
-            "resolve": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
-            }
-          }
+          "version": "1.8.2",
+          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
@@ -93,16 +136,16 @@
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
-              "version": "0.2.5",
-              "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+              "version": "0.2.6",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
             }
           }
         },
         "buffer": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/buffer/-/buffer-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.0.1.tgz",
+          "version": "3.1.2",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
@@ -140,18 +183,6 @@
               "version": "0.0.6",
               "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                }
-              }
             }
           }
         },
@@ -173,14 +204,14 @@
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.9.7",
-          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.7.tgz",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.7.tgz",
+          "version": "3.9.13",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
           "dependencies": {
             "browserify-aes": {
-              "version": "0.8.1",
-              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.1.tgz",
-              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.1.tgz"
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
             },
             "browserify-sign": {
               "version": "2.8.0",
@@ -188,9 +219,9 @@
               "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
                   "version": "1.1.1",
@@ -220,9 +251,9 @@
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
@@ -246,14 +277,14 @@
               }
             },
             "create-ecdh": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz",
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "elliptic": {
                   "version": "1.0.1",
@@ -275,9 +306,9 @@
               }
             },
             "create-hash": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
                 "ripemd160": {
                   "version": "1.0.0",
@@ -292,19 +323,19 @@
               }
             },
             "create-hmac": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.0.tgz"
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
-              "version": "2.2.3",
-              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.3.tgz",
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "miller-rabin": {
                   "version": "1.1.5",
@@ -321,34 +352,34 @@
               }
             },
             "pbkdf2-compat": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
             },
             "public-encrypt": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz",
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
               "dependencies": {
                 "bn.js": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                 },
                 "parse-asn1": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
@@ -356,27 +387,22 @@
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
-                    },
-                    "asn1.js-rfc3280": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
-                    },
-                    "pemstrip": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
                 }
               }
+            },
+            "randombytes": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "defined": {
           "version": "0.0.0",
@@ -388,6 +414,23 @@
           "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "dependencies": {
+            "JSONStream": {
+              "version": "0.8.4",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
             "minimist": {
               "version": "0.2.0",
               "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
@@ -396,33 +439,33 @@
             "through2": {
               "version": "0.5.1",
               "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
-            }
-          }
-        },
-        "domain-browser": {
-          "version": "1.1.3",
-          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz"
-        },
-        "duplexer2": {
-          "version": "0.0.2",
-          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
                 }
               }
             }
           }
+        },
+        "domain-browser": {
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
@@ -430,9 +473,9 @@
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
-          "version": "4.3.5",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+          "version": "4.5.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -447,9 +490,9 @@
               }
             },
             "minimatch": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "version": "2.0.4",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -484,6 +527,11 @@
             }
           }
         },
+        "has": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
+        },
         "http-browserify": {
           "version": "1.7.0",
           "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
@@ -507,9 +555,9 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.2.0",
-          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
+          "version": "6.2.1",
+          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
@@ -529,9 +577,23 @@
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
@@ -598,18 +660,6 @@
               "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                },
                 "readable-wrap": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
@@ -625,9 +675,9 @@
           }
         },
         "module-deps": {
-          "version": "3.6.4",
-          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.4.tgz",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.4.tgz",
+          "version": "3.7.5",
+          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.5.tgz",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.5.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
@@ -657,14 +707,14 @@
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 },
                 "escodegen": {
-                  "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.0.tgz",
+                  "version": "1.6.1",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
-                      "version": "1.9.1",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
+                      "version": "1.9.3",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
@@ -672,9 +722,9 @@
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
-                      "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz"
+                      "version": "1.2.5",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
@@ -742,7 +792,26 @@
                 "through2": {
                   "version": "0.5.1",
                   "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -763,6 +832,18 @@
               "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                },
                 "xtend": {
                   "version": "2.1.2",
                   "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
@@ -776,6 +857,11 @@
                   }
                 }
               }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
@@ -802,9 +888,9 @@
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
-          "version": "0.10.0",
-          "from": "https://registry.npmjs.org/process/-/process-0.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
+          "version": "0.10.1",
+          "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
@@ -817,9 +903,9 @@
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "version": "1.1.13",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
@@ -829,9 +915,9 @@
           }
         },
         "resolve": {
-          "version": "0.7.4",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
@@ -899,18 +985,6 @@
           "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                }
-              }
-            },
             "xtend": {
               "version": "4.0.0",
               "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
@@ -919,132 +993,29 @@
           }
         },
         "timers-browserify": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.2.0.tgz"
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
           "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
-        "umd": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-          "dependencies": {
-            "rfile": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-              "dependencies": {
-                "callsite": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                },
-                "resolve": {
-                  "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
-                }
-              }
-            },
-            "ruglify": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-              "dependencies": {
-                "uglify-js": {
-                  "version": "2.2.5",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "optimist": {
-                      "version": "0.3.7",
-                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                      "dependencies": {
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "through": {
-              "version": "2.3.6",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-            },
-            "uglify-js": {
-              "version": "2.4.16",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.1.34",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                    }
-                  }
-                },
-                "optimist": {
-                  "version": "0.3.7",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                  "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
         "url": {
-          "version": "0.10.2",
-          "from": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
+          "version": "0.10.3",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
               "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
@@ -1073,9 +1044,9 @@
       }
     },
     "browserify-shim": {
-      "version": "3.8.2",
-      "from": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.2.tgz",
-      "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.2.tgz",
+      "version": "3.8.3",
+      "from": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.3.tgz",
       "dependencies": {
         "exposify": {
           "version": "0.2.0",
@@ -1178,9 +1149,9 @@
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.15.tgz",
                   "dependencies": {
                     "source-map": {
-                      "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
@@ -5502,76 +5473,76 @@
     },
     "watchify": {
       "version": "3.0.0",
-      "from": "watchify@3.0.0",
+      "from": "https://registry.npmjs.org/watchify/-/watchify-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.0.0.tgz",
       "dependencies": {
         "browserify": {
           "version": "9.0.3",
-          "from": "browserify@^9.0.2",
+          "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.10.0",
-              "from": "JSONStream@~0.10.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "assert": {
               "version": "1.3.0",
-              "from": "assert@~1.3.0",
+              "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
             },
             "browser-pack": {
               "version": "4.0.1",
-              "from": "browser-pack@^4.0.0",
+              "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.8.4",
-                  "from": "JSONStream@~0.8.4",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.3.6",
-                      "from": "through@>=2.2.7 <3",
+                      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                     }
                   }
                 },
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "combine-source-map@~0.3.0",
+                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.1",
-                      "from": "inline-source-map@~0.3.0",
+                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.3.0",
-                          "from": "source-map@~0.3.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -5580,17 +5551,17 @@
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "convert-source-map@~0.3.0",
+                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@~0.1.31",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -5599,17 +5570,17 @@
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@~0.5.1",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.17",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
@@ -5618,156 +5589,156 @@
                 },
                 "umd": {
                   "version": "3.0.0",
-                  "from": "umd@^3.0.0",
+                  "from": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
                 }
               }
             },
             "browser-resolve": {
               "version": "1.8.2",
-              "from": "browser-resolve@^1.7.1",
+              "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz",
               "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "browserify-zlib@~0.1.2",
+              "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
                   "version": "0.2.6",
-                  "from": "pako@~0.2.0",
+                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
                 }
               }
             },
             "buffer": {
               "version": "3.1.2",
-              "from": "buffer@^3.0.0",
+              "from": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.8",
-                  "from": "base64-js@0.0.8",
+                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.4",
-                  "from": "ieee754@^1.1.4",
+                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
-                  "from": "is-array@^1.0.1",
+                  "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
                 }
               }
             },
             "builtins": {
               "version": "0.0.7",
-              "from": "builtins@~0.0.3",
+              "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
             },
             "commondir": {
               "version": "0.0.1",
-              "from": "commondir@0.0.1",
+              "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "concat-stream": {
               "version": "1.4.7",
-              "from": "concat-stream@~1.4.1",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@~0.0.5",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@^1.1.0",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@^0.1.4",
+                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
-              "from": "constants-browserify@~0.0.1",
+              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
               "version": "3.9.13",
-              "from": "crypto-browserify@^3.0.0",
+              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
               "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
               "dependencies": {
                 "browserify-aes": {
                   "version": "1.0.0",
-                  "from": "browserify-aes@^1.0.0",
+                  "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
                 },
                 "browserify-sign": {
                   "version": "2.8.0",
-                  "from": "browserify-sign@2.8.0",
+                  "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@^1.0.0",
+                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
                       "version": "1.1.1",
-                      "from": "browserify-rsa@^1.1.0",
+                      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "elliptic@^1.0.0",
+                      "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "brorand@^1.0.1",
+                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "hash.js@^1.0.0",
+                          "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-asn1": {
                       "version": "2.0.0",
-                      "from": "parse-asn1@^2.0.0",
+                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "1.0.3",
-                          "from": "asn1.js@^1.0.0",
+                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "minimalistic-assert@^1.0.0",
+                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
                         "asn1.js-rfc3280": {
                           "version": "1.0.0",
-                          "from": "asn1.js-rfc3280@^1.0.0",
+                          "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                         },
                         "pemstrip": {
                           "version": "0.0.1",
-                          "from": "pemstrip@0.0.1",
+                          "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                         }
                       }
@@ -5776,27 +5747,27 @@
                 },
                 "create-ecdh": {
                   "version": "2.0.0",
-                  "from": "create-ecdh@^2.0.0",
+                  "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@^1.0.0",
+                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "elliptic@^1.0.0",
+                      "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "brorand@^1.0.1",
+                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "hash.js@^1.0.0",
+                          "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
@@ -5805,44 +5776,44 @@
                 },
                 "create-hash": {
                   "version": "1.1.1",
-                  "from": "create-hash@^1.1.0",
+                  "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
                   "dependencies": {
                     "ripemd160": {
                       "version": "1.0.0",
-                      "from": "ripemd160@^1.0.0",
+                      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                     },
                     "sha.js": {
                       "version": "2.3.6",
-                      "from": "sha.js@^2.3.6",
+                      "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                     }
                   }
                 },
                 "create-hmac": {
                   "version": "1.1.3",
-                  "from": "create-hmac@^1.1.0",
+                  "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
                 },
                 "diffie-hellman": {
                   "version": "3.0.1",
-                  "from": "diffie-hellman@^3.0.1",
+                  "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@^1.0.0",
+                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "miller-rabin": {
                       "version": "1.1.5",
-                      "from": "miller-rabin@^1.1.2",
+                      "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "brorand@^1.0.1",
+                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         }
                       }
@@ -5851,37 +5822,37 @@
                 },
                 "pbkdf2-compat": {
                   "version": "3.0.2",
-                  "from": "pbkdf2-compat@^3.0.1",
+                  "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                 },
                 "public-encrypt": {
                   "version": "2.0.0",
-                  "from": "public-encrypt@^2.0.0",
+                  "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@^1.0.0",
+                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
                       "version": "2.0.0",
-                      "from": "browserify-rsa@^2.0.0",
+                      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                     },
                     "parse-asn1": {
                       "version": "3.0.0",
-                      "from": "parse-asn1@^3.0.0",
+                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "1.0.3",
-                          "from": "asn1.js@^1.0.0",
+                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "minimalistic-assert@^1.0.0",
+                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
@@ -5892,56 +5863,56 @@
                 },
                 "randombytes": {
                   "version": "2.0.1",
-                  "from": "randombytes@^2.0.0",
+                  "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "1.0.0",
-              "from": "deep-equal@^1.0.0",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
             },
             "deps-sort": {
               "version": "1.3.5",
-              "from": "deps-sort@^1.3.5",
+              "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.8.4",
-                  "from": "JSONStream@~0.8.4",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.3.6",
-                      "from": "through@>=2.2.7 <3",
+                      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@~0.2.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@~0.5.1",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.17",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
@@ -5952,54 +5923,54 @@
             },
             "domain-browser": {
               "version": "1.1.4",
-              "from": "domain-browser@~1.1.0",
+              "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
               "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
             },
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@~0.0.2",
+              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
             },
             "events": {
               "version": "1.0.2",
-              "from": "events@~1.0.0",
+              "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
             },
             "glob": {
               "version": "4.5.3",
-              "from": "glob@^4.0.5",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "2.0.4",
-                  "from": "minimatch@^2.0.1",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -6008,12 +5979,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@^1.3.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -6022,66 +5993,66 @@
             },
             "has": {
               "version": "1.0.0",
-              "from": "has@^1.0.0",
+              "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
             },
             "http-browserify": {
               "version": "1.7.0",
-              "from": "http-browserify@^1.4.0",
+              "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "dependencies": {
                 "Base64": {
                   "version": "0.2.1",
-                  "from": "Base64@~0.2.0",
+                  "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
                 }
               }
             },
             "https-browserify": {
               "version": "0.0.0",
-              "from": "https-browserify@~0.0.0",
+              "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
               "version": "6.2.1",
-              "from": "insert-module-globals@^6.2.0",
+              "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
               "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "JSONStream@~0.7.1",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     }
                   }
                 },
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "combine-source-map@~0.3.0",
+                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.1",
-                      "from": "inline-source-map@~0.3.0",
+                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.3.0",
-                          "from": "source-map@~0.3.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -6090,17 +6061,17 @@
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "convert-source-map@~0.3.0",
+                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@~0.1.31",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -6109,17 +6080,17 @@
                 },
                 "lexical-scope": {
                   "version": "1.1.0",
-                  "from": "lexical-scope@~1.1.0",
+                  "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
                   "dependencies": {
                     "astw": {
                       "version": "1.1.0",
-                      "from": "astw@~1.1.0",
+                      "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                       "dependencies": {
                         "esprima-fb": {
                           "version": "3001.1.0-dev-harmony-fb",
-                          "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
                           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                         }
                       }
@@ -6128,39 +6099,39 @@
                 },
                 "process": {
                   "version": "0.6.0",
-                  "from": "process@~0.6.0",
+                  "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@~2.3.4",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "labeled-stream-splicer": {
               "version": "1.0.2",
-              "from": "labeled-stream-splicer@^1.0.0",
+              "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
               "dependencies": {
                 "stream-splicer": {
                   "version": "1.3.1",
-                  "from": "stream-splicer@^1.1.0",
+                  "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
                   "dependencies": {
                     "readable-wrap": {
                       "version": "1.0.0",
-                      "from": "readable-wrap@^1.0.0",
+                      "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                     },
                     "indexof": {
                       "version": "0.0.1",
-                      "from": "indexof@0.0.1",
+                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     }
                   }
@@ -6169,101 +6140,101 @@
             },
             "module-deps": {
               "version": "3.7.3",
-              "from": "module-deps@^3.7.0",
+              "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.3.tgz",
               "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.3.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "JSONStream@~0.7.1",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.3.6",
-                      "from": "through@>=2.2.7 <3",
+                      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                     }
                   }
                 },
                 "detective": {
                   "version": "4.0.0",
-                  "from": "detective@^4.0.0",
+                  "from": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "0.9.0",
-                      "from": "acorn@~0.9.0",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                     },
                     "escodegen": {
                       "version": "1.6.1",
-                      "from": "escodegen@^1.4.1",
+                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                       "dependencies": {
                         "estraverse": {
                           "version": "1.9.3",
-                          "from": "estraverse@^1.9.1",
+                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                         },
                         "esutils": {
                           "version": "1.1.6",
-                          "from": "esutils@^1.1.6",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                         },
                         "esprima": {
                           "version": "1.2.5",
-                          "from": "esprima@^1.2.2",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                         },
                         "optionator": {
                           "version": "0.5.0",
-                          "from": "optionator@^0.5.0",
+                          "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                           "dependencies": {
                             "prelude-ls": {
                               "version": "1.1.1",
-                              "from": "prelude-ls@~1.1.1",
+                              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                             },
                             "deep-is": {
                               "version": "0.1.3",
-                              "from": "deep-is@~0.1.2",
+                              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@~0.0.2",
+                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             },
                             "type-check": {
                               "version": "0.3.1",
-                              "from": "type-check@~0.3.1",
+                              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                             },
                             "levn": {
                               "version": "0.2.5",
-                              "from": "levn@~0.2.5",
+                              "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                             },
                             "fast-levenshtein": {
                               "version": "1.0.6",
-                              "from": "fast-levenshtein@~1.0.0",
+                              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
                               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                             }
                           }
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@~0.1.40",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -6274,34 +6245,34 @@
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@~0.2.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "stream-combiner2": {
                   "version": "1.0.2",
-                  "from": "stream-combiner2@~1.0.0",
+                  "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
                   "dependencies": {
                     "through2": {
                       "version": "0.5.1",
-                      "from": "through2@~0.5.1",
+                      "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@~1.0.17",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             }
                           }
                         },
                         "xtend": {
                           "version": "3.0.0",
-                          "from": "xtend@~3.0.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                         }
                       }
@@ -6310,41 +6281,41 @@
                 },
                 "subarg": {
                   "version": "0.0.1",
-                  "from": "subarg@0.0.1",
+                  "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "minimist@~0.0.7",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "through2@~0.4.1",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.17",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "xtend@~2.1.1",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@~0.4.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -6353,249 +6324,249 @@
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@^4.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "os-browserify": {
               "version": "0.1.2",
-              "from": "os-browserify@~0.1.1",
+              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
             },
             "parents": {
               "version": "1.0.1",
-              "from": "parents@^1.0.1",
+              "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
               "dependencies": {
                 "path-platform": {
                   "version": "0.11.15",
-                  "from": "path-platform@~0.11.15",
+                  "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
                   "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
                 }
               }
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "path-browserify@~0.0.0",
+              "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
               "version": "0.10.1",
-              "from": "process@^0.10.0",
+              "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
             },
             "punycode": {
               "version": "1.2.4",
-              "from": "punycode@~1.2.3",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "querystring-es3@~0.2.0",
+              "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@^1.1.13",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@^1.1.4",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "shallow-copy": {
               "version": "0.0.1",
-              "from": "shallow-copy@0.0.1",
+              "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
             },
             "shasum": {
               "version": "1.0.1",
-              "from": "shasum@^1.0.0",
+              "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
               "dependencies": {
                 "json-stable-stringify": {
                   "version": "0.0.1",
-                  "from": "json-stable-stringify@~0.0.0",
+                  "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
-                      "from": "jsonify@~0.0.0",
+                      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                     }
                   }
                 },
                 "sha.js": {
                   "version": "2.3.6",
-                  "from": "sha.js@~2.3.0",
+                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                 }
               }
             },
             "shell-quote": {
               "version": "0.0.1",
-              "from": "shell-quote@~0.0.1",
+              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "from": "stream-browserify@^1.0.0",
+              "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@~0.10.x",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "subarg": {
               "version": "1.0.0",
-              "from": "subarg@^1.0.0",
+              "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
             },
             "syntax-error": {
               "version": "1.1.2",
-              "from": "syntax-error@^1.1.1",
+              "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "acorn@~0.9.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "1.1.1",
-              "from": "through2@^1.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "dependencies": {
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "timers-browserify": {
               "version": "1.4.0",
-              "from": "timers-browserify@^1.0.1",
+              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "tty-browserify@~0.0.0",
+              "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
             "url": {
               "version": "0.10.3",
-              "from": "url@~0.10.1",
+              "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@1.3.2",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 },
                 "querystring": {
                   "version": "0.2.0",
-                  "from": "querystring@0.2.0",
+                  "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@~0.10.1",
+              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "vm-browserify@~0.0.1",
+              "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "3.0.0",
-              "from": "xtend@^3.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             }
           }
         },
         "chokidar": {
           "version": "1.0.0-rc5",
-          "from": "chokidar@^1.0.0-rc4",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.2.1",
-              "from": "anymatch@^1.1.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.1.5",
-                  "from": "micromatch@^2.1.0",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@^1.0.1",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
                           "version": "0.2.2",
-                          "from": "array-slice@^0.2.2",
+                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
                         }
                       }
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@^1.8.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@^1.8.1",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.0",
-                              "from": "fill-range@^2.1.0",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@^1.1.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "0.2.0",
-                                  "from": "isobject@^0.2.0",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@^1.1.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.0",
-                                  "from": "repeat-string@^1.5.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.0.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.0.tgz"
                                 }
                               }
@@ -6604,254 +6575,254 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@^0.2.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.0",
-                          "from": "repeat-element@^1.1.0",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
                         }
                       }
                     },
                     "debug": {
                       "version": "2.1.3",
-                      "from": "debug@^2.1.3",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.0",
-                          "from": "ms@0.7.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.1",
-                      "from": "expand-brackets@^0.1.1",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@^2.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@^1.1.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "0.2.1",
-                      "from": "object.omit@^0.2.1",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@^0.1.1",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@^0.1.4",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "0.2.0",
-                          "from": "isobject@^0.2.0",
+                          "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.0",
-                      "from": "parse-glob@^3.0.0",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@^0.2.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.0",
-                          "from": "is-dotfile@^1.0.0",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@^1.0.0",
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.3.0",
-                      "from": "regex-cache@^0.3.0",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
                       "dependencies": {
                         "benchmarked": {
                           "version": "0.1.4",
-                          "from": "benchmarked@^0.1.3",
+                          "from": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
                           "dependencies": {
                             "ansi": {
                               "version": "0.3.0",
-                              "from": "ansi@^0.3.0",
+                              "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                             },
                             "benchmark": {
                               "version": "1.0.0",
-                              "from": "benchmark@^1.0.0",
+                              "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                             },
                             "chalk": {
                               "version": "1.0.0",
-                              "from": "chalk@^1.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.0.1",
-                                  "from": "ansi-styles@^2.0.1",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.3",
-                                  "from": "escape-string-regexp@^1.0.2",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "1.0.3",
-                                  "from": "has-ansi@^1.0.3",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "1.1.1",
-                                      "from": "ansi-regex@^1.1.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                                     },
                                     "get-stdin": {
                                       "version": "4.0.1",
-                                      "from": "get-stdin@^4.0.1",
+                                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "2.0.1",
-                                  "from": "strip-ansi@^2.0.1",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "1.1.1",
-                                      "from": "ansi-regex@^1.1.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "1.3.1",
-                                  "from": "supports-color@^1.3.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                                 }
                               }
                             },
                             "extend-shallow": {
                               "version": "1.1.2",
-                              "from": "extend-shallow@^1.1.2",
+                              "from": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
                             },
                             "file-reader": {
                               "version": "1.0.0",
-                              "from": "file-reader@^1.0.0",
+                              "from": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
                               "dependencies": {
                                 "extend-shallow": {
                                   "version": "0.2.0",
-                                  "from": "extend-shallow@^0.2.0",
+                                  "from": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
                                   "dependencies": {
                                     "array-slice": {
                                       "version": "0.2.2",
-                                      "from": "array-slice@^0.2.2",
+                                      "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz",
                                       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
                                     }
                                   }
                                 },
                                 "map-files": {
                                   "version": "0.3.0",
-                                  "from": "map-files@^0.3.0",
+                                  "from": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
                                   "dependencies": {
                                     "globby": {
                                       "version": "0.1.1",
-                                      "from": "globby@^0.1.1",
+                                      "from": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
                                       "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
                                       "dependencies": {
                                         "array-differ": {
                                           "version": "0.1.0",
-                                          "from": "array-differ@^0.1.0",
+                                          "from": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
                                           "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
                                         },
                                         "array-union": {
                                           "version": "0.1.0",
-                                          "from": "array-union@^0.1.0",
+                                          "from": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
                                           "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
                                           "dependencies": {
                                             "array-uniq": {
                                               "version": "0.1.1",
-                                              "from": "array-uniq@^0.1.0",
+                                              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
                                               "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                                             }
                                           }
                                         },
                                         "async": {
                                           "version": "0.9.0",
-                                          "from": "async@^0.9.0",
+                                          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                                         },
                                         "glob": {
                                           "version": "4.5.3",
-                                          "from": "glob@^4.0.2",
+                                          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                                           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                                           "dependencies": {
                                             "inflight": {
                                               "version": "1.0.4",
-                                              "from": "inflight@^1.0.4",
+                                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                               "dependencies": {
                                                 "wrappy": {
                                                   "version": "1.0.1",
-                                                  "from": "wrappy@1",
+                                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                                 }
                                               }
                                             },
                                             "inherits": {
                                               "version": "2.0.1",
-                                              "from": "inherits@2",
+                                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                             },
                                             "minimatch": {
                                               "version": "2.0.4",
-                                              "from": "minimatch@^2.0.1",
+                                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                                               "dependencies": {
                                                 "brace-expansion": {
                                                   "version": "1.1.0",
-                                                  "from": "brace-expansion@^1.0.0",
+                                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                                                   "dependencies": {
                                                     "balanced-match": {
                                                       "version": "0.2.0",
-                                                      "from": "balanced-match@^0.2.0",
+                                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                                     },
                                                     "concat-map": {
                                                       "version": "0.0.1",
-                                                      "from": "concat-map@0.0.1",
+                                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                                     }
                                                   }
@@ -6860,12 +6831,12 @@
                                             },
                                             "once": {
                                               "version": "1.3.1",
-                                              "from": "once@^1.3.0",
+                                              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                                               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                                               "dependencies": {
                                                 "wrappy": {
                                                   "version": "1.0.1",
-                                                  "from": "wrappy@1",
+                                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                                 }
                                               }
@@ -6876,12 +6847,12 @@
                                     },
                                     "relative": {
                                       "version": "0.1.6",
-                                      "from": "relative@^0.1.6",
+                                      "from": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
                                       "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
                                       "dependencies": {
                                         "normalize-path": {
                                           "version": "0.1.1",
-                                          "from": "normalize-path@^0.1.1",
+                                          "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz",
                                           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
                                         }
                                       }
@@ -6890,34 +6861,34 @@
                                 },
                                 "read-yaml": {
                                   "version": "1.0.0",
-                                  "from": "read-yaml@^1.0.0",
+                                  "from": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
                                   "dependencies": {
                                     "js-yaml": {
                                       "version": "3.2.7",
-                                      "from": "js-yaml@^3.2.3",
+                                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                                       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                                       "dependencies": {
                                         "argparse": {
                                           "version": "1.0.2",
-                                          "from": "argparse@~ 1.0.0",
+                                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                                           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                                           "dependencies": {
                                             "lodash": {
                                               "version": "3.6.0",
-                                              "from": "lodash@>= 3.2.0 < 4.0.0",
+                                              "from": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
                                               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
                                             },
                                             "sprintf-js": {
                                               "version": "1.0.2",
-                                              "from": "sprintf-js@~1.0.2",
+                                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
                                               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                                             }
                                           }
                                         },
                                         "esprima": {
                                           "version": "2.0.0",
-                                          "from": "esprima@~ 2.0.0",
+                                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
                                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                                         }
                                       }
@@ -6928,92 +6899,92 @@
                             },
                             "for-own": {
                               "version": "0.1.3",
-                              "from": "for-own@^0.1.3",
+                              "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.4",
-                                  "from": "for-in@^0.1.4",
+                                  "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                                 }
                               }
                             },
                             "has-values": {
                               "version": "0.1.3",
-                              "from": "has-values@^0.1.2",
+                              "from": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
                             }
                           }
                         },
                         "chalk": {
                           "version": "0.5.1",
-                          "from": "chalk@^0.5.1",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "1.1.0",
-                              "from": "ansi-styles@^1.1.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.3",
-                              "from": "escape-string-regexp@^1.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                             },
                             "has-ansi": {
                               "version": "0.1.0",
-                              "from": "has-ansi@^0.1.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@^0.2.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "0.3.0",
-                              "from": "strip-ansi@^0.3.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@^0.2.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "0.2.0",
-                              "from": "supports-color@^0.2.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                             }
                           }
                         },
                         "micromatch": {
                           "version": "1.6.2",
-                          "from": "micromatch@^1.2.2",
+                          "from": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
                           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
                           "dependencies": {
                             "extglob": {
                               "version": "0.2.0",
-                              "from": "extglob@^0.2.0",
+                              "from": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
                             },
                             "parse-glob": {
                               "version": "2.1.1",
-                              "from": "parse-glob@^2.1.1",
+                              "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
                               "dependencies": {
                                 "glob-base": {
                                   "version": "0.1.1",
-                                  "from": "glob-base@^0.1.0",
+                                  "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
                                 },
                                 "glob-path-regex": {
                                   "version": "1.0.0",
-                                  "from": "glob-path-regex@^1.0.0",
+                                  "from": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
                                 }
                               }
@@ -7022,17 +6993,17 @@
                         },
                         "to-key": {
                           "version": "1.0.0",
-                          "from": "to-key@^1.0.0",
+                          "from": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
                           "dependencies": {
                             "arr-map": {
                               "version": "1.0.0",
-                              "from": "arr-map@^1.0.0",
+                              "from": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
                             },
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@^0.1.4",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
@@ -7045,86 +7016,86 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@^1.0.0",
+              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@^0.1.5",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@^1.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.0",
-              "from": "is-binary-path@^1.0.0",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.0",
-                  "from": "binary-extensions@^1.0.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@^1.1.3",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@^1.3.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@~2.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.12",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26-2",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -7135,12 +7106,12 @@
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@~0.0.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "xtend@^4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }

--- a/src/nyc_trees/npm-shrinkwrap.json
+++ b/src/nyc_trees/npm-shrinkwrap.json
@@ -5430,6 +5430,11 @@
         }
       }
     },
+    "toastr": {
+      "version": "2.0.4",
+      "from": "https://registry.npmjs.org/toastr/-/toastr-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/toastr/-/toastr-2.0.4.tgz"
+    },
     "vinyl-buffer": {
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
@@ -5496,65 +5501,96 @@
       }
     },
     "watchify": {
-      "version": "2.1.1",
-      "from": "https://registry.npmjs.org/watchify/-/watchify-2.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/watchify/-/watchify-2.1.1.tgz",
+      "version": "3.0.0",
+      "from": "watchify@3.0.0",
+      "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.0.0.tgz",
       "dependencies": {
         "browserify": {
-          "version": "6.3.4",
-          "from": "https://registry.npmjs.org/browserify/-/browserify-6.3.4.tgz",
-          "resolved": "https://registry.npmjs.org/browserify/-/browserify-6.3.4.tgz",
+          "version": "9.0.3",
+          "from": "browserify@^9.0.2",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.8.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "version": "0.10.0",
+              "from": "JSONStream@~0.10.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+                  "from": "through@>=2.2.7 <3",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "assert": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+              "version": "1.3.0",
+              "from": "assert@~1.3.0",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
             },
             "browser-pack": {
-              "version": "3.2.0",
-              "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+              "version": "4.0.1",
+              "from": "browser-pack@^4.0.0",
+              "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
               "dependencies": {
+                "JSONStream": {
+                  "version": "0.8.4",
+                  "from": "JSONStream@~0.8.4",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.6",
+                      "from": "through@>=2.2.7 <3",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                    }
+                  }
+                },
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "from": "combine-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
+                      "version": "0.3.1",
+                      "from": "inline-source-map@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.3.0",
+                          "from": "source-map@~0.3.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                      "from": "convert-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@~0.1.31",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -5563,175 +5599,175 @@
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+                  "from": "through2@~0.5.1",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.17",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "umd": {
+                  "version": "3.0.0",
+                  "from": "umd@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
                 }
               }
             },
             "browser-resolve": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.5.0.tgz",
-              "dependencies": {
-                "resolve": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
-                }
-              }
+              "version": "1.8.2",
+              "from": "browser-resolve@^1.7.1",
+              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "from": "browserify-zlib@~0.1.2",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
-                  "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
-                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+                  "version": "0.2.6",
+                  "from": "pako@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
                 }
               }
             },
             "buffer": {
-              "version": "2.8.2",
-              "from": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
+              "version": "3.1.2",
+              "from": "buffer@^3.0.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
               "dependencies": {
                 "base64-js": {
-                  "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
+                  "version": "0.0.8",
+                  "from": "base64-js@0.0.8",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
+                  "from": "ieee754@^1.1.4",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+                  "from": "is-array@^1.0.1",
                   "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
                 }
               }
             },
             "builtins": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+              "from": "builtins@~0.0.3",
               "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
             },
             "commondir": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+              "from": "commondir@0.0.1",
               "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "concat-stream": {
               "version": "1.4.7",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+              "from": "concat-stream@~1.4.1",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@~0.0.5",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "from": "console-browserify@^1.1.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+              "from": "constants-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
-              "version": "3.9.7",
-              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.7.tgz",
-              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.7.tgz",
+              "version": "3.9.13",
+              "from": "crypto-browserify@^3.0.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
               "dependencies": {
                 "browserify-aes": {
-                  "version": "0.8.1",
-                  "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.1.tgz",
-                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.1.tgz"
+                  "version": "1.0.0",
+                  "from": "browserify-aes@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
                 },
                 "browserify-sign": {
                   "version": "2.8.0",
-                  "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+                  "from": "browserify-sign@2.8.0",
                   "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
                   "dependencies": {
                     "bn.js": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                      "version": "1.3.0",
+                      "from": "bn.js@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
+                      "from": "browserify-rsa@^1.1.0",
                       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                      "from": "elliptic@^1.0.0",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
+                          "from": "hash.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-asn1": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                      "from": "parse-asn1@^2.0.0",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
+                          "version": "1.0.3",
+                          "from": "asn1.js@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                              "from": "minimalistic-assert@^1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
                         "asn1.js-rfc3280": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
+                          "from": "asn1.js-rfc3280@^1.0.0",
                           "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                         },
                         "pemstrip": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
+                          "from": "pemstrip@0.0.1",
                           "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                         }
                       }
@@ -5739,28 +5775,28 @@
                   }
                 },
                 "create-ecdh": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz",
+                  "version": "2.0.0",
+                  "from": "create-ecdh@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                      "version": "1.3.0",
+                      "from": "bn.js@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                      "from": "elliptic@^1.0.0",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
+                          "from": "hash.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
@@ -5768,45 +5804,45 @@
                   }
                 },
                 "create-hash": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "create-hash@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
                   "dependencies": {
                     "ripemd160": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz",
+                      "from": "ripemd160@^1.0.0",
                       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                     },
                     "sha.js": {
                       "version": "2.3.6",
-                      "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+                      "from": "sha.js@^2.3.6",
                       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                     }
                   }
                 },
                 "create-hmac": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.0.tgz"
+                  "version": "1.1.3",
+                  "from": "create-hmac@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
                 },
                 "diffie-hellman": {
-                  "version": "2.2.3",
-                  "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.3.tgz",
+                  "version": "3.0.1",
+                  "from": "diffie-hellman@^3.0.1",
+                  "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
                   "dependencies": {
                     "bn.js": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                      "version": "1.3.0",
+                      "from": "bn.js@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "miller-rabin": {
                       "version": "1.1.5",
-                      "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                      "from": "miller-rabin@^1.1.2",
                       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         }
                       }
@@ -5814,51 +5850,99 @@
                   }
                 },
                 "pbkdf2-compat": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                  "version": "3.0.2",
+                  "from": "pbkdf2-compat@^3.0.1",
+                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                 },
                 "public-encrypt": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz",
+                  "version": "2.0.0",
+                  "from": "public-encrypt@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                      "version": "1.3.0",
+                      "from": "bn.js@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                      "version": "2.0.0",
+                      "from": "browserify-rsa@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                     },
                     "parse-asn1": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                      "version": "3.0.0",
+                      "from": "parse-asn1@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz",
+                          "version": "1.0.3",
+                          "from": "asn1.js@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                              "from": "minimalistic-assert@^1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
-                        },
-                        "asn1.js-rfc3280": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
-                        },
-                        "pemstrip": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "randombytes": {
+                  "version": "2.0.1",
+                  "from": "randombytes@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
+                }
+              }
+            },
+            "deep-equal": {
+              "version": "1.0.0",
+              "from": "deep-equal@^1.0.0",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+            },
+            "deps-sort": {
+              "version": "1.3.5",
+              "from": "deps-sort@^1.3.5",
+              "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "0.8.4",
+                  "from": "JSONStream@~0.8.4",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.6",
+                      "from": "through@>=2.2.7 <3",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "0.2.0",
+                  "from": "minimist@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                },
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "through2@~0.5.1",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.17",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     }
@@ -5866,97 +5950,56 @@
                 }
               }
             },
-            "deep-equal": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
-            },
-            "defined": {
-              "version": "0.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
-            },
-            "deps-sort": {
-              "version": "1.3.5",
-              "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-                },
-                "through2": {
-                  "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
-                }
-              }
-            },
             "domain-browser": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz"
+              "version": "1.1.4",
+              "from": "domain-browser@~1.1.0",
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
             },
             "duplexer2": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
+              "from": "duplexer2@~0.0.2",
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
             },
             "events": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+              "from": "events@~1.0.0",
               "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
             },
             "glob": {
-              "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "version": "4.5.3",
+              "from": "glob@^4.0.5",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "minimatch": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "version": "2.0.4",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -5965,80 +6008,99 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
+            "has": {
+              "version": "1.0.0",
+              "from": "has@^1.0.0",
+              "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
+            },
             "http-browserify": {
               "version": "1.7.0",
-              "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+              "from": "http-browserify@^1.4.0",
               "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "dependencies": {
                 "Base64": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+                  "from": "Base64@~0.2.0",
                   "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
                 }
               }
             },
             "https-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+              "from": "https-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
-              "version": "6.2.0",
-              "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
+              "version": "6.2.1",
+              "from": "insert-module-globals@^6.2.0",
+              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                      "from": "jsonparse@0.0.5",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     }
                   }
                 },
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "from": "combine-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
+                      "version": "0.3.1",
+                      "from": "inline-source-map@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.3.0",
+                          "from": "source-map@~0.3.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                      "from": "convert-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@~0.1.31",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -6047,17 +6109,17 @@
                 },
                 "lexical-scope": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+                  "from": "lexical-scope@~1.1.0",
                   "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
                   "dependencies": {
                     "astw": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                      "from": "astw@~1.1.0",
                       "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                       "dependencies": {
                         "esprima-fb": {
                           "version": "3001.1.0-dev-harmony-fb",
-                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                          "from": "esprima-fb@3001.1.0-dev-harmony-fb",
                           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                         }
                       }
@@ -6066,51 +6128,39 @@
                 },
                 "process": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+                  "from": "process@~0.6.0",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+                  "from": "through@~2.3.4",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "labeled-stream-splicer": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+              "from": "labeled-stream-splicer@^1.0.0",
               "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
               "dependencies": {
                 "stream-splicer": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+                  "from": "stream-splicer@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
                   "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        }
-                      }
-                    },
                     "readable-wrap": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                      "from": "readable-wrap@^1.0.0",
                       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                     },
                     "indexof": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                      "from": "indexof@0.0.1",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     }
                   }
@@ -6118,102 +6168,102 @@
               }
             },
             "module-deps": {
-              "version": "3.6.4",
-              "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.4.tgz",
-              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.4.tgz",
+              "version": "3.7.3",
+              "from": "module-deps@^3.7.0",
+              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.3.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                      "from": "jsonparse@0.0.5",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.3.6",
-                      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+                      "from": "through@>=2.2.7 <3",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                     }
                   }
                 },
                 "detective": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+                  "from": "detective@^4.0.0",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "0.9.0",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
+                      "from": "acorn@~0.9.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                     },
                     "escodegen": {
-                      "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.0.tgz",
-                      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.0.tgz",
+                      "version": "1.6.1",
+                      "from": "escodegen@^1.4.1",
+                      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                       "dependencies": {
                         "estraverse": {
-                          "version": "1.9.1",
-                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz",
-                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
+                          "version": "1.9.3",
+                          "from": "estraverse@^1.9.1",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                         },
                         "esutils": {
                           "version": "1.1.6",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                          "from": "esutils@^1.1.6",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                         },
                         "esprima": {
-                          "version": "1.2.3",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz"
+                          "version": "1.2.5",
+                          "from": "esprima@^1.2.2",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                         },
                         "optionator": {
                           "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                          "from": "optionator@^0.5.0",
                           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                           "dependencies": {
                             "prelude-ls": {
                               "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
+                              "from": "prelude-ls@~1.1.1",
                               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                             },
                             "deep-is": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                              "from": "deep-is@~0.1.2",
                               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                              "from": "wordwrap@~0.0.2",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             },
                             "type-check": {
                               "version": "0.3.1",
-                              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                              "from": "type-check@~0.3.1",
                               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                             },
                             "levn": {
                               "version": "0.2.5",
-                              "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                              "from": "levn@~0.2.5",
                               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                             },
                             "fast-levenshtein": {
                               "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                              "from": "fast-levenshtein@~1.0.0",
                               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                             }
                           }
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@~0.1.40",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -6224,479 +6274,876 @@
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+                  "from": "minimist@~0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-                },
-                "parents": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-                  "dependencies": {
-                    "path-platform": {
-                      "version": "0.11.15",
-                      "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-                      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
-                    }
-                  }
                 },
                 "stream-combiner2": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                  "from": "stream-combiner2@~1.0.0",
                   "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
                   "dependencies": {
                     "through2": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+                      "from": "through2@~0.5.1",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@~1.0.17",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "3.0.0",
+                          "from": "xtend@~3.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "subarg": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+                  "from": "subarg@0.0.1",
                   "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "from": "minimist@~0.0.7",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                  "from": "through2@~0.4.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.17",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                      "from": "xtend@~2.1.1",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                          "from": "object-keys@~0.4.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
                     }
                   }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@^4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "os-browserify": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+              "from": "os-browserify@~0.1.1",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
             },
             "parents": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+              "version": "1.0.1",
+              "from": "parents@^1.0.1",
+              "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
               "dependencies": {
                 "path-platform": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
+                  "version": "0.11.15",
+                  "from": "path-platform@~0.11.15",
+                  "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
                 }
               }
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+              "from": "path-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
-              "version": "0.8.0",
-              "from": "https://registry.npmjs.org/process/-/process-0.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz"
+              "version": "0.10.1",
+              "from": "process@^0.10.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
             },
             "punycode": {
               "version": "1.2.4",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+              "from": "punycode@~1.2.3",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+              "from": "querystring-es3@~0.2.0",
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
-              "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "version": "1.1.13",
+              "from": "readable-stream@^1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
             },
             "resolve": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+              "version": "1.1.6",
+              "from": "resolve@^1.1.4",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "shallow-copy": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+              "from": "shallow-copy@0.0.1",
               "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
             },
             "shasum": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+              "from": "shasum@^1.0.0",
               "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
               "dependencies": {
                 "json-stable-stringify": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                  "from": "json-stable-stringify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
-                      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                      "from": "jsonify@~0.0.0",
                       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                     }
                   }
                 },
                 "sha.js": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+                  "from": "sha.js@~2.3.0",
                   "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                 }
               }
             },
             "shell-quote": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+              "from": "shell-quote@~0.0.1",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "from": "stream-browserify@^1.0.0",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@~0.10.x",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "subarg": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+              "from": "subarg@^1.0.0",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
             },
             "syntax-error": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+              "from": "syntax-error@^1.1.1",
               "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
+                  "from": "acorn@~0.9.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+              "from": "through2@^1.0.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "timers-browserify": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.2.0.tgz",
-              "dependencies": {
-                "process": {
-                  "version": "0.10.0",
-                  "from": "https://registry.npmjs.org/process/-/process-0.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
-                }
-              }
+              "version": "1.4.0",
+              "from": "timers-browserify@^1.0.1",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+              "from": "tty-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
-            "umd": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-              "dependencies": {
-                "rfile": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-                  "dependencies": {
-                    "callsite": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                    },
-                    "resolve": {
-                      "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
-                    }
-                  }
-                },
-                "ruglify": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-                  "dependencies": {
-                    "uglify-js": {
-                      "version": "2.2.5",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                            }
-                          }
-                        },
-                        "optimist": {
-                          "version": "0.3.7",
-                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                          "dependencies": {
-                            "wordwrap": {
-                              "version": "0.0.2",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-                },
-                "uglify-js": {
-                  "version": "2.4.16",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.1.34",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "optimist": {
-                      "version": "0.3.7",
-                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                      "dependencies": {
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "uglify-to-browserify": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "url": {
-              "version": "0.10.2",
-              "from": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
-              "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
+              "version": "0.10.3",
+              "from": "url@~0.10.1",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "from": "punycode@1.3.2",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                },
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "querystring@0.2.0",
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "from": "util@~0.10.1",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "from": "vm-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "from": "indexof@0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "from": "xtend@^3.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             }
           }
         },
         "chokidar": {
-          "version": "0.10.9",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.10.9.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.10.9.tgz",
+          "version": "1.0.0-rc5",
+          "from": "chokidar@^1.0.0-rc4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
           "dependencies": {
+            "anymatch": {
+              "version": "1.2.1",
+              "from": "anymatch@^1.1.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
+              "dependencies": {
+                "micromatch": {
+                  "version": "2.1.5",
+                  "from": "micromatch@^2.1.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "1.0.1",
+                      "from": "arr-diff@^1.0.1",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "dependencies": {
+                        "array-slice": {
+                          "version": "0.2.2",
+                          "from": "array-slice@^0.2.2",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+                        }
+                      }
+                    },
+                    "braces": {
+                      "version": "1.8.0",
+                      "from": "braces@^1.8.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "from": "expand-range@^1.8.1",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.0",
+                              "from": "fill-range@^2.1.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "1.1.2",
+                                  "from": "is-number@^1.1.0",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                },
+                                "isobject": {
+                                  "version": "0.2.0",
+                                  "from": "isobject@^0.2.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                                },
+                                "randomatic": {
+                                  "version": "1.1.0",
+                                  "from": "randomatic@^1.1.0",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.0",
+                                  "from": "repeat-string@^1.5.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "preserve@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.0",
+                          "from": "repeat-element@^1.1.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.1.3",
+                      "from": "debug@^2.1.3",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.0",
+                          "from": "ms@0.7.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.1",
+                      "from": "expand-brackets@^0.1.1",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "filename-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "1.1.0",
+                      "from": "kind-of@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                    },
+                    "object.omit": {
+                      "version": "0.2.1",
+                      "from": "object.omit@^0.2.1",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.3",
+                          "from": "for-own@^0.1.1",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@^0.1.4",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        },
+                        "isobject": {
+                          "version": "0.2.0",
+                          "from": "isobject@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.0",
+                      "from": "parse-glob@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.2.0",
+                          "from": "glob-base@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.0",
+                          "from": "is-dotfile@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.3.0",
+                      "from": "regex-cache@^0.3.0",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
+                      "dependencies": {
+                        "benchmarked": {
+                          "version": "0.1.4",
+                          "from": "benchmarked@^0.1.3",
+                          "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@^0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            },
+                            "benchmark": {
+                              "version": "1.0.0",
+                              "from": "benchmark@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                            },
+                            "chalk": {
+                              "version": "1.0.0",
+                              "from": "chalk@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "from": "ansi-styles@^2.0.1",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@^1.0.2",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "from": "has-ansi@^1.0.3",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@^1.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    },
+                                    "get-stdin": {
+                                      "version": "4.0.1",
+                                      "from": "get-stdin@^4.0.1",
+                                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "from": "strip-ansi@^2.0.1",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@^1.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "from": "supports-color@^1.3.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                }
+                              }
+                            },
+                            "extend-shallow": {
+                              "version": "1.1.2",
+                              "from": "extend-shallow@^1.1.2",
+                              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
+                            },
+                            "file-reader": {
+                              "version": "1.0.0",
+                              "from": "file-reader@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
+                              "dependencies": {
+                                "extend-shallow": {
+                                  "version": "0.2.0",
+                                  "from": "extend-shallow@^0.2.0",
+                                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
+                                  "dependencies": {
+                                    "array-slice": {
+                                      "version": "0.2.2",
+                                      "from": "array-slice@^0.2.2",
+                                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+                                    }
+                                  }
+                                },
+                                "map-files": {
+                                  "version": "0.3.0",
+                                  "from": "map-files@^0.3.0",
+                                  "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
+                                  "dependencies": {
+                                    "globby": {
+                                      "version": "0.1.1",
+                                      "from": "globby@^0.1.1",
+                                      "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
+                                      "dependencies": {
+                                        "array-differ": {
+                                          "version": "0.1.0",
+                                          "from": "array-differ@^0.1.0",
+                                          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
+                                        },
+                                        "array-union": {
+                                          "version": "0.1.0",
+                                          "from": "array-union@^0.1.0",
+                                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+                                          "dependencies": {
+                                            "array-uniq": {
+                                              "version": "0.1.1",
+                                              "from": "array-uniq@^0.1.0",
+                                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "async": {
+                                          "version": "0.9.0",
+                                          "from": "async@^0.9.0",
+                                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                        },
+                                        "glob": {
+                                          "version": "4.5.3",
+                                          "from": "glob@^4.0.2",
+                                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                                          "dependencies": {
+                                            "inflight": {
+                                              "version": "1.0.4",
+                                              "from": "inflight@^1.0.4",
+                                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                              "dependencies": {
+                                                "wrappy": {
+                                                  "version": "1.0.1",
+                                                  "from": "wrappy@1",
+                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "inherits": {
+                                              "version": "2.0.1",
+                                              "from": "inherits@2",
+                                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                            },
+                                            "minimatch": {
+                                              "version": "2.0.4",
+                                              "from": "minimatch@^2.0.1",
+                                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                                              "dependencies": {
+                                                "brace-expansion": {
+                                                  "version": "1.1.0",
+                                                  "from": "brace-expansion@^1.0.0",
+                                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                                  "dependencies": {
+                                                    "balanced-match": {
+                                                      "version": "0.2.0",
+                                                      "from": "balanced-match@^0.2.0",
+                                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                                    },
+                                                    "concat-map": {
+                                                      "version": "0.0.1",
+                                                      "from": "concat-map@0.0.1",
+                                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "once": {
+                                              "version": "1.3.1",
+                                              "from": "once@^1.3.0",
+                                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                              "dependencies": {
+                                                "wrappy": {
+                                                  "version": "1.0.1",
+                                                  "from": "wrappy@1",
+                                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "relative": {
+                                      "version": "0.1.6",
+                                      "from": "relative@^0.1.6",
+                                      "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
+                                      "dependencies": {
+                                        "normalize-path": {
+                                          "version": "0.1.1",
+                                          "from": "normalize-path@^0.1.1",
+                                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "read-yaml": {
+                                  "version": "1.0.0",
+                                  "from": "read-yaml@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
+                                  "dependencies": {
+                                    "js-yaml": {
+                                      "version": "3.2.7",
+                                      "from": "js-yaml@^3.2.3",
+                                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                                      "dependencies": {
+                                        "argparse": {
+                                          "version": "1.0.2",
+                                          "from": "argparse@~ 1.0.0",
+                                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                                          "dependencies": {
+                                            "lodash": {
+                                              "version": "3.6.0",
+                                              "from": "lodash@>= 3.2.0 < 4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                                            },
+                                            "sprintf-js": {
+                                              "version": "1.0.2",
+                                              "from": "sprintf-js@~1.0.2",
+                                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "esprima": {
+                                          "version": "2.0.0",
+                                          "from": "esprima@~ 2.0.0",
+                                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@^0.1.3",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@^0.1.4",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "has-values": {
+                              "version": "0.1.3",
+                              "from": "has-values@^0.1.2",
+                              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "chalk": {
+                          "version": "0.5.1",
+                          "from": "chalk@^0.5.1",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "1.1.0",
+                              "from": "ansi-styles@^1.1.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3",
+                              "from": "escape-string-regexp@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "0.1.0",
+                              "from": "has-ansi@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@^0.2.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "0.3.0",
+                              "from": "strip-ansi@^0.3.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@^0.2.1",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "0.2.0",
+                              "from": "supports-color@^0.2.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                            }
+                          }
+                        },
+                        "micromatch": {
+                          "version": "1.6.2",
+                          "from": "micromatch@^1.2.2",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
+                          "dependencies": {
+                            "extglob": {
+                              "version": "0.2.0",
+                              "from": "extglob@^0.2.0",
+                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
+                            },
+                            "parse-glob": {
+                              "version": "2.1.1",
+                              "from": "parse-glob@^2.1.1",
+                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.1.1",
+                                  "from": "glob-base@^0.1.0",
+                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
+                                },
+                                "glob-path-regex": {
+                                  "version": "1.0.0",
+                                  "from": "glob-path-regex@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "to-key": {
+                          "version": "1.0.0",
+                          "from": "to-key@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
+                          "dependencies": {
+                            "arr-map": {
+                              "version": "1.0.0",
+                              "from": "arr-map@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
+                            },
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@^0.1.4",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.0",
+              "from": "arrify@^1.0.0",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@^0.1.5",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "glob-parent": {
+              "version": "1.2.0",
+              "from": "glob-parent@^1.0.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+            },
+            "is-binary-path": {
+              "version": "1.0.0",
+              "from": "is-binary-path@^1.0.0",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.3.0",
+                  "from": "binary-extensions@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "1.1.3",
+              "from": "is-glob@^1.1.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+            },
             "readdirp": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.1.0.tgz",
+              "version": "1.3.0",
+              "from": "readdirp@^1.3.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "from": "graceful-fs@~2.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@~0.2.12",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@~1.0.26-2",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
               }
-            },
-            "async-each": {
-              "version": "0.1.6",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             }
           }
         },
-        "through2": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-            }
-          }
+        "defined": {
+          "version": "0.0.0",
+          "from": "defined@~0.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+        },
+        "xtend": {
+          "version": "4.0.0",
+          "from": "xtend@^4.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }
-    },
-    "toastr": {
-      "version": "2.0.4",
-      "from": "toastr@*",
-      "resolved": "https://registry.npmjs.org/toastr/-/toastr-2.0.4.tgz"
     }
   }
 }

--- a/src/nyc_trees/package.json
+++ b/src/nyc_trees/package.json
@@ -44,8 +44,8 @@
     "toastr": "^2.0.4"
   },
   "devDependencies": {
-    "browserify": "^8.1.1",
-    "browserify-shim": "^3.8.1",
+    "browserify": "^9.0.4",
+    "browserify-shim": "^3.8.3",
     "chai": "^1.10.0",
     "csswring": "~1.3.0",
     "del": "^0.1.3",

--- a/src/nyc_trees/package.json
+++ b/src/nyc_trees/package.json
@@ -73,7 +73,7 @@
     "through2": "~0.6.3",
     "vinyl-buffer": "~1.0.0",
     "vinyl-source-stream": "^1.0.0",
-    "watchify": "^2.1.1"
+    "watchify": "^3.0.0"
   },
   "scripts": {
     "build": "sudo -u nyc-trees ./node_modules/.bin/gulp",


### PR DESCRIPTION
Some fixes that seem to make using watchify more stable have landed since
our previous version, but upgrading was not possible because watchify
switched away from polling to inotify for linux hosts, which does not
work in a VirtualBox shared folder.

3.0 added the ability to specify polling for file watching, which lets us
update.

Attempts to fix #712