### PR TITLE
Change CloudWatch alert thresholds based on past alerts

### DIFF
--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -175,7 +175,7 @@ t.add_resource(cw.Alarm(
     AlarmActions=[Ref(notification_arn_param)],
     Statistic='Sum',
     Period=300,
-    Threshold='5',
+    Threshold='20',
     EvaluationPeriods=1,
     ComparisonOperator='GreaterThanThreshold',
     MetricName='HTTPCode_Backend_4XX',

--- a/deployment/troposphere/data_store_template.py
+++ b/deployment/troposphere/data_store_template.py
@@ -257,7 +257,7 @@ t.add_resource(cw.Alarm(
     AlarmActions=[Ref(notification_arn_param)],
     Statistic='Average',
     Period=60,
-    Threshold='1',
+    Threshold='10',
     EvaluationPeriods=1,
     ComparisonOperator='GreaterThanThreshold',
     MetricName='DiskQueueDepth',

--- a/deployment/troposphere/tiler_template.py
+++ b/deployment/troposphere/tiler_template.py
@@ -164,7 +164,7 @@ t.add_resource(cw.Alarm(
     AlarmActions=[Ref(notification_arn_param)],
     Statistic='Sum',
     Period=300,
-    Threshold='5',
+    Threshold='20',
     EvaluationPeriods=1,
     ComparisonOperator='GreaterThanThreshold',
     MetricName='HTTPCode_Backend_4XX',


### PR DESCRIPTION
These changes adjust the CloudWatch alert thresholds based on alerts we've received from the staging, training, and production environments.