### PR TITLE
Add support for training environment

### DIFF
--- a/src/nyc_trees/nyc_trees/settings/production.py
+++ b/src/nyc_trees/nyc_trees/settings/production.py
@@ -31,6 +31,7 @@ if not instance_metadata:
 # See: https://docs.djangoproject.com/en/1.5/releases/1.5/#allowed-hosts-required-in-production  # NOQA
 ALLOWED_HOSTS = [
     'treescount.nycgovparks.org',
+    'training.treescount.azavea.com',
     'treescount.azavea.com',
     '.elb.amazonaws.com',
     'localhost'


### PR DESCRIPTION
This change allows the application to service requests via the training URL by adding it to Django's `ALLOWED_HOSTS`.