### PR TITLE
Fix glitch on Android 4.2 and earlier

### DIFF
--- a/src/nyc_trees/sass/partials/_footer.scss
+++ b/src/nyc_trees/sass/partials/_footer.scss
@@ -1,6 +1,9 @@
 footer {
   background-color: $gray-lightest;
   padding: 2rem 0;
+  transition: all 400ms $transition;
+  position: relative;
+  left: 0;
   @media (min-width: $screen-md) {
     padding: 5rem 0 4rem;
   }

--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -35,20 +35,9 @@ body {
   background-color: #fff;
   overflow-x: hidden;
   width: 100%;
-  transition: all 500ms $transition;
   position: relative;
   font-feature-settings: "kern" 1;
   text-rendering: geometricPrecision;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -moz-box;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -moz-box-orient: vertical;
-  -moz-box-direction: normal;
-  flex-direction: column;
   min-height: 100%;
   @media (min-width: $screen-sm) {
     background-color: $body-bg;

--- a/src/nyc_trees/sass/partials/_header.scss
+++ b/src/nyc_trees/sass/partials/_header.scss
@@ -109,17 +109,11 @@
   bottom: 0;
   background-color: $nav-side-color;
   width: 30rem;
-  -webkit-transform: translateX(-30rem);
-  -moz-transform: translateX(-30rem);
-  -ms-transform: translateX(-30rem);
-  transform: translateX(-30rem);
+  left: -30rem;
   z-index: 1;
   transition: all 400ms $transition;
   .menu-active & {
-    -webkit-transform: translateX(0);
-    -moz-transform: translateX(0);
-    -ms-transform: translateX(0);
-    transform: translateX(0);
+    left: 0;
     box-shadow: 0px 1rem 6rem 0px #0A0B0B;
   }
 }
@@ -127,24 +121,24 @@
 .right-content {
   padding-top: $navbar-height;
   position: relative;
-  -webkit-box-flex: 1;
-  -webkit-flex: 1;
-  -moz-box-flex: 1;
-  flex: 1 1 auto;
+  left: 0;
+  top: 0;
   transition: all 400ms $transition;
 }
 
 .menu-active .right-content, .menu-active footer, .menu-active .main-header, .menu-active .overlay-menued {
-  -webkit-transform: translateX(30rem);
-  -moz-transform: translateX(30rem);
-  -ms-transform: translateX(30rem);
-  transform: translateX(30rem);
+  left: 30rem;
+  transition: all 400ms $transition;
 }
 
 .main-header {
   position: fixed;
   left: 0;
   right: 0;
+  top: 0;
+  overflow: hidden;
+  height: $navbar-height;
+  width: 100vw;
   z-index: $zindex-main-header;
   transition: all 400ms $transition;
 }

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -4,7 +4,7 @@
     }
 
     .map-sidebar {
-        max-height: 75%;
+        max-height: 75vh;
         overflow: auto;
         overflow-x: hidden;
         box-shadow: 0 1px 2px rgba(black, .2);

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -13,7 +13,7 @@
 
 .map-survey {
     position: fixed;
-    top: 5.6rem;
+    top: $navbar-height;
     bottom: 0;
     left: 0;
     right: 0;
@@ -45,7 +45,7 @@
         }
 
         &.expanded {
-            top: 5.6rem;
+            top: $navbar-height;
             overflow: scroll;
             bottom: 0;
             display: block;
@@ -53,7 +53,7 @@
             padding: 0;
         }
     }
-    
+
     // Select2 dropdown styling
     .select2-container a.select2-choice {
       background: none;

--- a/src/nyc_trees/sass/partials/_variables.scss
+++ b/src/nyc_trees/sass/partials/_variables.scss
@@ -404,7 +404,7 @@ $container-lg:                 $container-desktop;
 //##
 
 // Basics of a navbar
-$navbar-height:                    5.6rem;
+$navbar-height:                    5.5rem;
 $navbar-margin-bottom:             0;
 $navbar-border-radius:             $border-radius-base;
 $navbar-padding-horizontal:        floor(($grid-gutter-width / 2));


### PR DESCRIPTION
This fixes a glitch with the default browser on Android 4.2 and earlier that caused elements with ```position: fixed``` and ```transform: translate``` to not register the transform.

Here is a stackoverflow discussion about the glitch. http://stackoverflow.com/questions/18572488/transform-doesnt-work-on-position-fixed-divs-on-android

Using ```transform: translate``` to reposition elements—in our case, the side navigation and header when the navigation opens—is generally more performant than alternatives like ```left``` or ```margin-left```. However, in this case, I've switched to ```left```, which works on Android 4.2 and earlier.

I've tested the basic page and map page layouts on latest Chrome, latest Firefox, IE9, Android 4.0, iOS7, and iOS8. All check out. More testing to come.