### PR TITLE
Topic/1110/add training images

### DIFF
--- a/src/nyc_trees/apps/home/static/flatpages/getting_started.html
+++ b/src/nyc_trees/apps/home/static/flatpages/getting_started.html
@@ -1,4 +1,4 @@
-<div>
+<div id="orientation">
   <h3>1. Orientation</h3>
 
   <p>NYC Parks uses a street tree mapping method developed by TreeKIT, a non-profit organization based in NYC that helps city dwellers measure, map, and collaboratively manage urban forests. You will use the TreeKIT method to accurately map the location of street trees and, in the process, collect some data about each tree and its immediate environment.</p>

--- a/src/nyc_trees/apps/home/static/flatpages/the_mapping_method.html
+++ b/src/nyc_trees/apps/home/static/flatpages/the_mapping_method.html
@@ -74,14 +74,14 @@
     <img src="/static/img/training/First-Second/first-second.png"/>
 </div>
 
-<div>
+<div id="mapping-to-the-end-point">
     <h3>5. Mapping to the End Point</h3>
 
     <p>Find the end point at the ending intersection using the same method you used to find the start point at the starting intersection. Walk and roll the measuring wheel from the center of the last tree trunk on the block edge to the end point. Lift the wheel and record the distance number in the <em>Treecorder.</em></p>
 </div>
 
 
-<div>
+<div id="mapping-trees-away-from-the-curb">
     <h3>6. Mapping Trees Away From The Curb</h3>
 
     <p>Some street trees are not planted near the sidewalk curb. That is OK! If the next tree you see is offset from the curb, just keep rolling the wheel along the curb until you arrive at the approximate center of the offset tree trunk. Log the tree as “Offset From The Curb” on your phone or tablet. The system will map the tree away from the curb later on. Just remember to keep going along the curb and logging each offset tree as you find them.</p>
@@ -94,7 +94,7 @@
 
 </div>
 
-<div>
+<div id="what-if-there-arent-any-trees">
     <h3>7. What If There Aren’t Any Trees?</h3>
 
     <p>Some streets don’t have street trees. That is OK! We need to record the block edges without street trees, too. After selecting your block edge, start point, and the side of the street you are mapping, you can click the “No Trees” button in the <em>Treecorder</em>, and that’s it! The block edge has been recorded as having no trees.</p>

--- a/src/nyc_trees/apps/home/static/flatpages/tree_data.html
+++ b/src/nyc_trees/apps/home/static/flatpages/tree_data.html
@@ -20,7 +20,7 @@
   <p>Dead trees and stumps need to be removed to make space for new trees in the future.</p>
 </div>
 
-<div>
+<div id="tree-trunk-size">
     <h3>2. Tree Trunk Size</h3>
 
     <p>Trunk size is measured in circumference, or the girth of the tree. The circumference is always measured at a point on the trunk that is 4.5 feet, or 54 inches, from the ground.</p>
@@ -47,7 +47,7 @@
     <p>Tree trunk size tells us about the amount of carbon dioxide a tree soaks up from the atmosphere, the amount of electricity it conserves by shading and cooling the local environment, and the amount of water it soaks up during a rainstorm.</p>
 </div>
 
-<div>
+<div id="tree-stump-size">
     <h3>3. Tree Stump Size</h3>
     <p>Tree stump size is measured in diameter, or the width across the top of the stump. Make a quick visual guestimate of the widest distance across the top of a stump at the outside edge of the bark. Use your tape measure across that distance. Enter the diameter into the <em>Treecorder.</em></p>
 
@@ -124,7 +124,7 @@
 </li>
 
         <li>
-            <h4>What if I’m Not Sure?</h4>
+            <h4 id="what-if-im-not-sure">What if I’m Not Sure?</h4>
             <p>Identifying a tree species can be challenging at first. Don’t worry; you will get the hang
                 of it quickly. Before long you will be able to impress all of your friends by naming the
                 species of each tree on your block. Yet a tricky tree can sometimes stump even the
@@ -134,7 +134,7 @@
     </ol>
 </div>
 
-<div>
+<div id="perceptions-of-tree-health">
     <h3>5. Perceptions of Tree Health</h3>
 
     <p>The health of a living street tree is rated <strong>good</strong>, <strong>fair</strong>, or <strong>poor</strong>, depending on five factors: 1) the density of leaves in the tree canopy; 2) the overall color of the leaves; 3) the presence or absence of broken branches; 4) the presence or absence of trunk wounds; and 5) the shape of the tree after repeated pruning or branch loss.</p>

--- a/src/nyc_trees/apps/home/static/flatpages/tree_surroundings.html
+++ b/src/nyc_trees/apps/home/static/flatpages/tree_surroundings.html
@@ -29,7 +29,7 @@ three inches from the ground is harmful. Select <strong>Harmful Guard</strong> i
 </div>
 
 
-<div>
+<div id="evidence-of-stewardship">
     <h3>2. Stewardship Practices</h3>
   <p>Evidence of street tree stewardship is measured as the number of different clues we find to
 suggest that someone is actively taking care of a tree. Stewardship, or volunteer tree care,

--- a/src/nyc_trees/apps/home/templates/home/quiz_complete_page.html
+++ b/src/nyc_trees/apps/home/templates/home/quiz_complete_page.html
@@ -43,7 +43,7 @@
     <div class="panel panel-warning">
 {% endif %}
     <div class="panel-heading">
-        {{ forloop.counter }}. {{ item.question.text }}
+        {{ forloop.counter }}. {{ item.question.text|safe }}
     </div>
     <div class="panel-body">
         <p>

--- a/src/nyc_trees/apps/home/templates/home/quiz_page.html
+++ b/src/nyc_trees/apps/home/templates/home/quiz_page.html
@@ -29,7 +29,7 @@
 <h3>
     Question {{ forloop.counter }} of {{ quiz.questions|length }}
 </h3>
-<p>{{ question.text }}</p>
+<p>{{ question.text|safe }}</p>
 
 {% if question.allow_multiple_selections %}
 <p>Please check all applicable answers.</p>

--- a/src/nyc_trees/apps/home/training/__init__.py
+++ b/src/nyc_trees/apps/home/training/__init__.py
@@ -90,4 +90,22 @@ quizzes = {
                 incorrect_markup=QS.q7_incorrect_markup,
                 answer=SingleAnswer(0),
                 choices=(QS.q7_c1, QS.q7_c2, QS.q7_c3)),
+            Question(
+                text=QS.q8_text,
+                correct_markup=QS.q8_correct_markup,
+                incorrect_markup=QS.q8_incorrect_markup,
+                answer=SingleAnswer(2),
+                choices=(QS.q8_c1, QS.q8_c2, QS.q8_c3)),
+            Question(
+                text=QS.q9_text,
+                correct_markup=QS.q9_correct_markup,
+                incorrect_markup=QS.q9_incorrect_markup,
+                answer=SingleAnswer(0),
+                choices=(QS.q9_c1, QS.q9_c2, QS.q9_c3, QS.q9_c4)),
+            Question(
+                text=QS.q10_text,
+                correct_markup=QS.q10_correct_markup,
+                incorrect_markup=QS.q10_incorrect_markup,
+                answer=SingleAnswer(1),
+                choices=(QS.q10_c1, QS.q10_c2, QS.q10_c3)),
         ))}

--- a/src/nyc_trees/apps/home/training/quiz_strings.py
+++ b/src/nyc_trees/apps/home/training/quiz_strings.py
@@ -37,6 +37,16 @@ _orientation = """
    target="_blank">Orientation.</a>
 """
 
+_evidence_of_stewardship = """
+<a href="/training/pure/tree_surroundings/#evidence-of-stewardship"
+   target="_blank">Evidence of Stewardship.</a>
+"""
+
+_what_if_im_not_sure = """
+<a href="/training/pure/tree_data/#what-if-im-not-sure"
+   target="_blank">What if I'm not sure?</a>
+"""
+
 
 class QuizStrings(object):
 
@@ -70,6 +80,7 @@ class QuizStrings(object):
     q2_text = """
     How do you map a street tree that is offset from the curb
     in an alternating pattern? Select all that apply.
+    <img src="/static/img/training/Stagger-Offset/stagger-offset.png"/>
     """
 
     q2_c1 = "Find the tree center and record the distance."
@@ -109,7 +120,10 @@ class QuizStrings(object):
     # QUESTION 4                                                 #
     ##############################################################
 
-    q4_text = "What is the diameter of a tree stump?"
+    q4_text = """
+    What is the diameter of a tree stump?
+    <img src="/static/img/training/Stump/stump.png"/>
+    """
 
     q4_c1 = "The distance from the center of the tree to the bark."
     q4_c2 = "Half the distance around the trunk of the tree."
@@ -188,3 +202,70 @@ class QuizStrings(object):
     q7_incorrect_markup = """
     Incorrect. Review %s
     """ % _orientation
+
+    ##############################################################
+    # QUESTION 8                                                 #
+    ##############################################################
+
+    q8_text = """
+    <img src="/static/img/training/Poor-health-one/poor-health-one.png"/>
+    One reason we can tell this tree is in poor health is:
+    """
+
+    q8_c1 = "The branches are not broken."
+    q8_c2 = "It is short."
+    q8_c3 = "The canopy is very sparse."
+
+    q8_correct_markup = """
+    Correct: Leaves with brown spots and holes, broken branches,
+    and significant damage to the trunk and bark are signs of a
+    tree in poor health. See: %s
+    """ % _perceptions_of_tree_health
+
+    q8_incorrect_markup = """
+    Incorrect. Review %s
+    """ % _perceptions_of_tree_health
+
+    ##############################################################
+    # QUESTION 9                                                 #
+    ##############################################################
+
+    q9_text = "Which Tree Steward signs should be counted?"
+
+    q9_c1 = "Curb your dog signs."
+    q9_c2 = "Parking signs."
+    q9_c3 = "Signs stapled to the tree."
+    q9_c4 = "Business flyers."
+
+    q9_correct_markup = """
+    Correct: Signs that explain the care or importance of street trees
+    are evidence of Stewardship. Signs placed by a business or the city
+    and signs attached directed onto the tree are not. See: %s
+    """ % _evidence_of_stewardship
+
+    q9_incorrect_markup = """
+    Incorrect. Review %s
+    """ % _evidence_of_stewardship
+
+    ##############################################################
+    # QUESTION 10                                                 #
+    ##############################################################
+
+    q10_text = """
+    What do you do when you are uncertain of the tree species you have chosen?
+    """
+
+    q10_c1 = "Take your best guess."
+    q10_c2 = "Take your best guess and select “No”."
+    q10_c3 = "Take your best guess and select “Yes”."
+
+    q10_correct_markup = """
+    Correct: If you are confident you can select Yes when you ID the tree.
+    However, when you have doubt in your choice, it is important and perfectly
+    acceptable to select Maybe or even No if you are really unsure.
+    See: %s
+    """ % _what_if_im_not_sure
+
+    q10_incorrect_markup = """
+    Incorrect. Review %s
+    """ % _what_if_im_not_sure


### PR DESCRIPTION
@dboyer notice that 'Evidence of Stewardship' does not exist in the training materials but is references in the quiz. I think they meant `Stewardship Practices', so I went with that, but left the text as is.