### PR TITLE
Fix unable to RSVP from event if it is full

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
@@ -20,7 +20,13 @@ The following variables must be in scope:
         <a href="{{ event_edit_url }}"
            class="btn btn-secondary"><i class="icon-cog"></i>Edit</a>
     {% endif %}
-    {% if can_rsvp %}
+    {% if is_rsvped %}
+        <a id="rsvp"
+           href="#"
+           data-verb="DELETE"
+           data-url="{{ rsvp_url }}"
+           class="btn btn-switch btn-rsvp active">Attending</a>
+    {% elif can_rsvp %}
         {% if not user.is_authenticated %}
             <a id="rsvp"
                href="{% url "login" %}?next={{ event.get_absolute_url }}"
@@ -33,12 +39,6 @@ The following variables must be in scope:
             <a id="rsvp"
                href="{% url "training_instructions" %}"
                class="btn btn-switch btn-rsvp">RSVP</a>
-        {% elif is_rsvped %}
-            <a id="rsvp"
-               href="#"
-               data-verb="DELETE"
-               data-url="{{ rsvp_url }}"
-               class="btn btn-switch btn-rsvp active">Attending</a>
         {% else %}
             <a id="rsvp"
                href="#"


### PR DESCRIPTION
Previously, one could not unregister from an event that had reached
maximum capacity, because the RSVP button would become disabled and
read "At Capacity".

This fixes that by updating the RSVP button so that it cannot be disabled for
users that have registered for an event.

Fixes #1045