### PR TITLE
Add space on training navigation buttons. Fixes #1137

### DIFF
--- a/src/nyc_trees/apps/home/templates/flatpages/training.html
+++ b/src/nyc_trees/apps/home/templates/flatpages/training.html
@@ -5,7 +5,7 @@
 
 {% block extra_content %}
 
-  <div class="training-bar visible-xs">
+  <div class="training-bar visible-xs clearfix">
     <a class="btn btn-secondary btn-mobile--max"
        data-class="training-flatpage-subpage-accept-feedback"
        style="display: none;">Try Again</a>
@@ -34,7 +34,7 @@
 
   <div class="training-flatpage-container" data-class="training-flatpage-container" style="display: none;">{{ flatpage.content }}</div>
 
-  <div class="training-bar hidden-xs">
+  <div class="training-bar hidden-xs clearfix">
     <a class="btn btn-secondary btn-mobile--max"
        data-class="training-flatpage-subpage-accept-feedback"
        style="display: none;">Try Again</a>


### PR DESCRIPTION
This should fix the issue where buttons touch bottom of page/area on tablet.

![image](https://cloud.githubusercontent.com/assets/1809908/7164576/0cf57f5e-e36f-11e4-93f9-446cb4198a2a.png)
