### PR TITLE
Fix sizing on download button

### DIFF
--- a/src/nyc_trees/apps/core/templates/core/partials/polling_download_section.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/polling_download_section.html
@@ -1,9 +1,9 @@
 <div class="description block item column-static">
     <div class="row">
-        <div class="col-xs-8">
+        <div class="col-xs-7">
             <h5>Printable Map</h5>
         </div>
-        <div class="col-xs-4 text-right column-static">
+        <div class="col-xs-5 text-right column-static">
             <a href="javascript:;" class="btn btn-default" data-poll-url="{{ poll_url }}">
                 <i class="animate-spin icon-spin4"></i>
             </a>


### PR DESCRIPTION
Was falling off the page like this:

![image](https://cloud.githubusercontent.com/assets/1809908/7186984/8222d976-e43b-11e4-8f14-d93d487e7d13.png)

Now it's looking sharp like this:

![image](https://cloud.githubusercontent.com/assets/1809908/7186988/8e2badba-e43b-11e4-9eff-6dfdac6a05e3.png)
