### PR TITLE
Modify colors

### DIFF
--- a/src/nyc_trees/sass/partials/_legend.scss
+++ b/src/nyc_trees/sass/partials/_legend.scss
@@ -17,19 +17,19 @@
     background-color: #8BC34A;
   }
   .available{
-    background-color: #A8C1B6;
+    background-color: #36b5db;
   }
   .reserved{
     background-color: #E55934;
   }
   .unavailable{
-    background-color: #36494E;
+    background-color: #aaa;
   }
   // If you change these colors, also change src/tiler/style/progress.mss
   .mapped {
-    background-color: #228F73;
+    background-color: #8BC34A;
   }
   .not-mapped {
-    background-color: #E55934;
+    background-color: #aaa;
   }
 }

--- a/src/tiler/style/default.mss
+++ b/src/tiler/style/default.mss
@@ -1,9 +1,9 @@
 /* If you change these colors, also change src/nyc_trees/sass/partials/_legend.scss */
 @surveyed-by-me: #228F73;
 @surveyed-by-others: #8BC34A;
-@available: #A8C1B6;
-@reserved: #E55934;
-@unavailable: #36494E;
+@available: #36b5db;
+@reserved: #e55934;
+@unavailable: #aaa;
 
 #survey_blockface {
   line-join: round;

--- a/src/tiler/style/progress.mss
+++ b/src/tiler/style/progress.mss
@@ -1,6 +1,7 @@
 /* If you change these colors, also change src/nyc_trees/sass/partials/_legend.scss */
-@mapped: #228F73;
-@not-mapped: #E55934;
+@mapped: #8BC34A;
+@not-mapped: #aaa;
+@not-mapped-zoomed-out: #ccc;
 
 #survey_blockface {
   line-join: round;
@@ -17,17 +18,29 @@
 
   [survey_type = 'surveyed-by-me'] {
     line-color: @mapped;
+    [zoom <= 16]{ line-width: 6; }
   }
   [survey_type = 'surveyed-by-others'] {
     line-color: <% if (type === 'progress_all') { %> @mapped <% } else { %> @not-mapped <% } %>;
+    [zoom <= 16]{ line-width: 6; }
   }
+
   [survey_type = 'available'] {
     line-color: @not-mapped;
+    [zoom <= 15]{
+      line-color: @not-mapped-zoomed-out;
+    }
   }
   [survey_type = 'reserved'] {
     line-color: @not-mapped;
+    [zoom <= 15]{
+      line-color: @not-mapped-zoomed-out;
+    }
   }
   [survey_type = 'unavailable'] {
     line-color: @not-mapped;
+    [zoom <= 15]{
+      line-color: @not-mapped-zoomed-out;
+    }
   }
 }


### PR DESCRIPTION
Changes on Progress Map:

* "Unmapped" gray lighter when zoomed out and darker when zoomed in; makes it easier to see the green progress from zoomed out and easier to select when zoomed in
* "Mapped" green lines thicker when zoomed out and normal when zoomed in; makes them stand out more from a distance, but easy to click and distinguish when zoomed in

![image](https://cloud.githubusercontent.com/assets/1809908/7121942/f6b06c2a-e1e5-11e4-87b1-5de0704e41ed.png)

![image](https://cloud.githubusercontent.com/assets/1809908/7121953/0f7578a4-e1e6-11e4-842d-b38a18fb73c6.png)

Changes on Reservation Map:

* "Available" uses blue to make it visually distinctive from "Unavailable"

![image](https://cloud.githubusercontent.com/assets/1809908/7122000/4c9cc64c-e1e6-11e4-9be1-0c42c1b7416e.png)

Fixes #1106
