### PR TITLE
Don't ignore event related HTTP errors on survey pages

### DIFF
--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -12,7 +12,7 @@ from celery import chain
 
 from django.conf import settings
 from django.contrib.gis.geos import GeometryCollection
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.urlresolvers import reverse
 from django.db import transaction, connection
 from django.db.models import Prefetch
@@ -389,7 +389,7 @@ def blockface(request, blockface_id):
 def _validate_event_and_group(request, event_slug):
     event = get_object_or_404(Event, group=request.group, slug=event_slug)
     if not user_is_checked_in_to_event(request.user, event):
-        return HttpResponseForbidden('User not checked-in to this event')
+        raise PermissionDenied('User not checked-in to this event')
     return event
 
 


### PR DESCRIPTION
The `_validate_event_and_group` function returns an HTTP error if the
user is not checked into the current event. Consumers of this helper function
erroneously assume that a valid event is returned. The result is that some
survey endpoints can be triggered by users even if they have not been
checked into the event.