### PR TITLE
Add Windshaft request parsing support

### DIFF
--- a/deployment/ansible/roles/nyc-trees.beaver/templates/windshaft.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.beaver/templates/windshaft.conf.j2
@@ -1,3 +1,4 @@
 [/var/log/{upstart/nyc-trees-tiler.log,nyc-trees-tiler.log}]
+format: rawjson
 type: windshaft
 tags: windshaft,beaver

--- a/deployment/ansible/roles/nyc-trees.logstash/templates/logstash.conf.j2
+++ b/deployment/ansible/roles/nyc-trees.logstash/templates/logstash.conf.j2
@@ -11,6 +11,14 @@ input {
   }
 }
 
+filter {
+  if [type] == "windshaft" {
+    date {
+      match => [ "timestamp", "E, dd MMM yyyy HH:mm:ss z" ]
+    }
+  }
+}
+
 output {
   elasticsearch {
     embedded => false

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -57,6 +57,11 @@ var Windshaft = require('windshaft'),
             port: statsdPort
         },
 
+        // ISO date formatting is not respected here. There is a Logstash
+        // filter downstream that converts `timestamp` into `@timestamp`
+        // with the proper formatting.
+        log_format: '{ "timestamp": ":date[iso]", "@fields": { "remote_addr": ":remote-addr", "body_bytes_sent": ":res[content-length]", "request_time": ":response-time", "status": ":status", "request": ":method :url HTTP/:http-version", "request_method": ":method", "http_referrer": ":referrer", "http_user_agent": ":user-agent" } }',
+
         enable_cors: true,
 
         mapnik: {


### PR DESCRIPTION
These changes break individual Windshaft tile requests into specific attributes that are indexed in ElasticSearch for querying.

1. Windshaft emits logs as JSON
2. Beaver picks them up and ships them to Logstash
3. Logstash converts the `timestamp` field into `@timestamp` with the proper formatting
4. Resulting JSON blob is shipped to ElasticSearch

---

![discover_-_kibana_4](https://cloud.githubusercontent.com/assets/43639/7147969/fe0de168-e2cc-11e4-87a9-4c5175532dff.png)
