### PR TITLE
Make dashboard circles clickable

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/home.html
+++ b/src/nyc_trees/apps/home/templates/home/home.html
@@ -18,3 +18,31 @@
 {% block page_js %}
 <script type="text/javascript" src="{{ "js/home.js"|static_url }}"></script>
 {% endblock %}
+
+{% block extra_content %}
+{% if user.is_authenticated %}
+  {% include 'home/partials/species_modal.html' with species_by_name=counts.species_by_name %}
+{% else %}
+  {% include 'home/partials/species_modal.html' with species_by_name=counts_all.species_by_name %}
+{% endif %}
+
+<div class="modal fade" id="users-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Users</h4>
+      </div>
+      <div class="modal-body">
+        <ul class="list-unstyled">
+          <li><strong class="color--primary">{{ counts_all.user }}</strong> users have registered</li>
+          <li><strong class="color--primary">{{ counts_all.attended_events }}</strong> have attended events</li>
+          <li><strong class="color--primary">{{ counts_all.individual_mappers }}</strong> are individual mappers</li>
+        </ul>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">OK</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/nyc_trees/apps/home/templates/home/partials/circle.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/circle.html
@@ -1,8 +1,13 @@
 <div class="col-xs-4 col-circle{% if xs3col %} col-sm-3{% endif %}{% if hide_xs %} hidden-xs{% endif %}">
-    <div class="progress-circle color--{{ color }}">
+    <a class="progress-circle color--{{ color }}"
+        {% if url %}
+            href="{{ url }}"
+        {% elif modal %}
+            data-toggle="modal" data-target="{{ modal }}"
+        {% endif %}>
         <div class="progress-circle-content">
             <div class="progress-circle-number">{{ n }}</div>
             <div class="progress-circle-label">{{ label }}</div>
         </div>
-    </div>
+    </a>
 </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -1,6 +1,9 @@
 {% load utils %}
 {% load waffle_tags %}
 
+{% url 'events_list_page' as events_page_url %}
+{% url 'progress_page' as progress_page_url %}
+
 <div class="page-dashboard">
 
     <div class="hero">
@@ -46,21 +49,21 @@
                             </ul>
                             <div class="tab-content">
                                 <div class="tab-pane active" id="all-time">
-                                    {% include "home/partials/circle.html" with label="Blocks" n=counts_all.block color="primary" %}
-                                    {% include "home/partials/circle.html" with label="Complete" n=counts_all.block_percent color="quaternary" %}
-                                    {% include "home/partials/circle.html" with label="Users" n=counts_all.user color="secondary" %}
+                                    {% include "home/partials/circle.html" with label="Blocks" n=counts_all.block color="primary" url=progress_page_url %}
+                                    {% include "home/partials/circle.html" with label="Complete" n=counts_all.block_percent color="quaternary" url=progress_page_url %}
+                                    {% include "home/partials/circle.html" with label="Users" n=counts_all.user color="secondary" modal="#users-modal" %}
                                     {% include "home/partials/ticker.html" with n=counts_all.tree %}
                                 </div>
                                 <div class="tab-pane" id="past-week">
-                                    {% include "home/partials/circle.html" with label="Blocks" n=counts_week.block color="primary" %}
-                                    {% include "home/partials/circle.html" with label="Complete" n=counts_week.block_percent color="quaternary" %}
-                                    {% include "home/partials/circle.html" with label="Events" n=counts_week.event color="secondary" %}
+                                    {% include "home/partials/circle.html" with label="Blocks" n=counts_week.block color="primary" url=progress_page_url %}
+                                    {% include "home/partials/circle.html" with label="Complete" n=counts_week.block_percent color="quaternary" url=progress_page_url %}
+                                    {% include "home/partials/circle.html" with label="Events" n=counts_week.event color="secondary" url=events_page_url %}
                                     {% include "home/partials/ticker.html" with n=counts_week.tree %}
                                 </div>
                                 <div class="tab-pane" id="my-trees">
-                                    {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" %}
-                                    {% include "home/partials/circle.html" with label="Species" n=counts.species color="quaternary" %}
-                                    {% include "home/partials/circle.html" with label="Events" n=counts.event color="secondary" %}
+                                    {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" url=progress_page_url %}
+                                    {% include "home/partials/circle.html" with label="Species" n=counts.species color="quaternary" modal="#species-modal" %}
+                                    {% include "home/partials/circle.html" with label="Events" n=counts.event color="secondary" url=events_page_url %}
                                     {% include "home/partials/ticker.html" with n=counts.tree_digits %}
                                 </div>
                             </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -1,6 +1,8 @@
 {% load utils %}
 {% load waffle_tags %}
 
+{% url 'progress_page' as progress_page_url %}
+
 <div class="page-home">
 
     <div class="hero">
@@ -60,10 +62,10 @@
                     <div class="home-container clearfix">
                         <div class="progress-circles">
                             {% with xs3col=True %}
-                                {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" %}
-                                {% include "home/partials/circle.html" with label="Complete" n=counts.block_percent color="primary" hide_xs=True %}
-                                {% include "home/partials/circle.html" with label="Users" n=counts.user color="quaternary" %}
-                                {% include "home/partials/circle.html" with label="Species" n=counts.species color="secondary" %}
+                                {% include "home/partials/circle.html" with label="Blocks" n=counts_all.block color="primary" url=progress_page_url %}
+                                {% include "home/partials/circle.html" with label="Complete" n=counts_all.block_percent color="primary" hide_xs=True  url=progress_page_url %}
+                                {% include "home/partials/circle.html" with label="Users" n=counts_all.user color="quaternary" modal="#users-modal" %}
+                                {% include "home/partials/circle.html" with label="Species" n=counts_all.species color="secondary" modal="#species-modal" %}
                             {% endwith %}
                         </div>
                     </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/species_modal.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/species_modal.html
@@ -1,0 +1,23 @@
+<div class="modal fade" id="species-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Species</h4>
+      </div>
+      <div class="modal-body">
+        {% if species_by_name %}
+          <ul class="list-unstyled">
+          {% for common_name, count in species_by_name %}
+            <li><strong class="color--primary">{{ count }}</strong> {{ common_name }}</li>
+          {% endfor %}
+        {% else %}
+          <p>No trees have been surveyed yet.</p>
+        {% endif %}
+        </ul>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">OK</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/nyc_trees/apps/users/__init__.py
+++ b/src/nyc_trees/apps/users/__init__.py
@@ -5,7 +5,7 @@ from __future__ import division
 
 from django.core.urlresolvers import reverse
 
-from libs.sql import get_user_tree_count, get_user_species_count
+from libs.sql import get_user_tree_count, get_user_surveyed_species
 from apps.users.forms import PrivacySettingsForm
 from apps.users.models import achievements
 
@@ -21,7 +21,9 @@ def user_profile_context(user, its_me=True, home_page=True):
 
     block_count = user.survey_set.distinct('blockface').count()
     tree_count = get_user_tree_count(user)
-    species_count = get_user_species_count(user)
+    species_surveyed = get_user_surveyed_species(user)
+    # Distinct count, not total
+    species_count = len(species_surveyed)
     event_count = user.eventregistration_set \
         .filter(did_attend=True) \
         .count()
@@ -56,6 +58,7 @@ def user_profile_context(user, its_me=True, home_page=True):
             'tree': tree_count,
             'tree_digits': tree_digits,
             'species': species_count,
+            'species_by_name': species_surveyed,
             'event': event_count
         },
         'achievements': [achievements[key]

--- a/src/nyc_trees/apps/users/templates/users/partials/profile/contributions.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/contributions.html
@@ -2,10 +2,12 @@
 
 {% block section_content %}
 
+{% url 'progress_page' as progress_page_url %}
+
 <div class="progress-circles">
-        {% include "home/partials/circle.html" with label="Trees" n=counts.tree color="primary" %}
-        {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="quaternary" %}
-        {% include "home/partials/circle.html" with label="Species" n=counts.species color="secondary" %}
+        {% include "home/partials/circle.html" with label="Trees" n=counts.tree color="primary" url=progress_page_url %}
+        {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="quaternary" url=progress_page_url %}
+        {% include "home/partials/circle.html" with label="Species" n=counts.species color="secondary" modal="#species-modal" %}
 </div>
 
 {% endblock section_content %}

--- a/src/nyc_trees/apps/users/templates/users/profile.html
+++ b/src/nyc_trees/apps/users/templates/users/profile.html
@@ -76,3 +76,7 @@
 {% block page_js %}
     <script type="text/javascript" src="{{ "js/userProfile.js"|static_url }}"></script>
 {% endblock page_js %}
+
+{% block extra_content %}
+{% include 'home/partials/species_modal.html' with species_by_name=counts.species_by_name %}
+{% endblock %}

--- a/src/nyc_trees/sass/partials/_home.scss
+++ b/src/nyc_trees/sass/partials/_home.scss
@@ -123,11 +123,17 @@ $hero-box-side-padding: 3rem;
 }
 
 .progress-circle {
+  display: block;
+  cursor: pointer;
   border: 4px solid;
   border-radius: 50%;
   height: 0;
   padding-bottom: 92%;
   width: 100%;
+
+  &:hover .progress-circle-label {
+      text-decoration: underline;
+  }
 }
 
 .progress-circle-container {


### PR DESCRIPTION
This makes circles clickable on the dashboard, home page, and user
profile.

* Blocks should go to the progress map
* Events should go to the events page
* Users should display a modal with some basic users stats
* Species should display a modal with stats about surveyed species

Fixes #972