### PR TITLE
Codify AMI promotion process

### DIFF
--- a/deployment/deployment-helper.sh
+++ b/deployment/deployment-helper.sh
@@ -123,13 +123,21 @@ toggle_tile_server_stack() {
 }
 
 function get_latest_internal_ami() {
+  AWS_IMAGES=$(aws ec2 describe-images --owner self)
+
+  # No images are owned by requesting user; look for images
+  # this user can launch.
+  if [[ -z $AWS_IMAGES ]]; then
+    AWS_IMAGES=$(aws ec2 describe-images --executable-users self)
+  fi
+
   # 1. Get list of AMIs owned by this account
   # 2. Filter by type (only argument to this function)
   # 3. Filter again for the IMAGES row
   # 4. Sort by AMI name (contains a date created timestamp)
   # 5. Take the top row
   # 6. Take the 4th column
-  aws ec2 describe-images --owners self \
+  echo "${AWS_IMAGES}" \
     | grep "${1}" \
     | grep IMAGES \
     | sort -k8 -r \

--- a/scripts/aws/promote-ami.sh
+++ b/scripts/aws/promote-ami.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+if env | grep -q "NYC_TREES_DEPLOY_DEBUG"; then
+  set -x
+fi
+
+function packer_isotime() {
+   date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+if (env | grep -q "NYC_TREES_PROMOTE_AMI" && env | grep -q "NYC_TREES_PROMOTE_ACCOUNT_ID"); then
+    # Grant launch permissions to provided account ID
+    aws ec2 modify-image-attribute \
+        --image-id ${NYC_TREES_PROMOTE_AMI} \
+        --operation-type add \
+        --user-ids ${NYC_TREES_PROMOTE_ACCOUNT_ID} \
+        --attribute launchPermission && \
+    # Update tags on AMI to denote that it has been promoted
+    # to production
+    aws ec2 create-tags \
+        --resources ${NYC_TREES_PROMOTE_AMI} \
+        --tags Key=Environment,Value=Production Key=Promoted,Value=$(packer_isotime)
+else
+    echo "An AMI ID and AWS account ID to promote must be provided."
+
+    exit 1
+fi


### PR DESCRIPTION
These changes support AMI promotion from one account to another. Sharing is facilitated by giving launch permissions to another account ID. Once shared, the AMI tags are updated to reflect the promotion and avoid any image pruning processes.