### PR TITLE
Bump pip role version

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,6 +1,6 @@
 azavea.apache2,0.2.2
 azavea.ntp,0.1.1
-azavea.pip,0.1.0
+azavea.pip,0.1.1
 azavea.nodejs,0.3.0
 azavea.postgresql,0.2.1
 azavea.postgresql-support,0.2.0


### PR DESCRIPTION
This change fixes a scenario during AMI creation where Packer installs the `python-pip` and `python-dev` packages prior to running Ansible because Python is an Ansible dependency. The version of the `python-pip` package installed when no version number is specified (as is the case in the Packer template) conflicts with the version installed by this role because it prompts the user for dependent package downgrades.

See also: https://github.com/azavea/ansible-pip/pull/1