### PR TITLE
Cleanup progress modes

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -310,7 +310,7 @@ def printable_event_map(request, event_slug):
     event = get_object_or_404(Event, group=request.group, slug=event_slug)
     context = {
         'event': event,
-        'layer': get_context_for_territory_layer(request, request.group.id),
+        'layer': get_context_for_territory_layer(request.group.id),
     }
     return context
 

--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -17,14 +17,13 @@ from apps.users.models import TrustedMapper
 
 
 def get_context_for_progress_layer():
-    models = [Blockface, Survey, Territory, BlockfaceReservation]
+    models = [Blockface, Survey, Territory]
     return _get_context_for_layer("progress", models)
 
 
 @login_required
 def get_context_for_user_progress_layer(request):
-    models = [Blockface, Survey, Territory, BlockfaceReservation,
-              TrustedMapper]
+    models = [Blockface, Survey, Territory]
     return _get_context_for_layer("user_progress", models,
                                   {'user': request.user.pk})
 

--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -28,6 +28,11 @@ def get_context_for_user_progress_layer(request):
                                   {'user': request.user.pk})
 
 
+def get_context_for_group_progress_layer():
+    models = [Blockface, Survey, Territory]
+    return _get_context_for_layer("group_progress", models)
+
+
 @login_required
 def get_context_for_reservable_layer(request):
     models = [Group, Blockface, Territory, BlockfaceReservation, TrustedMapper]

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -41,7 +41,7 @@ from apps.survey.layer_context import (
     get_context_for_reservations_layer, get_context_for_reservable_layer,
     get_context_for_progress_layer, get_context_for_territory_survey_layer,
     get_context_for_printable_reservations_layer,
-    get_context_for_territory_layer
+    get_context_for_territory_layer, get_context_for_user_progress_layer
 )
 from apps.survey.helpers import (teammates_for_event, group_percent_completed,
                                  teammates_for_individual_mapping)
@@ -66,13 +66,14 @@ def progress_page(request):
              'label': 'Not mapped by you'},
         ],
         'legend_mode': 'all',
-        'layer_all': get_context_for_progress_layer(request, 'progress_all'),
-        'layer_my': get_context_for_progress_layer(request, 'progress_my'),
+        'layer_all': get_context_for_progress_layer(),
         'help_shown': _was_help_shown(request, 'progress_page_help_shown')
     }
 
     user = request.user
     if user.is_authenticated():
+        context['layer_my'] = get_context_for_user_progress_layer(request)
+
         blocks = (user.survey_set
                   .distinct('blockface')
                   .values_list('blockface_id', flat=True))
@@ -175,7 +176,7 @@ def group_borders_geojson(request):
                      queryset=Territory.objects.select_related('blockface')))
 
     def get_tile_url(id):
-        return get_context_for_territory_layer(request, id)['tile_url']
+        return get_context_for_territory_layer(id)['tile_url']
 
     return [
         {
@@ -412,7 +413,7 @@ def start_survey_from_event(request, event_slug):
         return HttpResponseForbidden('Event not currently in-progress')
 
     return {
-        'layer': get_context_for_territory_survey_layer(request, group.id),
+        'layer': get_context_for_territory_survey_layer(group.id),
         'location': [event.location.y, event.location.x],
         'choices': _get_survey_choices(),
         'teammates': teammates_for_event(group, event, request.user)

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -122,7 +122,7 @@ def group_detail(request):
             'follows': follow_count
         },
         'group_events_id': GROUP_EVENTS_ID,
-        'layer': get_context_for_territory_layer(request, request.group.id),
+        'layer': get_context_for_territory_layer(request.group.id),
         'territory_bounds': _group_territory_bounds(request.group),
         'render_follow_button_without_count': request.POST.get(
             'render_follow_button_without_count', False)
@@ -314,7 +314,7 @@ def _update_event_maps(request, group):
 def _make_blockface_and_tiler_urls_result(request, blockfaces, group_id):
     result = {
         'blockDataList': _make_blockface_data_result(blockfaces),
-        'tilerUrls': get_context_for_territory_admin_layer(request, group_id)
+        'tilerUrls': get_context_for_territory_admin_layer(group_id)
     }
     return result
 

--- a/src/nyc_trees/js/src/lib/BlockfaceLayer.js
+++ b/src/nyc_trees/js/src/lib/BlockfaceLayer.js
@@ -45,16 +45,15 @@ function getStyle(map, color) {
 
 // Note: this must be kept in sync with src/tiler/style/*.mss
 // Line widths are purposefully 2 pixels wider than the tiler styling
+// The "Mapped" lines on the progress map never get smaller than 6 pixels,
+// so we never make our selected line smaller than 8 pixels
+// (even for unmapped / non progress page lines)
 function getLineWidth(zoom) {
     if (zoom >= 19) {
         return 18;
     } else if (zoom === 18) {
         return 10;
-    } else if (zoom === 17) {
-        return 6;
-    } else if (zoom === 16) {
-        return 4;
-    } else {
-        return 3;
+    } else if (zoom <= 17) {
+        return 8;
     }
 }

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -87,10 +87,10 @@ function loadLayers($mode) {
                 // Note: this must be kept in sync with
                 // src/nyc_trees/apps/survey/urls/blockface.py
                 var url =
-                        '/blockedge/' + gridData.id +
-                        '/progress-page-blockedge-popup/?survey_type=' + gridData.survey_type;
+                        '/blockedge/' + gridData.id + '/progress-page-blockedge-popup/';
+
                 if (gridData.group_id) {
-                    url += '&group_id=' + gridData.group_id;
+                    url += '?group_id=' + gridData.group_id;
                 }
                 $actionBar.load(url);
                 return true;

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -77,26 +77,9 @@ function loadLayers($mode) {
     }
     if (tileUrl) {
         tileLayer = mapModule.addTileLayer(progressMap, tileUrl);
-
         grid = mapModule.addGridLayer(progressMap, gridUrl);
 
-        selectedLayer = new SelectableBlockfaceLayer(progressMap, grid, {
-            onAdd: function(gridData) {
-                selectedLayer.clearLayers();
-
-                // Note: this must be kept in sync with
-                // src/nyc_trees/apps/survey/urls/blockface.py
-                var url =
-                        '/blockedge/' + gridData.id + '/progress-page-blockedge-popup/';
-
-                if (gridData.group_id) {
-                    url += '?group_id=' + gridData.group_id;
-                }
-                $actionBar.load(url);
-                return true;
-            }
-        });
-        progressMap.addLayer(selectedLayer);
+        createSelectableLayer();
 
         if (bounds) {
             mapModule.fitBounds(progressMap, bounds);
@@ -114,7 +97,13 @@ function loadLayers($mode) {
                 onEachFeature: function(feature, layer) {
                     layer.on('click', function showGroupBlockfaces() {
                         progressMap.removeLayer(tileLayer);
+                        progressMap.removeLayer(grid);
+
                         tileLayer = mapModule.addTileLayer(progressMap, feature.properties.tileUrl);
+                        grid = mapModule.addGridLayer(progressMap, feature.properties.gridUrl);
+
+                        createSelectableLayer();
+
                         mapModule.fitBounds(progressMap, feature.properties.bounds);
                         $actionBar.load(feature.properties.popupUrl);
                     });
@@ -123,4 +112,23 @@ function loadLayers($mode) {
             geojsonLayer.addTo(progressMap);
         });
     }
+}
+
+function createSelectableLayer() {
+    selectedLayer = new SelectableBlockfaceLayer(progressMap, grid, {
+        onAdd: function(gridData) {
+            selectedLayer.clearLayers();
+
+            // Note: this must be kept in sync with
+            // src/nyc_trees/apps/survey/urls/blockface.py
+            var url = '/blockedge/' + gridData.id + '/progress-page-blockedge-popup/';
+
+            if (gridData.group_id) {
+                url += '?group_id=' + gridData.group_id;
+            }
+            $actionBar.load(url);
+            return true;
+        }
+    });
+    progressMap.addLayer(selectedLayer);
 }

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -27,8 +27,8 @@ var Windshaft = require('windshaft'),
     interactivity = {
         group_territory_survey: 'id,survey_type,restriction',
         group_territory_admin: 'id,survey_type,turf_group_id',
-        progress: 'id,group_id,survey_type',
-        user_progress: 'id,group_id,survey_type',
+        progress: 'id,group_id',
+        user_progress: 'id,group_id',
         user_reservable: 'id,group_id,group_slug,survey_type,restriction',
         user_reservations: 'id'
     },
@@ -113,7 +113,7 @@ function req2interactivity(req) {
 function req2style(req) {
     var type =  req.params.type;
     if (type === 'progress' || type === 'user_progress') {
-        return styles.progress({type: type});
+        return styles.progress();
     } else {
         return styles.default();
     }

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -29,6 +29,7 @@ var Windshaft = require('windshaft'),
         group_territory_admin: 'id,survey_type,turf_group_id',
         progress: 'id,group_id',
         user_progress: 'id,group_id',
+        group_progress: 'id,group_id',
         user_reservable: 'id,group_id,group_slug,survey_type,restriction',
         user_reservations: 'id'
     },
@@ -112,7 +113,7 @@ function req2interactivity(req) {
 
 function req2style(req) {
     var type =  req.params.type;
-    if (type === 'progress' || type === 'user_progress') {
+    if (type === 'progress' || type === 'user_progress' || type === 'group_progress') {
         return styles.progress();
     } else {
         return styles.default();

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -25,12 +25,12 @@ var Windshaft = require('windshaft'),
     styles = files('./style'),
 
     interactivity = {
-        territory_survey: 'id,survey_type,restriction',
-        territory_admin: 'id,survey_type,turf_group_id',
-        progress_all: 'id,group_id,survey_type',
-        progress_my: 'id,group_id,survey_type',
-        reservable: 'id,group_id,group_slug,survey_type,restriction',
-        reservations: 'id'
+        group_territory_survey: 'id,survey_type,restriction',
+        group_territory_admin: 'id,survey_type,turf_group_id',
+        progress: 'id,group_id,survey_type',
+        user_progress: 'id,group_id,survey_type',
+        user_reservable: 'id,group_id,group_slug,survey_type,restriction',
+        user_reservations: 'id'
     },
 
     config = {
@@ -112,7 +112,7 @@ function req2interactivity(req) {
 
 function req2style(req) {
     var type =  req.params.type;
-    if (type === 'progress_all' || type === 'progress_my') {
+    if (type === 'progress' || type === 'user_progress') {
         return styles.progress({type: type});
     } else {
         return styles.default();
@@ -120,46 +120,14 @@ function req2style(req) {
 }
 
 function req2sql(req) {
-    /*
-     This function expects the SQL files loaded into the
-     'queries' object to have a specific naming convention. If
-     a user= or group= query string argument is provided, this function
-     prepends 'user_' or 'group_' to the 'type' parameter to generate the
-     SQL file name. Example:
-
-     URL:  /123456/nyc_trees/foo/1/2/3.png
-     File: foo.sql
-
-     URL:  /123456/nyc_trees/foo/1/2/3.png?user=1
-     File: user_foo.sql
-
-     URL:  /123456/nyc_trees/bar/1/2/3.png?group=2
-     File: group_bar.sql
-     */
-    var q = req.query,
-        t =  req.params.type,
-        type = (t === 'progress_all' || t === 'progress_my' ? 'progress' : t),
-        queryPrefix = q.group ? 'group_' : q.user ? 'user_' : '',
-        queryName = queryPrefix + type,
+    var type =  req.params.type,
         context = req2context(req),
         additionalErr = '';
-    if (queries[queryName]) {
-        return queries[queryName](context);
+    if (queries[type]) {
+        return queries[type](context);
     } else {
-        additionalErr = additionalErr || getAdditionalErr('group', queryName);
-        additionalErr = additionalErr || getAdditionalErr('user', queryName);
-        throw 'No query defined for ' + queryName + '. ' + additionalErr;
+        throw 'No query defined for ' + type + '.';
     }
-}
-
-function getAdditionalErr(prefix, queryName) {
-    var bar = prefix + '_' + queryName,
-        additionalErr = '';
-    if (queries[bar]) {
-        additionalErr = 'There is a tiler query defined for ' + bar +
-            '. Did you forget the ' + prefix + '= query string argument?';
-    }
-    return additionalErr;
 }
 
 Windshaft.Server(config).listen(port);

--- a/src/tiler/sql/group_progress.sql
+++ b/src/tiler/sql/group_progress.sql
@@ -1,0 +1,17 @@
+-- The 'DISTINCT ON' and 'ORDER BY' clause are needed so that we only use
+-- the latest survey for a blockface
+(SELECT
+  DISTINCT ON (block.id)
+  block.geom, block.id, turf.group_id,
+  CASE
+    WHEN survey.user_id IS NOT NULL THEN 'T'
+    ELSE 'F'
+  END AS is_mapped
+  FROM survey_blockface AS block
+  LEFT OUTER JOIN survey_territory AS turf
+    ON block.id = turf.blockface_id
+  LEFT OUTER JOIN survey_survey AS survey
+    ON block.id = survey.blockface_id
+  WHERE turf.group_id = <%= group_id %>
+  ORDER BY block.id, survey.created_at DESC NULLS LAST
+) AS query

--- a/src/tiler/sql/progress.sql
+++ b/src/tiler/sql/progress.sql
@@ -4,18 +4,13 @@
   DISTINCT ON (block.id)
   block.geom, block.id, turf.group_id,
   CASE
-    WHEN survey.id IS NOT NULL THEN 'surveyed-by-others'
-    WHEN (turf.id IS NULL AND block.is_available AND reservation.id IS NULL) THEN 'available'
-    ELSE 'unavailable'
-  END AS survey_type
+    WHEN survey.id IS NOT NULL THEN 'T'
+    ELSE 'F'
+  END AS is_mapped
   FROM survey_blockface AS block
-  LEFT OUTER JOIN survey_territory AS turf
-    ON block.id = turf.blockface_id
   LEFT OUTER JOIN survey_survey AS survey
     ON block.id = survey.blockface_id
-  LEFT OUTER JOIN survey_blockfacereservation AS reservation
-    ON (block.id = reservation.blockface_id
-        AND reservation.canceled_at IS NULL
-        AND reservation.expires_at > now() at time zone 'utc')
+  LEFT OUTER JOIN survey_territory AS turf
+    ON block.id = turf.blockface_id
   ORDER BY block.id, survey.created_at DESC NULLS LAST
 ) AS query

--- a/src/tiler/sql/user_progress.sql
+++ b/src/tiler/sql/user_progress.sql
@@ -4,26 +4,13 @@
   DISTINCT ON (block.id)
   block.geom, block.id, turf.group_id,
   CASE
-    WHEN (survey.user_id IS NOT DISTINCT FROM <%= user_id %>
-          OR survey.teammate_id IS NOT DISTINCT FROM <%= user_id %>) THEN 'surveyed-by-me'
-    WHEN survey.id IS NOT NULL THEN 'surveyed-by-others'
-    WHEN reservation.user_id IS NOT DISTINCT FROM <%= user_id %> THEN 'reserved'
-    WHEN (block.is_available AND reservation.id IS NULL
-          AND (turf.id IS NULL OR trustedmapper.id IS NOT NULL)) THEN 'available'
-    ELSE 'unavailable'
-  END AS survey_type
+    WHEN survey.user_id IS NOT DISTINCT FROM <%= user_id %> THEN 'T'
+    ELSE 'F'
+  END AS is_mapped
   FROM survey_blockface AS block
   LEFT OUTER JOIN survey_territory AS turf
     ON block.id = turf.blockface_id
   LEFT OUTER JOIN survey_survey AS survey
     ON block.id = survey.blockface_id
-  LEFT OUTER JOIN survey_blockfacereservation AS reservation
-    ON (block.id = reservation.blockface_id
-        AND reservation.canceled_at IS NULL
-        AND reservation.expires_at > now() at time zone 'utc')
-  LEFT OUTER JOIN users_trustedmapper AS trustedmapper
-    ON (turf.group_id = trustedmapper.group_id
-        AND trustedmapper.user_id = <%= user_id %>
-        AND trustedmapper.is_approved)
   ORDER BY block.id, survey.created_at DESC NULLS LAST
 ) AS query

--- a/src/tiler/style/progress.mss
+++ b/src/tiler/style/progress.mss
@@ -16,28 +16,11 @@
   [zoom = 18]{ line-width: 8; }
   [zoom = 19]{ line-width: 16; }
 
-  [survey_type = 'surveyed-by-me'] {
+  [is_mapped = 'T'] {
     line-color: @mapped;
-    [zoom <= 16]{ line-width: 6; }
+    [zoom <= 17]{ line-width: 6; }
   }
-  [survey_type = 'surveyed-by-others'] {
-    line-color: <% if (type === 'progress_all') { %> @mapped <% } else { %> @not-mapped <% } %>;
-    [zoom <= 16]{ line-width: 6; }
-  }
-
-  [survey_type = 'available'] {
-    line-color: @not-mapped;
-    [zoom <= 15]{
-      line-color: @not-mapped-zoomed-out;
-    }
-  }
-  [survey_type = 'reserved'] {
-    line-color: @not-mapped;
-    [zoom <= 15]{
-      line-color: @not-mapped-zoomed-out;
-    }
-  }
-  [survey_type = 'unavailable'] {
+  [is_mapped = 'F'] {
     line-color: @not-mapped;
     [zoom <= 15]{
       line-color: @not-mapped-zoomed-out;


### PR DESCRIPTION
 - Simplifies layers by moving computing of `survey_type` to the app server.
 - Enables caching of the main progress layer by removing the `user` query parameter
 - Simplifies styling of the various progress layers by generating a `is_mapped` column in the SQL query
 - Changes group progress layer to show mapped vs. unmapped blockfaces
 - Adds support for clicking blockfaces to see information to the group mode

Fixes #1212 
Fixes #1220