### PR TITLE
Show help on Progress Page and New Reservations page

### DIFF
--- a/src/nyc_trees/apps/core/admin.py
+++ b/src/nyc_trees/apps/core/admin.py
@@ -73,7 +73,10 @@ class NycUserAdmin(UserAdmin):
                                  'training_finished_tree_data',
                                  'training_finished_tree_surroundings',
                                  'training_finished_intro_quiz',
-                                 'training_finished_groups_to_follow')})
+                                 'training_finished_groups_to_follow')}),
+
+        ('Help', {'fields': ('progress_page_help_shown',
+                             'reservations_page_help_shown')})
     )
 
     add_fieldsets = UserAdmin.add_fieldsets + (

--- a/src/nyc_trees/apps/core/migrations/0021_auto_20150408_1216.py
+++ b/src/nyc_trees/apps/core/migrations/0021_auto_20150408_1216.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0020_auto_20150323_1457'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='progress_page_help_shown',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='reservations_page_help_shown',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -85,6 +85,9 @@ class User(NycModel, AbstractUser):
 
     opt_in_stewardship_info = models.BooleanField(default=False)
 
+    progress_page_help_shown = models.BooleanField(default=False)
+    reservations_page_help_shown = models.BooleanField(default=False)
+
     reservation_ids_in_map_pdf = models.TextField(default='', blank=True)
     reservations_map_pdf_filename = models.CharField(
         max_length=255, default='', blank=True)

--- a/src/nyc_trees/apps/survey/templates/survey/progress.html
+++ b/src/nyc_trees/apps/survey/templates/survey/progress.html
@@ -47,7 +47,9 @@
 
 {% block main %}
 
-<div id="map" class="map-event"></div>
+<div id="map" class="map-event"
+     data-help-shown="{{ help_shown }}">
+</div>
 
 {% endblock main %}
 

--- a/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
@@ -35,7 +35,9 @@
 
 <div id="map" class="map-event"
      data-tile-url="{{ layer.tile_url }}"
-     data-grid-url="{{ layer.grid_url }}"></div>
+     data-grid-url="{{ layer.grid_url }}"
+     data-help-shown="{{ help_shown }}">
+</div>
 
 {% endblock main %}
 

--- a/src/nyc_trees/js/src/lib/mapHelp.js
+++ b/src/nyc_trees/js/src/lib/mapHelp.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var $ = require('jquery'),
+    mapModule = require('../map');
+
+var dom = {
+        legendModal: '#legend',
+        toggleLegend: '.legend-button'
+    },
+    $legendModal= $(dom.legendModal),
+    helpShown = ('True' === mapModule.getDomMapAttribute('help-shown'));
+
+if (!helpShown) {
+    // Help hasn't been shown yet, so show it on page load
+    $legendModal.modal('show');
+
+    // When legend is closed, Show notification of how to re-open it
+    $legendModal.one('hidden.bs.modal', onCloseLegend);
+}
+
+function onCloseLegend(e) {
+    $(dom.toggleLegend).append(
+        '<div class="legend-help">Go&nbsp;back&nbsp;to&nbsp;the help&nbsp;information.</div>'
+    );
+    // Hide notification on any click
+    $(document).one('click', function () {
+        $('.legend-help').hide();
+    });
+}

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -13,7 +13,8 @@ module.exports = {
     create: create,
     addTileLayer: addTileLayer,
     addGridLayer: addGridLayer,
-    fitBounds: fitBounds
+    fitBounds: fitBounds,
+    getDomMapAttribute: getDomMapAttribute
 };
 
 function create(options) {
@@ -128,7 +129,8 @@ function initLocationSearch($controlsContainer, map) {
 }
 
 function initLegend($controlsContainer, map) {
-    var $button = $('<a class="legend-button" data-toggle="modal" href="#legend" href="javascript:;" title="Legend">?</a>');
+    var $button = $(
+        '<a class="legend-button" data-toggle="modal" href="#legend" href="javascript:;" title="Legend">?</a>');
     $controlsContainer.prepend($button);
 }
 

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -6,6 +6,8 @@ var $ = require('jquery'),
     mapModule = require('./map'),
     SelectableBlockfaceLayer = require('./lib/SelectableBlockfaceLayer');
 
+require('./lib/mapHelp');
+
 // Extends the leaflet object
 require('leaflet-utfgrid');
 

--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -22,6 +22,8 @@ var $ = require('jquery'),
         unavailableBlockfaceModal: '#unavailable-blockface-modal'
     };
 
+require('./lib/mapHelp');
+
 // Extends the leaflet object
 require('leaflet-utfgrid');
 

--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -118,6 +118,33 @@
   z-index: $zindex-modal;
 }
 
+.legend-button {
+  position: relative;
+}
+
+.legend-help {
+  position: absolute;
+  left: 220%;
+  top: -1.4em;
+  font-size: 180%;
+  padding: 1em;
+  background-color: black;
+  color: white;
+}
+
+.legend-help:after {
+  position: absolute;
+  top: 1.4em;
+  right: 100%;
+  height: 0;
+  width: 0;
+  border: solid transparent;
+  border-right-color: black;
+  border-width: 12px 25px;
+  content: " ";
+  pointer-events: none;
+}
+
 @media (max-width: $screen-sm - 1) {
   .pageheading-description-detail {
     .tab-status-map-tab & {


### PR DESCRIPTION
* Add fields to User model to record whether user has seen the help
* Record same information on session object for non-logged-in users
* Help is considered shown after page is loaded for the first time
* Communicate `help_shown` to JS via data attribute on map element

New module `lib/mapHelp.js` controls showing the help
* Show legend modal on page load
* Show notification (once) when legend closed
* Hide notification on any click

To test:
1) Log out
2) Pull down the branch, and build
3) Visit progress page. Help should be shown.
4) Close legend. Notification should be shown.
5) Click anywhere. Notification should disappear.
6) Log in. Help should not be shown.
7) Show and close legend. Navigation should not appear.
8) Visit new reservations page. Help should be shown.
9) Close legend. Notification should be shown.
10) Click anywhere. Notification should disappear.

Fixes #967