### PR TITLE
Clean up the Django Admin page

### DIFF
--- a/src/nyc_trees/apps/core/admin.py
+++ b/src/nyc_trees/apps/core/admin.py
@@ -3,14 +3,27 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from waffle.models import Sample, Switch
+
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from django.contrib import admin
 from django.contrib.gis.admin import OSMGeoAdmin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
+from django.contrib.auth.models import Group as AuthGroup
+from django.contrib.sites.models import Site
 
 from apps.core.models import User, Group
+
+
+admin.site.unregister(AuthGroup)
+
+if not settings.DEBUG:
+    admin.site.unregister(Site)
+    admin.site.unregister(Sample)
+    admin.site.unregister(Switch)
 
 
 @admin.register(Group)

--- a/src/nyc_trees/apps/event/admin.py
+++ b/src/nyc_trees/apps/event/admin.py
@@ -4,6 +4,9 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.contrib import admin
+from django.contrib.gis.admin import OSMGeoAdmin
 import apps.event.models as m
-admin.site.register(m.Event)
+
+
+admin.site.register(m.Event, OSMGeoAdmin)
 admin.site.register(m.EventRegistration)

--- a/src/nyc_trees/apps/survey/migrations/0017_auto_20150415_1419.py
+++ b/src/nyc_trees/apps/survey/migrations/0017_auto_20150415_1419.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0016_blockface_source'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='species',
+            options={'ordering': ['common_name', 'scientific_name', 'cultivar'], 'verbose_name_plural': 'Species'},
+        ),
+        migrations.AlterModelOptions(
+            name='territory',
+            options={'verbose_name_plural': 'Territories'},
+        ),
+    ]

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -31,6 +31,9 @@ class Territory(NycModel, models.Model):
     def __unicode__(self):
         return '%s -> %s' % (self.group, self.blockface_id)
 
+    class Meta:
+        verbose_name_plural = "Territories"
+
 
 class Survey(NycModel, models.Model):
     # We do not anticipate deleting a Blockface, but we definitely
@@ -70,6 +73,7 @@ class Species(NycModel, models.Model):
     class Meta:
         unique_together = ("scientific_name", "cultivar", "common_name")
         ordering = ['common_name', 'scientific_name', 'cultivar']
+        verbose_name_plural = "Species"
 
 
 CURB_CHOICES = (


### PR DESCRIPTION
Adds the ability to edit an event location from the admin site

Disables access to to the builtin Group model that we don't use

In staging/production builds:
Disables editing Site objects, which we set up with a script
Disables editing a few Waffle models, but leaves Flag enabled

Also fixes #1065