### PR TITLE
Remove GeoJSON from UTF grids

### DIFF
--- a/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
+++ b/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
@@ -54,15 +54,21 @@ module.exports = BlockfaceLayer.extend({
     },
 
     addBlockface: function(data, latlng) {
-        if (data && data.geojson) {
-            var geom = mapUtil.parseGeoJSON(data.geojson);
-            if (this.options.onAdd(data, geom, latlng)) {
-                this.addData({
-                    "type": "Feature",
-                    "geometry": geom,
-                    "properties": data
-                });
-            }
+        var self = this;
+        if (!data || !data.id) {
+            return;
         }
+        mapUtil.fetchBlockface(data.id).then(function(blockfaceData) {
+            if (blockfaceData && blockfaceData.geojson) {
+                var geom = mapUtil.parseGeoJSON(blockfaceData.geojson);
+                if (self.options.onAdd(data, geom, latlng)) {
+                    self.addData({
+                        "type": "Feature",
+                        "geometry": geom,
+                        "properties": data
+                    });
+                }
+            }
+        });
     }
 });

--- a/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
+++ b/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
@@ -8,12 +8,15 @@ var $ = require('jquery'),
 
     color = '#FFEB3B';
 
-/* Adds a geojson layer to the given map, based on the geojson data of a UtfGrid.
- * The UtfGrid must have a "geojson" property as a data attribute.
+/* Adds a geojson layer to the given map.
  *
  * Geojson fatures are added to the map when their corresponding
  * features are clicked in the UtfGrid, and they are removed when the geojson
  * feature is clicked.
+ *
+ * Depends on a UtfGrid with an "id" property. A GeoJSON represention of the
+ * selected blockface is fetched via AJAX, using the ID to construct the
+ * fetch URL.
  *
  * Accepts two callbacks: onAdd and onRemove, which are called prior to adding
  * or removing geojson features.
@@ -58,17 +61,17 @@ module.exports = BlockfaceLayer.extend({
         if (!data || !data.id) {
             return;
         }
-        mapUtil.fetchBlockface(data.id).then(function(blockfaceData) {
-            if (blockfaceData && blockfaceData.geojson) {
-                var geom = mapUtil.parseGeoJSON(blockfaceData.geojson);
-                if (self.options.onAdd(data, geom, latlng)) {
+        if (self.options.onAdd(data, latlng)) {
+            mapUtil.fetchBlockface(data.id).then(function(blockfaceData) {
+                if (blockfaceData && blockfaceData.geojson) {
+                    var geom = mapUtil.parseGeoJSON(blockfaceData.geojson);
                     self.addData({
                         "type": "Feature",
                         "geometry": geom,
                         "properties": data
                     });
                 }
-            }
-        });
+            });
+        }
     }
 });

--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -87,7 +87,7 @@ var progress = new SavedState({
 });
 
 var selectedLayer = new SelectableBlockfaceLayer(reservationMap, grid, {
-    onAdd: function(gridData, __, latlng) {
+    onAdd: function(gridData, latlng) {
         onAddRemove();
         if (selectedBlockfacesCount >= blockfaceLimit) {
             $(dom.limitReachedModal).modal('show');

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -131,10 +131,13 @@ var dom = {
     grid = mapModule.addGridLayer(blockfaceMap),
 
     selectedLayer = new SelectableBlockfaceLayer(blockfaceMap, grid, {
-        onAdd: function(gridData, geom) {
-            var latLngs = mapUtil.getLatLngs(geom);
+        onAdd: function() {
+            return true;
+        },
+        onAdded: function(feature, layer) {
+            var latLngs = mapUtil.getLatLngs(feature.geometry);
 
-            blockfaceId = gridData.id;
+            blockfaceId = feature.properties.id;
 
             selectedLayer.clearLayers();
             endPointLayers.clearLayers();

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -21,12 +21,12 @@ var Windshaft = require('windshaft'),
     styles = files('./style'),
 
     interactivity = {
-        territory_survey: 'id,survey_type,restriction,geojson',
-        territory_admin: 'id,survey_type,turf_group_id,geojson',
-        progress_all: 'id,group_id,survey_type,geojson',
-        progress_my: 'id,group_id,survey_type,geojson',
-        reservable: 'id,group_id,group_slug,survey_type,restriction,geojson',
-        reservations: 'id,geojson'
+        territory_survey: 'id,survey_type,restriction',
+        territory_admin: 'id,survey_type,turf_group_id',
+        progress_all: 'id,group_id,survey_type',
+        progress_my: 'id,group_id,survey_type',
+        reservable: 'id,group_id,group_slug,survey_type,restriction',
+        reservations: 'id'
     },
 
     config = {

--- a/src/tiler/sql/group_territory_admin.sql
+++ b/src/tiler/sql/group_territory_admin.sql
@@ -2,9 +2,6 @@
   block.id,
   block.geom,
   turf.group_id AS turf_group_id,
-  <% if (is_utf_grid) { %>
-  ST_AsGeoJSON(block.geom) AS geojson,
-  <% } %>
   CASE
     WHEN block.is_available THEN
       CASE

--- a/src/tiler/sql/group_territory_survey.sql
+++ b/src/tiler/sql/group_territory_survey.sql
@@ -1,9 +1,6 @@
 (SELECT
   block.id,
   block.geom,
-  <% if (is_utf_grid) { %>
-  ST_AsGeoJSON(block.geom) AS geojson,
-  <% } %>
   CASE
     WHEN (block.is_available AND reservation.id IS NULL) THEN 'available'
     ELSE 'unavailable'

--- a/src/tiler/sql/progress.sql
+++ b/src/tiler/sql/progress.sql
@@ -2,9 +2,6 @@
 -- the latest survey for a blockface
 (SELECT
   DISTINCT ON (block.id)
-  <% if (is_utf_grid) { %>
-  ST_AsGeoJSON(block.geom) AS geojson,
-  <% } %>
   block.geom, block.id, turf.group_id,
   CASE
     WHEN survey.id IS NOT NULL THEN 'surveyed-by-others'

--- a/src/tiler/sql/user_progress.sql
+++ b/src/tiler/sql/user_progress.sql
@@ -2,9 +2,6 @@
 -- the latest survey for a blockface
 (SELECT
   DISTINCT ON (block.id)
-  <% if (is_utf_grid) { %>
-  ST_AsGeoJSON(block.geom) AS geojson,
-  <% } %>
   block.geom, block.id, turf.group_id,
   CASE
     WHEN (survey.user_id IS NOT DISTINCT FROM <%= user_id %>

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -1,58 +1,49 @@
 (SELECT
-    <% if (is_utf_grid) { %>
-    CASE
-      WHEN survey_type = 'available' THEN ST_AsGeoJSON(geom)
-      ELSE NULL
-    END AS geojson,
-    <% } %>
-    *
-    FROM (SELECT
-      block.geom,
-      block.id,
-      turf.group_id,
-      core_group.slug AS group_slug,
-      CASE
-        WHEN (block.is_available AND reservation.id IS NULL
-              AND (turf.id IS NULL
-                   OR trustedmapper.id IS NOT NULL
-                   OR core_group.admin_id = <%= user_id %>)) THEN 'available'
-        -- If a blockface is currently reserved, we should make it look
-        -- 'available'.  We use a GeoJSON layer in the UI for the user's
-        -- reserved blockfaces, and when a blockface is deselected we want to
-        -- be able to reselect it
-        WHEN reservation.user_id IS NOT DISTINCT FROM <%= user_id %> THEN 'available'
-        ELSE 'unavailable'
-      END AS survey_type,
-      CASE
-        WHEN reservation.id IS NOT NULL AND reservation.user_id <> <%= user_id %> THEN 'reserved'
-        WHEN (core_group.id IS NOT NULL
-              AND NOT core_group.allows_individual_mappers) THEN 'unavailable'
-        WHEN NOT block.is_available THEN 'unavailable'
-        -- We should only allow requesting access to active groups that you are
-        -- not already a trusted mapper or admin of
-        WHEN (turf.id IS NOT NULL
-              AND (core_group.is_active = TRUE
-                   AND trustedmapper.id IS NULL
-                   AND core_group.admin_id <> <%= user_id %>)) THEN 'group_territory'
-        -- If a group is inactive, it is unavailable unless you are an admin or
-        -- a trusted mapper of that group
-        WHEN (turf.id IS NOT NULL
-              AND core_group.is_active = FALSE
-              AND trustedmapper.id IS NULL
-              AND core_group.admin_id <> <%= user_id %>) THEN 'unavailable'
-        ELSE 'none'
-      END AS restriction
-      FROM survey_blockface AS block
-      LEFT OUTER JOIN survey_territory AS turf
-        ON block.id = turf.blockface_id
-      LEFT JOIN core_group ON core_group.id = turf.group_id
-      LEFT OUTER JOIN survey_blockfacereservation AS reservation
-        ON (block.id = reservation.blockface_id
-            AND reservation.canceled_at IS NULL
-            AND reservation.expires_at > now() at time zone 'utc')
-      LEFT OUTER JOIN users_trustedmapper AS trustedmapper
-        ON (turf.group_id = trustedmapper.group_id
-            AND trustedmapper.user_id = <%= user_id %>
-            AND trustedmapper.is_approved)
-    ) AS subquery
+  block.geom,
+  block.id,
+  turf.group_id,
+  core_group.slug AS group_slug,
+  CASE
+    WHEN (block.is_available AND reservation.id IS NULL
+          AND (turf.id IS NULL
+               OR trustedmapper.id IS NOT NULL
+               OR core_group.admin_id = <%= user_id %>)) THEN 'available'
+    -- If a blockface is currently reserved, we should make it look
+    -- 'available'.  We use a GeoJSON layer in the UI for the user's
+    -- reserved blockfaces, and when a blockface is deselected we want to
+    -- be able to reselect it
+    WHEN reservation.user_id IS NOT DISTINCT FROM <%= user_id %> THEN 'available'
+    ELSE 'unavailable'
+  END AS survey_type,
+  CASE
+    WHEN reservation.id IS NOT NULL AND reservation.user_id <> <%= user_id %> THEN 'reserved'
+    WHEN (core_group.id IS NOT NULL
+          AND NOT core_group.allows_individual_mappers) THEN 'unavailable'
+    WHEN NOT block.is_available THEN 'unavailable'
+    -- We should only allow requesting access to active groups that you are
+    -- not already a trusted mapper or admin of
+    WHEN (turf.id IS NOT NULL
+          AND (core_group.is_active = TRUE
+               AND trustedmapper.id IS NULL
+               AND core_group.admin_id <> <%= user_id %>)) THEN 'group_territory'
+    -- If a group is inactive, it is unavailable unless you are an admin or
+    -- a trusted mapper of that group
+    WHEN (turf.id IS NOT NULL
+          AND core_group.is_active = FALSE
+          AND trustedmapper.id IS NULL
+          AND core_group.admin_id <> <%= user_id %>) THEN 'unavailable'
+    ELSE 'none'
+  END AS restriction
+  FROM survey_blockface AS block
+  LEFT OUTER JOIN survey_territory AS turf
+    ON block.id = turf.blockface_id
+  LEFT JOIN core_group ON core_group.id = turf.group_id
+  LEFT OUTER JOIN survey_blockfacereservation AS reservation
+    ON (block.id = reservation.blockface_id
+        AND reservation.canceled_at IS NULL
+        AND reservation.expires_at > now() at time zone 'utc')
+  LEFT OUTER JOIN users_trustedmapper AS trustedmapper
+    ON (turf.group_id = trustedmapper.group_id
+        AND trustedmapper.user_id = <%= user_id %>
+        AND trustedmapper.is_approved)
 ) AS query

--- a/src/tiler/sql/user_reservations.sql
+++ b/src/tiler/sql/user_reservations.sql
@@ -1,7 +1,4 @@
 (SELECT
-  <% if (is_utf_grid) { %>
-  ST_AsGeoJSON(block.geom) AS geojson,
-  <% } %>
   block.geom, block.id, CASE WHEN block.is_available AND reservation.user_id = <%= user_id %> THEN  'reserved' ELSE 'unavailable' END as survey_type
   FROM survey_blockface AS block
   LEFT OUTER JOIN survey_blockfacereservation AS reservation


### PR DESCRIPTION
Removing the GeoJSON speeds up grid tile queries by 4x on a dev VM. Fetching the GeoJSON for a feature via an AJAX request when it is clicked takes less than 50ms in dev.

Connects to #1128