### PR TITLE
Fix ios8 scrolling glitch on map page

### DIFF
--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -49,7 +49,7 @@ body {
   -moz-box-orient: vertical;
   -moz-box-direction: normal;
   flex-direction: column;
-  min-height: 100vh;
+  min-height: 100%;
   @media (min-width: $screen-sm) {
     background-color: $body-bg;
   }


### PR DESCRIPTION
I noticed this glitch when testing the map pages on iOS 8. The page height was expanding beyond the height of the screen, making the page scrollable, which we don't want.

Before video:

http://sandbox.azavea.com/temporary/nyc-ios8-scroll-before.mov

After video:

http://sandbox.azavea.com/temporary/nyc-ios8-scroll-after.mov