### PR TITLE
Hide 'you're almost there' when training complete

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/training.html
+++ b/src/nyc_trees/apps/home/templates/home/training.html
@@ -8,7 +8,11 @@
 
   <h2>Training</h2>
   <p class="pageheading-description-detail">
+    {% if user.online_training_complete %}
+    {# when we receive text for this, remove this comment and put it here #}
+    {% else %}
     You're almost there! Continue your training to become a mapper.
+    {% endif %}
   </p>
 
 {% endblock aside %}


### PR DESCRIPTION
addresses #576 on github

This commit changes #576 to a design/content issue and hides some incorrect text for the time being.