### PR TITLE
Prevent registration of usernames that conflict with URLs

### DIFF
--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -100,6 +100,12 @@ class User(NycModel, AbstractUser):
                       'contributions_are_public': 'contributions',
                       'achievements_are_public': 'achievements'}
 
+    # Please keep in sync with special `/user/*` endpoints.
+    # Ref: src/nyc_trees/apps/users/urls/user.py
+    reserved_usernames = ('profile',
+                          'settings',
+                          'achievements')
+
     def clean(self):
         if ((User.objects.exclude(pk=self.pk)
              .filter(email__iexact=self.email).exists())):

--- a/src/nyc_trees/apps/login/forms.py
+++ b/src/nyc_trees/apps/login/forms.py
@@ -8,6 +8,7 @@ import floppyforms.__future__ as forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.template import loader
 from django.utils.encoding import force_bytes
@@ -38,6 +39,11 @@ class NycRegistrationForm(RegistrationFormUniqueEmail):
         label='I am over 13 years old',
         required=False
     )
+
+    def clean_username(self):
+        if self.cleaned_data['username'].lower() in User.reserved_usernames:
+            raise ValidationError('This username is not available.')
+        return super(NycRegistrationForm, self).clean_username()
 
 
 class UsernameOrEmailPasswordResetForm(forms.Form):

--- a/src/nyc_trees/apps/users/urls/user.py
+++ b/src/nyc_trees/apps/users/urls/user.py
@@ -7,11 +7,13 @@ from django.conf.urls import patterns, url
 from apps.users.routes import user as r
 
 # These URLs have the prefix 'user/'
+# NOTE: When adding special `/user/*` endpoints, please remember to update
+# `User.reserved_usernames` to prevent URL ambiguity.
 urlpatterns = patterns(
     '',
     url(r'^profile/$', r.user_detail_redirect, name='user_detail_redirect'),
 
-    url(r'settings/$', r.user_profile_settings, name='user_profile_settings'),
+    url(r'^settings/$', r.user_profile_settings, name='user_profile_settings'),
 
     url(r'^achievements/$', r.achievements, name='achievements'),
 


### PR DESCRIPTION
Add form validation error to prevent registration of usernames that
would conflict with any of our special `/user/*` URLs.

Fixes #1171