### PR TITLE
Make `debugcelery` stop the correct upstart job

### DIFF
--- a/scripts/debugcelery.sh
+++ b/scripts/debugcelery.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-STOP_SERVICE="(sudo service nyc-trees-celery stop || /bin/true)"
+STOP_SERVICE="(sudo service celery stop || /bin/true)"
 CHANGE_DIR="cd /opt/app/"
 RUN_CELERY="envdir /etc/nyc-trees.d/env celery -A 'nyc_trees.celery:app' worker --autoreload -l debug"
 


### PR DESCRIPTION
fixes an issue @jwalgran and I ran into during development where the
script will start more celery workers that don't seem to get jobs if
there is already a celery process in place.