### PR TITLE
Make actionbar invisible when empty

### DIFF
--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -2,7 +2,7 @@
   padding-bottom: 0 !important;
   .tab-status-map-tab &, .page-new-reservation & {
     position: static;
-    height: 7rem;
+    height: 7.1rem;
     @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
       height: 4rem;
       font-size: 12px;
@@ -59,7 +59,9 @@
   }
   & > .event {
     padding: 0;
-
+  }
+  &:empty {
+    visibility: hidden;
   }
   @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
     height: 7rem;


### PR DESCRIPTION
Address but does not fix the issue #721.

Removes the border on the action-bar when it's empty. Slightly better on desktop, but doesn't impact mobile.

Before:

![image](https://cloud.githubusercontent.com/assets/1809908/7207464/a0b2f1f6-e507-11e4-94fd-2d9aa9a5e0e6.png)

After:

![image](https://cloud.githubusercontent.com/assets/1809908/7207431/6b5a7074-e507-11e4-85e5-5e354632e5b8.png)