### PR TITLE
Pin Django dependency to 1.7.x

### DIFF
--- a/src/nyc_trees/requirements/base.txt
+++ b/src/nyc_trees/requirements/base.txt
@@ -1,4 +1,4 @@
-Django>=1.7.2
+Django>=1.7.2,<1.7.99
 ipython==2.3.0
 psycopg2==2.5.4
 Pillow==2.6.1


### PR DESCRIPTION
The Internet suggested this range syntax for safety

https://groups.google.com/forum/#!msg/python-virtualenv/DvG1InRGdR0/14b9CISO2AcJ