### PR TITLE
Show more stats on logged in homepage

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/partials/circle.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/circle.html
@@ -1,0 +1,8 @@
+<div class="col-xs-4 col-circle{% if xs3col %} col-sm-3{% endif %}{% if hide_xs %} hidden-xs{% endif %}">
+    <div class="progress-circle color--{{ color }}">
+        <div class="progress-circle-content">
+            <div class="progress-circle-number">{{ n }}</div>
+            <div class="progress-circle-label">{{ label }}</div>
+        </div>
+    </div>
+</div>

--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -30,10 +30,41 @@
         <div class="row">
             <main class="col-sm-12 main-dashboard">
                 {% flag full_access %}
-                    <section class="section-ticker">
+                    <section class="section-home">
                         <div class="home-container home-small">
-                            <h4 class="section-heading">Total Trees Counted</h4>
-                            {% include "home/partials/ticker.html" %}
+                            <h4 class="section-heading">Progress</h4>
+                            <ul class="nav nav-tabs nav-tabs--filter">
+                                <li class="active">
+                                    <a data-toggle="tab" href="#all-time">All Time</a>
+                                </li>
+                                <li>
+                                    <a data-toggle="tab" href="#past-week">Past Week</a>
+                                </li>
+                                <li>
+                                    <a data-toggle="tab" href="#my-trees">My Trees</a>
+                                </li>
+                            </ul>
+                            <div class="tab-content">
+                                <div class="tab-pane active" id="all-time">
+                                    {% include "home/partials/circle.html" with label="Blocks" n=counts_all.block color="primary" %}
+                                    {% include "home/partials/circle.html" with label="Complete" n=counts_all.block_percent color="quaternary" %}
+                                    {% include "home/partials/circle.html" with label="Users" n=counts_all.user color="secondary" %}
+                                    {% include "home/partials/ticker.html" with n=counts_all.tree %}
+                                </div>
+                                <div class="tab-pane" id="past-week">
+                                    {% include "home/partials/circle.html" with label="Blocks" n=counts_week.block color="primary" %}
+                                    {% include "home/partials/circle.html" with label="Complete" n=counts_week.block_percent color="quaternary" %}
+                                    {% include "home/partials/circle.html" with label="Events" n=counts_week.event color="secondary" %}
+                                    {% include "home/partials/ticker.html" with n=counts_week.tree %}
+                                </div>
+                                <div class="tab-pane" id="my-trees">
+                                    {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" %}
+                                    {% include "home/partials/circle.html" with label="Species" n=counts.species color="quaternary" %}
+                                    {% include "home/partials/circle.html" with label="Events" n=counts.event color="secondary" %}
+                                    {% include "home/partials/ticker.html" with n=counts.tree_digits %}
+                                </div>
+                            </div>
+                            <div>trees mapped</div>
                         </div>
                     </section>
 

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -53,7 +53,7 @@
                 <section class="section-ticker text-center">
                     <div class="home-container">
                         <h2>Help us count our <span class="color--primary">street trees</span>!</h2>
-                        {% include "home/partials/ticker.html" with tree_count=counts.tree %}
+                        {% include "home/partials/ticker.html" with n=counts.tree %}
                     </div>
                 </section>
                 <section class="section-progress text-center">

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -59,38 +59,12 @@
                 <section class="section-progress text-center">
                     <div class="home-container clearfix">
                         <div class="progress-circles">
-                            <div class="col-xs-4 col-sm-3 col-circle">
-                                <div class="progress-circle color--primary">
-                                    <div class="progress-circle-content">
-                                        <div class="progress-circle-number">{{ counts.block }}</div>
-                                        <div class="progress-circle-label">Blocks</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-4 col-sm-3 hidden-xs col-circle">
-                                <div class="progress-circle color--primary">
-                                    <div class="progress-circle-content">
-                                        <div class="progress-circle-number">{{ counts.block_percent }}</div>
-                                        <div class="progress-circle-label">Complete</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-4 col-sm-3 col-circle">
-                                <div class="progress-circle color--quaternary">
-                                    <div class="progress-circle-content">
-                                        <div class="progress-circle-number">{{ counts.user }}</div>
-                                        <div class="progress-circle-label">Users</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-4 col-sm-3 col-circle">
-                                <div class="progress-circle color--secondary">
-                                    <div class="progress-circle-content">
-                                        <div class="progress-circle-number">{{ counts.species }}</div>
-                                        <div class="progress-circle-label">Species</div>
-                                    </div>
-                                </div>
-                            </div>
+                            {% with xs3col=True %}
+                                {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" %}
+                                {% include "home/partials/circle.html" with label="Complete" n=counts.block_percent color="primary" hide_xs=True %}
+                                {% include "home/partials/circle.html" with label="Users" n=counts.user color="quaternary" %}
+                                {% include "home/partials/circle.html" with label="Species" n=counts.species color="secondary" %}
+                            {% endwith %}
                         </div>
                     </div>
                 </section>

--- a/src/nyc_trees/apps/home/templates/home/partials/ticker.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/ticker.html
@@ -1,5 +1,5 @@
-<div class="ticker">
-    {% for digit in tree_count %}
+<div class="ticker" style="clear:both">
+    {% for digit in n %}
         <div class="ticker-digit">
             <div class="ticker-box ticker-box-top">{{ digit }}</div>
             <div class="ticker-box ticker-box-bg"></div>

--- a/src/nyc_trees/apps/home/tests.py
+++ b/src/nyc_trees/apps/home/tests.py
@@ -198,9 +198,13 @@ class HomeTestCase(UsersTestCase):
             self._assertContains(
                 '<section class="section-about">', it_is)
 
-        def assert_contributions_visible(self, it_is):
+        def assert_progress_visible(self, it_is):
             self._assertContains(
                 '<div class="progress-circles', it_is)
+
+        def assert_achievements_visible(self, it_is):
+            self._assertContains(
+                '<section class="achievements"', it_is)
 
     def _render_homepage(self, user=None):
         if not user:
@@ -222,17 +226,17 @@ class HomeTestCase(UsersTestCase):
         response = self._render_homepage()
         response.assert_about_visible(True)
         response.assert_training_visible(False)
-        response.assert_contributions_visible(True)
+        response.assert_progress_visible(True)
 
     def test_untrained_user_content(self):
         response = self._render_homepage(self.user)
         response.assert_about_visible(False)
         response.assert_training_visible(True)
-        response.assert_contributions_visible(False)
+        response.assert_achievements_visible(False)
 
     def test_online_trained_user_content(self):
         self._complete_user_online_training()
         response = self._render_homepage(self.user)
         response.assert_about_visible(False)
         response.assert_training_visible(False)
-        response.assert_contributions_visible(True)
+        response.assert_achievements_visible(True)

--- a/src/nyc_trees/apps/home/views.py
+++ b/src/nyc_trees/apps/home/views.py
@@ -3,10 +3,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from libs.sql import get_total_tree_count, get_total_species_count
+from datetime import timedelta
+from django.utils.timezone import now
+
+from libs.sql import get_total_tree_count, get_total_species_count, \
+    get_block_count_past_week
 
 from apps.core.models import User
 
+from apps.event.models import Event
 from apps.event.event_list import all_events, EventList
 
 from apps.home.training import training_summary
@@ -17,35 +22,15 @@ from apps.users import user_profile_context
 
 
 def home_page(request):
-    # In order to show the tree count in a "ticker" we need to break it up
-    # into digits and pad it with zeroes.
-    tree_count = get_total_tree_count()
-    trees_digits = [digit for digit in "{:07d}".format(tree_count)]
-
     if request.user.is_authenticated():
-        context = user_profile_context(request.user, True)
+        context = user_profile_context(request.user)
         context['training_steps'] = training_summary.get_context(request.user)
-        context['tree_count'] = trees_digits
+        context['counts_all'] = _global_counts()
+        context['counts_week'] = _global_counts(past_week=True)
     else:
-        blocks_total = Blockface.objects.all().count()
-        blocks_mapped = Survey.objects.all().distinct('blockface_id').count()
-        if blocks_mapped > 0:
-            blocks_percent = "{:.0%}".format(
-                float(blocks_mapped) / float(blocks_total))
-        else:
-            blocks_percent = "0%"
-
-        user_count = User.objects.filter(is_active=True).count()
-
         context = {
             'user': request.user,
-            'counts': {
-                'species': get_total_species_count(),
-                'tree': trees_digits,
-                'block': blocks_mapped,
-                'block_percent': blocks_percent,
-                'user': user_count,
-            }
+            'counts': _global_counts()
         }
 
     all_events_list = (
@@ -57,6 +42,46 @@ def home_page(request):
 
     context.update({'all_events': all_events_list})
     return context
+
+
+def _global_counts(past_week=False):
+    blocks_total = Blockface.objects.all().count()
+    if past_week:
+        blocks_mapped = get_block_count_past_week()
+    else:
+        blocks_mapped = Survey.objects.all().distinct('blockface_id').count()
+    if blocks_mapped > 0:
+        blocks_percent = "{:.0%}".format(
+            float(blocks_mapped) / float(blocks_total))
+    else:
+        blocks_percent = "0%"
+    if past_week:
+        blocks_percent = '+' + blocks_percent
+
+    user_count = User.objects.filter(is_active=True).count()
+
+    if past_week:
+        week_ago = now() - timedelta(days=7)
+        event_count = Event.objects \
+            .filter(begins_at__lt=now(), ends_at__gte=week_ago) \
+            .count()
+    else:
+        event_count = -999  # not needed
+
+    # In order to show the tree count in a "ticker" we need to break it up
+    # into digits and pad it with zeroes.
+    tree_count = get_total_tree_count(past_week)
+    trees_digits = [digit for digit in "{:07d}".format(tree_count)]
+
+    global_counts = {
+        'species': get_total_species_count(),
+        'tree': trees_digits,
+        'block': blocks_mapped,
+        'block_percent': blocks_percent,
+        'user': user_count,
+        'event': event_count
+        }
+    return global_counts
 
 
 def retrieve_job_status(request):

--- a/src/nyc_trees/apps/users/templates/users/partials/profile/contributions.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/contributions.html
@@ -3,30 +3,9 @@
 {% block section_content %}
 
 <div class="progress-circles">
-    <div class="col-xs-4 col-circle">
-        <div class="progress-circle color--primary">
-            <div class="progress-circle-content">
-                <div class="progress-circle-number">{{ counts.tree }}</div>
-                <div class="progress-circle-label">Trees</div>
-            </div>
-        </div>
-    </div>
-    <div class="col-xs-4 col-circle">
-        <div class="progress-circle color--quaternary">
-            <div class="progress-circle-content">
-                <div class="progress-circle-number">{{ counts.block }}</div>
-                <div class="progress-circle-label">Blocks</div>
-            </div>
-        </div>
-    </div>
-    <div class="col-xs-4 col-circle">
-        <div class="progress-circle color--secondary">
-            <div class="progress-circle-content">
-                <div class="progress-circle-number">{{ counts.species }}</div>
-                <div class="progress-circle-label">Species</div>
-            </div>
-        </div>
-    </div>
+        {% include "home/partials/circle.html" with label="Trees" n=counts.tree color="primary" %}
+        {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="quaternary" %}
+        {% include "home/partials/circle.html" with label="Species" n=counts.species color="secondary" %}
 </div>
 
 {% endblock section_content %}

--- a/src/nyc_trees/apps/users/views/user.py
+++ b/src/nyc_trees/apps/users/views/user.py
@@ -34,7 +34,7 @@ def user_detail(request, username):
         # Private profile acts like a missing page to others
         raise Http404()
 
-    return user_profile_context(user, its_me)
+    return user_profile_context(user, its_me=its_me, home_page=False)
 
 
 def profile_settings(request):

--- a/src/nyc_trees/libs/sql.py
+++ b/src/nyc_trees/libs/sql.py
@@ -46,13 +46,15 @@ def get_group_tree_count(group):
     return _get_count(sql, [group.pk])
 
 
-def get_total_tree_count():
+def get_total_tree_count(past_week=False):
     sql = _survey_sql + """
         SELECT COUNT(*)
         FROM survey_tree AS tree
         JOIN most_recent_survey
           ON tree.survey_id = most_recent_survey.id"""
-
+    if past_week:
+        sql += " WHERE most_recent_survey.created_at" \
+               " > now() at time zone 'utc' - INTERVAL '7 days'"
     return _get_count(sql)
 
 
@@ -81,3 +83,17 @@ def get_total_species_count():
         ) subquery"""
 
     return _get_count(sql)
+
+
+def get_block_count_past_week():
+    sql = _survey_sql + """
+        SELECT COUNT(*)
+        FROM survey_blockface AS block
+        JOIN most_recent_survey
+          ON block.id = most_recent_survey.blockface_id
+       WHERE most_recent_survey.created_at
+             > now() at time zone 'utc' - INTERVAL '7 days'"""
+
+    return _get_count(sql)
+
+


### PR DESCRIPTION
* Add tabbed displays for "all time", "past week", and "my trees"
* Show stats in each tab per wireframes
* Augment contexts with new stats
* Continue to show related but simpler "contributions" section on profile page