### PR TITLE
Add progress circles to group page. Fixes #1100

### DIFF
--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -83,7 +83,8 @@
         <div class="block nopadding--top clearfix">
             {% include "home/partials/circle.html" with label="Trees" n=3 color="primary" url=progress_page_url %}
             {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" url=progress_page_url %}
-            {% include "home/partials/circle.html" with label="Events" n=counts.event color="primary" modal="#users-modal" %}
+            {% include "home/partials/circle.html" with label="Events " n=counts.event color="primary" modal="#users-modal" %}
+            {% include "home/partials/circle.html" with label="Attendees" n=counts.event color="primary" modal="#users-modal" %}
         </div>
     </section>
     <section class="events" id="{{ group_events_id }}">

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -80,29 +80,10 @@
     </section>
     <section class="contributions">
         <h4 class="section-heading">Contributions</h4>
-        <div class="contribution block item">
-            <div class="row">
-                <div class="contribution-label col-xs-6"><i class="icon-globe"></i>Trees</div>
-                <div class="contribution-number col-xs-6">{{ counts.tree }}</div>
-            </div>
-        </div>
-        <div class="contribution block item">
-            <div class="row">
-                <div class="contribution-label col-xs-6"><i class="icon-flow-tree"></i>Mapped in Area</div>
-                <div class="contribution-number col-xs-6">{{ counts.block }}</div>
-            </div>
-        </div>
-        <div class="contribution block item">
-            <div class="row">
-                <div class="contribution-label col-xs-6"><i class="icon-tag"></i>Events Held</div>
-                <div class="contribution-number col-xs-6">{{ counts.event }}</div>
-            </div>
-        </div>
-        <div class="contribution block item">
-            <div class="row">
-                <div class="contribution-label col-xs-6"><i class="icon-user"></i>Event Attendees</div>
-                <div class="contribution-number col-xs-6">{{ counts.attendees }}</div>
-            </div>
+        <div class="block nopadding--top clearfix">
+            {% include "home/partials/circle.html" with label="Trees" n=3 color="primary" url=progress_page_url %}
+            {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" url=progress_page_url %}
+            {% include "home/partials/circle.html" with label="Events" n=counts.event color="primary" modal="#users-modal" %}
         </div>
     </section>
     <section class="events" id="{{ group_events_id }}">

--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -168,7 +168,23 @@ aside {
 }
 
 .nomargin {
-  margin: 0;
+  margin: 0 !important;
+}
+
+.nomargin--top {
+  margin-top: 0 !important;
+}
+
+.nomargin--bottom {
+  margin-bottom: 0 !important;
+}
+
+.nopadding--top {
+  padding-top: 0 !important;
+}
+
+.nopadding--bottom {
+  padding-bottom: 0 !important;
 }
 
 .rightarrow {

--- a/src/nyc_trees/sass/partials/_home.scss
+++ b/src/nyc_trees/sass/partials/_home.scss
@@ -132,9 +132,9 @@ $hero-box-side-padding: 3rem;
   height: 0;
   padding-bottom: 92%;
   width: 100%;
-
-  &:hover .progress-circle-label {
-      text-decoration: underline;
+  @include transition(.2s ease-in-out color);
+  &:hover {
+    color: darken($brand-primary, 20%) !important;
   }
 }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1809908/7125431/b8fc209a-e1fe-11e4-8bc9-2d5e54b77ebf.png)

I removed the data about number of attendees because I felt like the number of followers, which we already show on this page, is a better representation of that activity. Plus, this allows us to use the standard 3 circle pattern that is on the dashboard.