### PR TITLE
Redirect non-mappers to Reservations Instructions page

### DIFF
--- a/src/nyc_trees/apps/home/routes.py
+++ b/src/nyc_trees/apps/home/routes.py
@@ -21,3 +21,7 @@ retrieve_job_status = do(v.retrieve_job_status)
 individual_mapper_instructions = individual_mapper_do(
     render_template('home/individual_mapper_instructions.html'),
     v.individual_mapper_instructions)
+
+trusted_mapper_request_sent = individual_mapper_do(
+    render_template('home/trusted_mapper_request_sent.html'),
+    v.trusted_mapper_request_sent)

--- a/src/nyc_trees/apps/home/templates/home/individual_mapper_instructions.html
+++ b/src/nyc_trees/apps/home/templates/home/individual_mapper_instructions.html
@@ -1,9 +1,5 @@
 {% extends "base_two_frames.html" %}
 
-{% block nav %}
-{% include "core/partials/nav.html" with active_page="about" %}
-{% endblock %}
-
 {% block aside %}
 <h2>Mapper Status</h2>
 {% endblock aside %}

--- a/src/nyc_trees/apps/home/templates/home/trusted_mapper_request_sent.html
+++ b/src/nyc_trees/apps/home/templates/home/trusted_mapper_request_sent.html
@@ -1,0 +1,17 @@
+{% extends "base_two_frames.html" %}
+
+{% block aside %}
+<h2>Mapper Status</h2>
+{% endblock aside %}
+
+{% block main %}
+
+<p>
+    Your request for individual mapper status has been sent!
+</p>
+<p>
+    Once approved by a group admin, you will receive an email confirmation
+    to allow you to map block edges in this group territory.
+</p>
+
+{% endblock main %}

--- a/src/nyc_trees/apps/home/urls.py
+++ b/src/nyc_trees/apps/home/urls.py
@@ -26,6 +26,10 @@ urlpatterns = patterns(
         r.individual_mapper_instructions,
         name='individual_mapper_instructions'),
 
+    url(r'^trusted-mapper-request-sent/$',
+        r.trusted_mapper_request_sent,
+        name='trusted_mapper_request_sent'),
+
     url(r'^jobs/(?P<job_id>\d+)/$', r.retrieve_job_status,
         name='retrieve_job_status'),
 

--- a/src/nyc_trees/apps/home/views.py
+++ b/src/nyc_trees/apps/home/views.py
@@ -105,5 +105,9 @@ def individual_mapper_instructions(request):
     pass
 
 
+def trusted_mapper_request_sent(request):
+    pass
+
+
 def about_faq_page(request):
     pass

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -43,7 +43,8 @@ printable_reservations_map = route(
         v.printable_reservations_page))
 
 reserve_blockface_page = route(
-    GET=individual_mapper_do(
+    GET=do(
+        login_required,
         render_template('survey/reserve_blockface.html'),
         v.reserve_blockfaces_page))
 

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -18,11 +18,11 @@ from django.db import transaction, connection
 from django.db.models import Prefetch
 from django.http import (HttpResponse, HttpResponseForbidden,
                          HttpResponseBadRequest)
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.utils.timezone import now
 
 from apps.core.models import Group
-from apps.core.helpers import user_is_group_admin
+from apps.core.helpers import user_is_group_admin, user_is_individual_mapper
 
 from apps.event.models import Event
 from apps.event.helpers import user_is_checked_in_to_event
@@ -296,6 +296,9 @@ def _user_reservations(user):
 
 
 def reserve_blockfaces_page(request):
+    if not user_is_individual_mapper(request.user):
+        return redirect('reservations_instructions')
+
     current_reservations_amount = BlockfaceReservation.objects \
         .filter(user=request.user) \
         .current() \

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -93,51 +93,22 @@
           {% include "groups/partials/detail_event_list.html" %}
         </div>
     </section>
-    {% if show_mapper_request %}
+    {% if group.allows_individual_mappers %}
     <section>
-        <h4 class="section-heading">Individual Mapping</h4>
-        <p>Volun<b>treers</b> are able to map trees on their own, outside of scheduled events! Click the button below to request individual mapping status within this group&rsquo;s Census Zone. Remember to contact your local loaning hub to check out individual tools and start mapping on your own.</p>
-        <button class="btn btn-primary btn-mobile--max"
-                data-action="request-access"
-                data-group-slug="{{ group.slug }}">Request Individual Mapper Status</button>
+        <form method="POST" action="{% url 'request_mapper_status' group_slug=group.slug %}">
+            {% csrf_token %}
+            <h4 class="section-heading">Individual Mapping</h4>
+            <p>
+                Volun<b>treers</b> are able to map trees on their own, outside of scheduled events!
+                Click the button below to request individual mapping status within this group&rsquo;s Census Zone.
+                Remember to contact your local loaning hub to check out individual tools and start mapping on your own.
+            </p>
+            <button class="btn btn-primary btn-mobile--max">Request Individual Mapper Status</button>
+        </form>
     </section>
     {% endif %}
 
 {% endblock main %}
-
-{% block extra_content %}
-<div class="modal fade" id="request-access-complete-modal">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">Request Sent</h4>
-            </div>
-            <div class="modal-body">
-                <p>Your request has been sent.</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<div class="modal fade" id="request-access-fail-modal">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">Error Sending Request</h4>
-            </div>
-            <div class="modal-body">
-                <p>There was a problem submitting your request. Please try again.</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>
-            </div>
-        </div>
-    </div>
-</div>
-{% endblock extra_content %}
 
 {% block page_js %}
 <script type="text/javascript" src="{{ "js/group_detail.js"|static_url }}"></script>

--- a/src/nyc_trees/apps/users/tests.py
+++ b/src/nyc_trees/apps/users/tests.py
@@ -486,8 +486,7 @@ class TrustedMapperTests(UsersTestCase):
 
         # User request mapper status
         request = make_request(user=user, method='POST')
-        response = request_mapper_status(request, group_slug=group.slug)
-        self.assertEqual(response.content, '{"success": true}')
+        request_mapper_status(request, group_slug=group.slug)
 
         # Clear the test inbox
         mail.outbox = []
@@ -525,12 +524,10 @@ class TrustedMapperTests(UsersTestCase):
         self.group.allows_individual_mappers = True
         self.group.clean_and_save()
         self.assertFalse(self._is_eligible())
-        self.assertRaises(AssertionError, self._become_trusted_mapper)
 
         self.group.admin = self.other_user
         self.group.clean_and_save()
         self.assertFalse(self._is_eligible())
-        self.assertRaises(AssertionError, self._become_trusted_mapper)
 
         TrustedMapper.objects.all().delete()
         self.assertFalse(self._is_eligible())
@@ -539,9 +536,7 @@ class TrustedMapperTests(UsersTestCase):
         self.assertTrue(self._is_eligible())
 
         self._become_trusted_mapper()
-
         self.assertFalse(self._is_eligible())
-        self.assertRaises(AssertionError, self._become_trusted_mapper)
 
 
 class AnonUserTests(UsersTestCase):

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -33,7 +33,6 @@ urlpatterns = patterns(
         r.edit_user_mapping_priveleges,
         name='edit_user_mapping_priveleges'),
 
-    # Keep in sync with src/nyc_trees/js/src/group_detail.js
     # Keep in sync with src/nyc_trees/js/src/reserveBlockfacePage.js
     url(r'^(?P<group_slug>[\w-]+)/request-trusted-mapper-status/$',
         r.request_mapper_status,

--- a/src/nyc_trees/js/src/group_detail.js
+++ b/src/nyc_trees/js/src/group_detail.js
@@ -26,20 +26,3 @@ if ($('#map').length > 0) {
 
     mapModule.addTileLayer(territoryMap);
 }
-
-$(dom.requestAccessButton).click(function() {
-    var groupSlug = $(dom.requestAccessButton).data('group-slug');
-    $(dom.modals).modal('hide');
-    $.ajax({
-            // Keep this URL in sync with "request_mapper_status"
-            // in src/nyc_trees/apps/users/urls/group.py
-            url: '/group/' + groupSlug + '/request-trusted-mapper-status/',
-            type: 'POST'
-        })
-        .done(function() {
-            $(dom.requestAccessCompleteModal).modal('show');
-        })
-        .fail(function() {
-            $(dom.requestAccessFailModal).modal('show');
-        });
-});


### PR DESCRIPTION
When non individual mappers try to access the Reservations page, they
will be redirected to the reservations instructions page.

Fixes #1198