### PR TITLE
Updated and remove dup activation email footers

### DIFF
--- a/src/nyc_trees/templates/registration/activation_email.html
+++ b/src/nyc_trees/templates/registration/activation_email.html
@@ -22,8 +22,9 @@
     </a>
 </p>
 <p>
-    If you have additional questions or need help with your account, please email
-    us at <a href="mailto:TreesCount.Help@parks.nyc.gov">TreesCount.Help@parks.nyc.gov</a>
+    Please contact us at
+    <a href="mailto:TreesCount.Help@parks.nyc.gov">TreesCount.Help@parks.nyc.gov</a>
+    for technical assistance or any questions related to the TreesCount! 2015 website.
 </p>
 </body>
 

--- a/src/nyc_trees/templates/registration/activation_email.txt
+++ b/src/nyc_trees/templates/registration/activation_email.txt
@@ -1,14 +1,13 @@
 {% extends "mail/base_email.txt" %}
 {% load i18n %}
 {% load url from future %}
-{% block content %}
-Thank you for signing up for TreesCount!
+{% block content %}Thank you for signing up for TreesCount!
 
 Your username is {{ user.username }}
 
 Please click on this link to confirm your email address.
 
-http://{{site.domain}}{% url 'registration_activate' activation_key %}
+http://{{site.domain}}{% url 'registration_activate' activation_key %}{% endblock content %}
 
 {% comment %}
 **registration/activation_email.txt**
@@ -47,4 +46,3 @@ following context:
 
         {{ request.scheme }}://{{ request.get_host }}{% url 'registration_activate' activation_key %}
 {% endcomment %}
-{% endblock content %}

--- a/src/nyc_trees/templates/registration/activation_email.txt
+++ b/src/nyc_trees/templates/registration/activation_email.txt
@@ -10,9 +10,6 @@ Please click on this link to confirm your email address.
 
 http://{{site.domain}}{% url 'registration_activate' activation_key %}
 
-If you have additional questions or need help with your account, please email
-us at TreesCount.Help@parks.nyc.gov
-
 {% comment %}
 **registration/activation_email.txt**
 


### PR DESCRIPTION
The HTML template had stale footer text.

The text template included a custom footer in addition to inheriting the footer from the base template.