### PR TITLE
Add partial for non_field_errors

### DIFF
--- a/src/nyc_trees/apps/core/templates/core/partials/email_form.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/email_form.html
@@ -1,7 +1,7 @@
 <form method="POST">
     <fieldset>
         {% csrf_token %}
-        {{ form.non_field_errors }}
+        {% include "core/partials/non_field_errors.html" %}
         <div class="block item">
             {{ form.subject.errors }}
             {{ form.subject.label_tag }}

--- a/src/nyc_trees/apps/core/templates/core/partials/non_field_errors.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/non_field_errors.html
@@ -1,0 +1,8 @@
+{# Source: http://stackoverflow.com/questions/1368483/styling-django-non-field-errors-on-forms/16215790#16215790 #}
+{% if form.non_field_errors %}
+  <div class="non-field-errors">
+    {% for err in form.non_field_errors %}
+      <p class="form-error">{{ err }}</p>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/src/nyc_trees/apps/event/templates/event/partials/event_form.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/event_form.html
@@ -1,7 +1,7 @@
 <form method="POST" id="event-form">
         {% csrf_token %}
 
-        {{ form.non_field_errors }}
+        {% include "core/partials/non_field_errors.html" %}
 
         <fieldset class="h4 color--primary">Event details</fieldset>
 

--- a/src/nyc_trees/apps/login/templates/login/forgot_username.html
+++ b/src/nyc_trees/apps/login/templates/login/forgot_username.html
@@ -14,7 +14,7 @@
             Forgot your username? Enter the Email address you used to register
             with TreesCount! and click the “Send” button below.
         </p>
-        {{ form.non_field_errors }}
+        {% include "core/partials/non_field_errors.html" %}
         <p>
           <div class="fieldWrapper">
             {{ form.email.errors }}

--- a/src/nyc_trees/apps/users/templates/groups/settings.html
+++ b/src/nyc_trees/apps/users/templates/groups/settings.html
@@ -46,7 +46,8 @@
 
                     <fieldset>
 
-                        {{ form.non_field_errors }}
+                        {% include "core/partials/non_field_errors.html" %}
+
                         <div class="block item">
                             {{ form.description.errors }}
                             {{ form.description.label_tag }}

--- a/src/nyc_trees/templates/registration/activation_complete.html
+++ b/src/nyc_trees/templates/registration/activation_complete.html
@@ -12,7 +12,7 @@ Optional Information
 <form method="POST">
     {% csrf_token %}
 
-    {{ form.non_field_errors }}
+    {% include "core/partials/non_field_errors.html" %}
 
     <div class="field">
         {{ form.first_name.label_tag }}

--- a/src/nyc_trees/templates/registration/login.html
+++ b/src/nyc_trees/templates/registration/login.html
@@ -14,7 +14,7 @@
 <form method="post" action="">
     {% csrf_token %}
 
-    {{ form.non_field_errors }}
+    {% include "core/partials/non_field_errors.html" %}
 
     <p>
         {{ form.username.errors }}

--- a/src/nyc_trees/templates/registration/password_change_form.html
+++ b/src/nyc_trees/templates/registration/password_change_form.html
@@ -8,7 +8,7 @@
 <form method="post" action="">
     {% csrf_token %}
 
-    {{ form.non_field_errors }}
+    {% include "core/partials/non_field_errors.html" %}
 
     <p>
         {{ form.old_password.errors }}

--- a/src/nyc_trees/templates/registration/password_reset_confirm.html
+++ b/src/nyc_trees/templates/registration/password_reset_confirm.html
@@ -8,7 +8,7 @@
 <form method="post" action="">
     {% csrf_token %}
 
-    {{ form.non_field_errors }}
+    {% include "core/partials/non_field_errors.html" %}
 
     <p>
         <label for="id_new_password1">New password:</label>

--- a/src/nyc_trees/templates/registration/password_reset_form.html
+++ b/src/nyc_trees/templates/registration/password_reset_form.html
@@ -11,7 +11,7 @@
 <form method="post" action="">
     {% csrf_token %}
 
-    {{ form.non_field_errors }}
+    {% include "core/partials/non_field_errors.html" %}
 
     <p>
         {{ form.email_or_username.errors }}

--- a/src/nyc_trees/templates/registration/registration_form.html
+++ b/src/nyc_trees/templates/registration/registration_form.html
@@ -8,7 +8,7 @@
 <form method="post" action="">
     {% csrf_token %}
 
-    {{ form.non_field_errors }}
+    {% include "core/partials/non_field_errors.html" %}
 
     <p class="required">
         {{ form.username.errors }}


### PR DESCRIPTION
This partial will allow us to more easily customize the style of form
errors that are not specific to any particular field.

Fixes #1023