### PR TITLE
Replace lorem ipsum on progress map, group detail, and event email form

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/email_rsvps.html
+++ b/src/nyc_trees/apps/event/templates/event/email_rsvps.html
@@ -10,13 +10,14 @@
                 Your message has been sent to {{ rsvp_count }} recipient(s).
             {% else %}
                 <h4 class="section-heading">Recipients</h4>
-                <span>{{ rsvp_count }}</span> RSVPS
                 {% if rsvp_count > 0 %}
+                    <span>{{ rsvp_count }}</span> RSVPS
                     <a href="{% url 'event_admin_check_in_page' group_slug=group.slug event_slug=event.slug%}">See all</a>
+                    <p>This form will allow you to contact your event registrants, either before the event or up to 7 days after the event. <i>Note that only event attendees who have opted into emails will receive these updates!! Do not use this to update your event details – edit the event details directly instead.</i></p>
                     {% include "core/partials/email_form.html" %}
                 {% else %}
                     {# There is no one to email! #}
-                    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+                    <p>There are no volun<b>treers</b> RSVPed for your event. Please try again when there is at least 1 volun<b>treer</b> RSVPed.</p>
                 {% endif %}
             {% endif %}
             </section>

--- a/src/nyc_trees/apps/home/templates/home/partials/legend.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/legend.html
@@ -17,7 +17,7 @@
                 </div>
                 <h5>Legend</h5>
                 {% for entry in legend_entries %}
-                    <div class="entry" data-mode="{{ entry.mode }}">
+                    <div class="entry {% if entry.mode != legend_mode %}hidden{% endif%}" data-mode="{{ entry.mode }}">
                         <div class="swatch {{ entry.css_class }}"></div>
                         {{ entry.label }}
                     </div>

--- a/src/nyc_trees/apps/survey/templates/survey/partials/progress_legend.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/progress_legend.html
@@ -5,7 +5,21 @@ Progress
 {% endblock %}
 
 {% block legend_text %}
-The progress map shows lorem ipsum dolor sit amet, consectetur adipiscing
-elit. Sed eu congue lorem, id feugiat tortor. Aliquam ante elit, sodales eget
-porttitor vel, commodo et felis.
+<div data-mode="default">
+    Welcome to the TreesCount! 2015 progress map!
+
+    <p>This map shows where your fellow tree-loving citizens have already mapped street trees in NYC.
+       Explore the map to view overall progress, your progress, and the progress of TreesCount! Partner groups!</p>
+</div>
+<div data-mode="all" class="hidden">
+    This map shows the block edges mapped so far by all volun<b>treers</b> for TreesCount! 2015. Sign up for an event to help us finish mapping our street trees!
+</div>
+<div data-mode="my" class="hidden">
+    This map shows the block edges that have been mapped by you!
+
+    <p>Sign up for an event or make a block edge reservation to keep on mapping!</p>
+</div>
+<div data-mode="groups" class="hidden">
+    This map shows you our TreesCount! Partner groups’ Census Zones and their mapping progress. Click on a Census Zone for more details!
+</div>
 {% endblock %}

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -61,6 +61,7 @@ def progress_page(request):
             {'mode': 'my', 'css_class': 'not-mapped',
              'label': 'Not mapped by you'},
         ],
+        'legend_mode': 'all',
         'layer_all': get_context_for_progress_layer(request, 'progress_all'),
         'layer_my': get_context_for_progress_layer(request, 'progress_my'),
         'help_shown': _was_help_shown(request, 'progress_page_help_shown')

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -114,7 +114,7 @@
     {% if show_mapper_request %}
     <section>
         <h4 class="section-heading">Individual Mapping</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu congue lorem, id feugiat tortor. Aliquam ante elit, sodales eget porttitor vel, commodo et felis.</p>
+        <p>Volun<b>treers</b> are able to map trees on their own, outside of scheduled events! Click the button below to request individual mapping status within this group&rsquo;s Census Zone. Remember to contact your local loaning hub to check out individual tools and start mapping on your own.</p>
         <button class="btn btn-primary btn-mobile--max"
                 data-action="request-access"
                 data-group-slug="{{ group.slug }}">Request Individual Mapper Status</button>

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -24,28 +24,34 @@ var progressMap = mapModule.create({
         modeDropdown: '.dropdown',
         modeButton: '.btn',
         modeChoice: '.dropdown li a',
-        legendEntries: '.entry',
+        legendEntries: '[data-mode]',
         actionBar: '#action-bar'
     },
     $actionBar = $(dom.actionBar);
 
 $(dom.modeChoice).click(onModeChanged);
 
-$(dom.modeChoice).first().trigger('click');
+loadLayers($(dom.modeChoice).first());
 
 function onModeChanged(e) {
-    var $mode = $(e.currentTarget),
-        tileUrl = $mode.data('tile-url'),
-        gridUrl = $mode.data('grid-url'),
-        bounds = $mode.data('bounds');
+    e.preventDefault();
+    var $mode = $(e.currentTarget);
 
     // Shown chosen mode on dropdown button
     $mode.parents(dom.modeDropdown).find(dom.modeButton).text($mode.text());
 
     // Show appropriate legend entries
     var mode = $mode.attr('href').slice(1);  // strip leading #
-    $(dom.legendEntries).hide();
-    $('[data-mode=' + mode + ']').show();
+    $(dom.legendEntries).addClass('hidden');
+    $('[data-mode=' + mode + ']').removeClass('hidden');
+
+    loadLayers($mode);
+}
+
+function loadLayers($mode) {
+    var tileUrl = $mode.data('tile-url'),
+        gridUrl = $mode.data('grid-url'),
+        bounds = $mode.data('bounds');
 
     // Clear action bar
     $actionBar.empty();


### PR DESCRIPTION
Modifies progress page to change legend text on mode change, while showing
default legend text before the mode is changed.

Fixes #957