### PR TITLE
Hide training on soft launch logged in home page

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -29,28 +29,35 @@
     <div class="container">
         <div class="row">
             <main class="col-sm-12 main-dashboard">
-                {% if user.online_training_complete %}
-                {% if immediate_events.event_infos %}
-                <section class="events section-home">
-                    <div class="home-container">
-                        <h4 class="section-heading">This week's events</h4>
-                        <div data-class="event-list-container">
-                            {% include "event/partials/event_list.html" with event_list=immediate_events %}
+                {% flag full_access %}
+                    {% if user.online_training_complete %}
+                    {% if immediate_events.event_infos %}
+                    <section class="events section-home">
+                        <div class="home-container">
+                            <h4 class="section-heading">This week's events</h4>
+                            <div data-class="event-list-container">
+                                {% include "event/partials/event_list.html" with event_list=immediate_events %}
+                            </div>
                         </div>
-                    </div>
-                </section>
-                {% endif %}
-                {% include "users/partials/activity.html" %}
+                    </section>
+                    {% endif %}
+                    {% include "users/partials/activity.html" %}
 
+                    {% else %}
+                    <section class="trainings section-home">
+                        <div class="home-container">
+                            {% include "home/partials/training.html" %}
+                        </div>
+                    </section>
+                    {% endif %}
                 {% else %}
-                <section class="trainings section-home">
-                    <div class="home-container">
-                        {% include "home/partials/training.html" %}
-                    </div>
-                </section>
-                {% endif %}
+                    <section class="soft-launch">
+                        {% with title="" section_id="soft-launch" public=False %}
+                            {% include "users/partials/profile/soft_launch.html"%}
+                        {% endwith %}
+                    </section>
+                {% endflag %}
             </main>
         </div>
     </div>
-
 </div>


### PR DESCRIPTION
The training section is hidden via partial on the user profile page, but
needs a slightly different layout on the logged in home page.

![screen shot 2015-03-31 at 10 59 26 am](https://cloud.githubusercontent.com/assets/17363/6925560/080adfc4-d795-11e4-858e-ccd0ac8c975c.png)

Fixes #1003 