### PR TITLE
Load admin page OpenLayers from https CDN

### DIFF
--- a/src/nyc_trees/apps/core/admin.py
+++ b/src/nyc_trees/apps/core/admin.py
@@ -29,6 +29,7 @@ if not settings.DEBUG:
 @admin.register(Group)
 class GroupAdmin(OSMGeoAdmin):
     prepopulated_fields = {"slug": ("name",)}
+    openlayers_url = settings.ADMIN_OPENLAYERS_URL
 
 
 class NycUserChangeForm(UserChangeForm):

--- a/src/nyc_trees/apps/event/admin.py
+++ b/src/nyc_trees/apps/event/admin.py
@@ -3,10 +3,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.gis.admin import OSMGeoAdmin
 import apps.event.models as m
 
 
-admin.site.register(m.Event, OSMGeoAdmin)
+@admin.register(m.Event)
+class EventAdmin(OSMGeoAdmin):
+    openlayers_url = settings.ADMIN_OPENLAYERS_URL
+
 admin.site.register(m.EventRegistration)

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -360,3 +360,6 @@ SOFT_LAUNCH_REGEXES = [
 ]
 
 RESERVATION_REMINDER_WINDOW = 3
+
+ADMIN_OPENLAYERS_URL = 'https://cdnjs.cloudflare.com/ajax/libs/openlayers/'\
+                       '2.13.1/OpenLayers.js'


### PR DESCRIPTION
The Django admin has a built in slippy map for editing geometries, built
on top of OpenLayers. By default, the admin template loads OpenLayers
from http://openlayers.org/api/2.13/OpenLayers.js, which fails with an
"insecure" error when the site is running under https.

This commit overrides that insecure URL with a secure one from cdnjs.

Connects to #952 