### PR TITLE
Attach event PDF to reservation confirmation email

### DIFF
--- a/src/nyc_trees/apps/mail/tasks.py
+++ b/src/nyc_trees/apps/mail/tasks.py
@@ -8,6 +8,7 @@ from apps.core.models import User
 from apps.mail import MessageType
 from apps.mail.libs import send_to, storage_pdf_to_attachment
 from apps.survey.models import Blockface
+from apps.event.models import Event
 
 
 @task
@@ -22,4 +23,20 @@ def notify_reservation_confirmed(pdf_filename, user_id, blockface_ids):
     return send_to(user,
                    MessageType.NEW_RESERVATIONS_CONFIRMED,
                    blockfaces=blockfaces,
+                   attachments=attachments)
+
+
+@task
+def notify_rsvp(pdf_filename, absolute_event_url, user_id, event_id):
+    user = User.objects.get(pk=user_id)
+    event = Event.objects.get(pk=event_id)
+    if pdf_filename:
+        attachments = [storage_pdf_to_attachment(pdf_filename)]
+    else:
+        attachments = None
+
+    return send_to(user,
+                   MessageType.RSVP,
+                   event=event,
+                   event_url=absolute_event_url,
                    attachments=attachments)

--- a/src/nyc_trees/apps/mail/views.py
+++ b/src/nyc_trees/apps/mail/views.py
@@ -24,18 +24,6 @@ def notify_group_mapping_approved(request, group, username):
                    reservations_url=reservations_url)
 
 
-def notify_rsvp(request, user, event):
-    relative_event_url = reverse('event_detail', kwargs={
-        'group_slug': event.group.slug,
-        'event_slug': event.slug
-    })
-    event_url = request.build_absolute_uri(relative_event_url)
-    return send_to(user,
-                   MessageType.RSVP,
-                   event=event,
-                   event_url=event_url)
-
-
 def send_reservation_reminder(user_id, **kwargs):
     user = get_object_or_404(User, id=user_id)
     reservations_url = urljoin(

--- a/src/nyc_trees/apps/users/tests.py
+++ b/src/nyc_trees/apps/users/tests.py
@@ -13,6 +13,7 @@ from django.core import mail
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponseRedirect
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.utils.timezone import now
 
 from apps.core.models import User, Group
@@ -419,6 +420,11 @@ class IndividualMapperTests(UsersTestCase):
         self.user.training_finished_groups_to_follow = True
         self.user.clean_and_save()
 
+    # This test asserts that an email is sent when RSVPing to an
+    # event. Because the email is sent via a Celery task, we use
+    # CELERY_ALWAYS_EAGER to force synchronous execution and ensure
+    # the assertion is made after the task is complete.
+    @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_individual_mapper_workflow(self):
         self.assertFalse(self.user.individual_mapper)
         self.assertFalse(self.user.field_training_complete)


### PR DESCRIPTION
Since the meeting point for an event may not be easily expressed as an
address, it helps to send the registrant a map centered on the event
location.

I made the ``send_to`` helper expect and handle a list of attachments
because reservation confirmation emails will need to include both a
static data collection template and the dynamic reservation map PDF.

Is is possible that the PDF for a new or updated event is has not been
created by the time a person RSVPs for the event, so we need to chain
the notification task after ``wait_for_default_storage_file``.

I tested this with the following method:

1. Start two instances of ``./scripts/debugcelery.sh``
1. Open a browser to an event detail page with an RSVP button
1. Open another browser to the edit page for the same event
1. Edit the location of the event with the minimap, save the change, then immediately click RSVP in the other browser

Worker 1

```
[2015-04-01 16:41:57,041: INFO/MainProcess] Received task: libs.pdf_maps.create_and_save_pdf[69d7f801-0efc-4eed-bfb7-e3ca6088d7e1]
[2015-04-01 16:41:57,049: DEBUG/MainProcess] Task accepted: libs.pdf_maps.create_and_save_pdf[69d7f801-0efc-4eed-bfb7-e3ca6088d7e1] pid:8600
[2015-04-01 16:41:58,811: INFO/MainProcess] Received task: apps.event.tasks.wait_for_default_storage_file[e3a89dca-3f09-47c0-94be-b1b0bc656adc] eta:[2015-04-01 16:42:00.775636-04:00]
[2015-04-01 16:42:15,399: INFO/MainProcess] Task libs.pdf_maps.create_and_save_pdf[69d7f801-0efc-4eed-bfb7-e3ca6088d7e1] succeeded in 18.35755479s: u'event_map/new-2_PE8Fd5Ap2GwYg92V5r8sbQ.pdf'
[2015-04-01 16:42:15,401: DEBUG/MainProcess] Task accepted: apps.event.tasks.wait_for_default_storage_file[e3a89dca-3f09-47c0-94be-b1b0bc656adc] pid:8600
[2015-04-01 16:42:15,410: INFO/MainProcess] Task
apps.event.tasks.wait_for_default_storage_file[e3a89dca-3f09-47c0-94be-b1b0bc656adc]
succeeded in 0.00988132799102s:
u'event_map/new-2_PE8Fd5Ap2GwYg92V5r8sbQ.pdf'
```

Worker 2

```
[2015-04-01 16:41:58,762: INFO/MainProcess] Received task: apps.event.tasks.wait_for_default_storage_file[e3a89dca-3f09-47c0-94be-b1b0bc656adc]
[2015-04-01 16:41:58,773: DEBUG/MainProcess] Task accepted: apps.event.tasks.wait_for_default_storage_file[e3a89dca-3f09-47c0-94be-b1b0bc656adc] pid:9065
[2015-04-01 16:41:58,815: INFO/MainProcess] Task apps.event.tasks.wait_for_default_storage_file[e3a89dca-3f09-47c0-94be-b1b0bc656adc] retry: Retry in 2s
[2015-04-01 16:42:15,404: INFO/MainProcess] Received task: apps.event.tasks.notify_rsvp[af5bdb92-d446-4e97-a560-6805a0cb27ab]
[2015-04-01 16:42:15,412: DEBUG/MainProcess] Task accepted: apps.event.tasks.notify_rsvp[af5bdb92-d446-4e97-a560-6805a0cb27ab] pid:9065
[2015-04-01 16:42:17,260: INFO/MainProcess] Task apps.event.tasks.notify_rsvp[af5bdb92-d446-4e97-a560-6805a0cb27ab] succeeded in 1.854089967s: {u'to': u'jwalgran@azavea.com', u'subject': u'You are registered for New 2 on Wednesday, April 1st', u'body_text': u'\nWe...
```

Fixes #856