### PR TITLE
Change hamburger menu color to grey

### DIFF
--- a/src/nyc_trees/sass/partials/_header.scss
+++ b/src/nyc_trees/sass/partials/_header.scss
@@ -86,7 +86,7 @@
   width: 2.2rem;
   height: .2rem;
   border-radius: .1rem;
-  background-color: #fff;
+  background-color: $gray-light;
 
   &+.icon-bar {
     margin-top: .5rem;


### PR DESCRIPTION
The white blended in too much with the logo. This provides more contrast.

Before:

![image](https://cloud.githubusercontent.com/assets/1809908/6974521/615e2928-d961-11e4-8d47-6d45df37d74f.png)

After:

![image](https://cloud.githubusercontent.com/assets/1809908/6974517/595eaa18-d961-11e4-931e-c746f4e7c3e0.png)
