### PR TITLE
Add header text to printable maps

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/printable_event_map.html
+++ b/src/nyc_trees/apps/event/templates/event/printable_event_map.html
@@ -2,6 +2,11 @@
 {% load utils %}
 
 {% block body %}
+    <div class="map-pdf-header">
+        <div>TreesCount! 2015 Event Map</div>
+        <div>{{ event.title }}, hosted by {{ event.group.name }}.</div>
+        <div>{{ event.begins_at|date:"l, F jS fA" }} to {{ event.ends_at|date:"fA" }}.</div>
+    </div>
     <div id="map" class="map-pdf"
          data-tile-url="{{ layer.tile_url }}"
          data-lat="{{ event.location.y }}" data-lon="{{ event.location.x }}">

--- a/src/nyc_trees/apps/survey/templates/survey/printable_reservations_map.html
+++ b/src/nyc_trees/apps/survey/templates/survey/printable_reservations_map.html
@@ -2,6 +2,11 @@
 {% load utils %}
 
 {% block body %}
+    <div class="map-pdf-header">
+        <div>TreesCount! 2015 Reservations Map</div>
+        <div>For more information about your block edge reservations,</div>
+        <div>visit http://treescount.nycgovparks.org/blockedge.</div>
+    </div>
     <div id="map" class="map-pdf"
          data-tile-url="{{ layer.tile_url }}"
          {% if bounds %}data-bounds="{{ bounds }}"{% endif %}

--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -78,6 +78,14 @@
   height: 9.3in
 }
 
+.map-pdf-header {
+  position: absolute;
+  z-index: $zindex-modal + 1;
+  margin-bottom: 3pt;
+  font-size: 12pt;
+  background: white;
+}
+
 .map-sidebar-context {
   position: relative;
   background-color: $body-bg;


### PR DESCRIPTION
Header text added. Styling welcome.
In particular, the `map-pdf-header` style specifies `background: white`.
That works correctly when viewing the printable map as HTML (e.g. `/blockedge/printable-map`)
but does not work when rendered to a PDF by PhantomJS.

Fixes #880