### PR TITLE
Show all RSVPd events on "Your Events this week"

### DIFF
--- a/src/nyc_trees/apps/event/event_list.py
+++ b/src/nyc_trees/apps/event/event_list.py
@@ -331,9 +331,9 @@ def immediate_events(request):
               .order_by('begins_at'))
 
     if user.is_authenticated():
-        follows = Follow.objects.filter(user_id=user.id)
-        groups = follows.values_list('group', flat=True)
-        immediate_events = nowish.filter(group_id__in=groups)
+        events = (EventRegistration.objects.filter(user=user)
+                  .values_list('event_id', flat=True))
+        immediate_events = nowish.filter(id__in=events)
     else:
         immediate_events = nowish.none()
 

--- a/src/nyc_trees/apps/event/templates/event/event_list_page.html
+++ b/src/nyc_trees/apps/event/templates/event/event_list_page.html
@@ -36,15 +36,17 @@
   <div class="tab-content">
     <div class="tab-pane active" id="list">
       <section>
-        {# TODO: make event_list return a totally empty context to avoid introspection #}
-        <h4>Your Events this week</h4>
-        <div data-class="event-list-container">
-        {% if immediate_events.event_infos %}
-          {% include "event/partials/event_list.html" with event_list=immediate_events %}
-        {% else %}
-          <p class="no-data">You are not attending any events yet.</p>
+        {% if user.is_authenticated %}
+          {# TODO: make event_list return a totally empty context to avoid introspection #}
+          <h4>Your Events this week</h4>
+          <div data-class="event-list-container">
+          {% if immediate_events.event_infos %}
+            {% include "event/partials/event_list.html" with event_list=immediate_events %}
+          {% else %}
+            <p class="no-data">You are not attending any events yet.</p>
+          {% endif %}
+          </div>
         {% endif %}
-        </div>
 
         {# TODO: make event_list return a totally empty context to avoid introspection #}
         <h4>Browse events</h4>

--- a/src/nyc_trees/apps/event/tests.py
+++ b/src/nyc_trees/apps/event/tests.py
@@ -47,9 +47,7 @@ class EventListTest(EventTestCase):
         request = make_request(user=self.user)
         ctx = events_list_page(request)
         self.assertEqual(len(ctx['all_events']['event_infos']), 1)
-        self.assertEqual(len(ctx['immediate_events']['event_infos']), 1)
-        self.assertFalse(
-            ctx['immediate_events']['event_infos'][0]['user_is_registered'])
+        self.assertEqual(len(ctx['immediate_events']['event_infos']), 0)
 
     def test_following_user_registered(self):
         EventRegistration.objects.create(user=self.user,


### PR DESCRIPTION
Only display events that you have explicitly RSVPd to on the events
listing page.

Test this by RSVPing to an upcoming event that belongs to a group that you are *not* following. The event should appear in "Your events this week".

Fixes #1027