### PR TITLE
Hide progress counts in soft launch mode / show map links in full access mode

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -1,4 +1,5 @@
 {% load utils %}
+{% load waffle_tags %}
 
 <div class="page-dashboard">
 
@@ -10,8 +11,11 @@
                 <div class="row">
                     <div class="col-sm-6 col-sm-push-6">
                         <div class="hero-content">
-                            <h1 class="hero-heading">Welcome back, volun<span class="color--primary">treer!</span></h1>
-                            <p class="hero-text">In the past week, <span class="color--primary">405 trees</span> in <span class="color--primary">12 blocks</span> have been added. We're <span class="color--primary">43%</span> of the way to our goal!</p>
+                            <h1 class="hero-heading">Welcome back,
+                            volun<span class="color--primary">treer!</span></h1>
+                            {% flag full_access %}
+                                <p class="hero-text">In the past week, <span class="color--primary">405 trees</span> in <span class="color--primary">12 blocks</span> have been added. We're <span class="color--primary">43%</span> of the way to our goal!</p>
+                            {% endflag %}
                         </div>
                     </div>
                 </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -15,6 +15,9 @@
                             volun<span class="color--primary">treer!</span></h1>
                             {% flag full_access %}
                                 <p class="hero-text">In the past week, <span class="color--primary">405 trees</span> in <span class="color--primary">12 blocks</span> have been added. We're <span class="color--primary">43%</span> of the way to our goal!</p>
+                                <div class="text-right">
+                                    <a class="hero-link hero-text text-center color--secondary h4" href="{% url 'progress_page' %}">Show me the map →</a>
+                                </div>
                             {% endflag %}
                         </div>
                     </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -12,6 +12,11 @@
                     <div class="col-sm-6 col-sm-push-6">
                         <div class="hero-content">
                             <h1 class="hero-heading">We're mapping <span class="color--primary">every street tree</span> in New York City!</h1>
+                            {% flag full_access %}
+                                <div class="text-right">
+                                    <a class="hero-link hero-text text-center color--secondary h4" href="{% url 'progress_page' %}">Show me the map →</a>
+                                </div>
+                            {% endflag %}
                         </div>
                     </div>
                 </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -1,4 +1,5 @@
 {% load utils %}
+{% load waffle_tags %}
 
 <div class="page-home">
 
@@ -46,6 +47,8 @@
                         </p>
                     </div>
                 </section>
+
+                {% flag full_access %}
                 <section class="section-ticker text-center section-home">
                     <div class="home-container">
                         <h2>Help us count our <span class="color--primary">street trees</span>!</h2>
@@ -97,6 +100,8 @@
                         </div>
                     </div>
                 </section>
+                {% endflag %}
+
                 <section class="section-appeal section-home">
                     <div class="row">
                         <div class="col-sm-6">


### PR DESCRIPTION
There will be no progress until the full launch, so these numbers will always be zero.

Progress map links were removed in 8b2edea, but we want them to be visible when the site is in full access mode.