### PR TITLE
Scroll to top during training subpage navigation

### DIFF
--- a/src/nyc_trees/js/src/trainingFlatpage.js
+++ b/src/nyc_trees/js/src/trainingFlatpage.js
@@ -22,6 +22,8 @@ function showSubpage() {
         $exercise = $subpage.children('form'),
         index = currentPage;
 
+    window.scrollTo(0, 0);
+
     $subpages.hide();
 
     // fully initialize the subpage for viewing, including cleaning up


### PR DESCRIPTION
fixes #1194 on github

tested on chrome, chrome iphone5 emulation, and firefox.