### PR TITLE
Upgrade Windshaft to version 0.36.0

### DIFF
--- a/deployment/ansible/roles/nyc-trees.tiler/tasks/dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/tasks/dependencies.yml
@@ -1,5 +1,15 @@
 ---
+- name: Install canvas rendering dependencies
+  apt: pkg={{ item }} state=present
+  with_items:
+    - "libcairo2-dev=1.13.*"
+    - "libpango1.0-dev=1.36.*"
+    - "libjpeg8-dev=8c*"
+    - "libgif-dev=4.1.*"
+
 - name: Install tiler javascript dependencies
   command: npm install --unsafe-perm
   args:
     chdir: "{{ tiler_home }}"
+  environment:
+    PKG_CONFIG_PATH: "/usr/lib/pkgconfig/pycairo.pc"

--- a/src/tiler/npm-shrinkwrap.json
+++ b/src/tiler/npm-shrinkwrap.json
@@ -4,323 +4,375 @@
   "dependencies": {
     "lodash": {
       "version": "2.4.1",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+      "from": "lodash@>=2.4.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
     },
     "windshaft": {
-      "version": "0.19.4",
-      "from": "https://registry.npmjs.org/windshaft/-/windshaft-0.19.4.tgz",
-      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-0.19.4.tgz",
+      "version": "0.36.0",
+      "from": "windshaft@>=0.36.0 <0.37.0",
+      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-0.36.0.tgz",
       "dependencies": {
+        "chronograph": {
+          "version": "0.1.0",
+          "from": "../../tmp/npm-4434-a51dd40a/1429345702615-0.2620117061305791/0b8c35eee510cfa14a16be24d70533b38ecc1d2d",
+          "resolved": "git://github.com/CartoDB/chronographjs.git#0b8c35eee510cfa14a16be24d70533b38ecc1d2d"
+        },
         "underscore": {
-          "version": "1.3.3",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz"
+          "version": "1.6.0",
+          "from": "underscore@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         },
         "step": {
           "version": "0.0.5",
-          "from": "https://registry.npmjs.org/step/-/step-0.0.5.tgz",
+          "from": "step@>=0.0.5 <0.1.0",
           "resolved": "https://registry.npmjs.org/step/-/step-0.0.5.tgz"
         },
+        "queue-async": {
+          "version": "1.0.7",
+          "from": "queue-async@>=1.0.7 <1.1.0",
+          "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz"
+        },
         "grainstore": {
-          "version": "0.18.1",
-          "from": "https://registry.npmjs.org/grainstore/-/grainstore-0.18.1.tgz",
-          "resolved": "https://registry.npmjs.org/grainstore/-/grainstore-0.18.1.tgz",
+          "version": "0.23.0",
+          "from": "grainstore@>=0.23.0 <0.24.0",
+          "resolved": "https://registry.npmjs.org/grainstore/-/grainstore-0.23.0.tgz",
           "dependencies": {
-            "redis-mpool": {
-              "version": "0.0.4",
-              "from": "http://github.com/CartoDB/node-redis-mpool/tarball/0.0.4",
-              "resolved": "http://github.com/CartoDB/node-redis-mpool/tarball/0.0.4",
+            "carto": {
+              "version": "0.9.5-cdb2",
+              "from": "https://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
+              "resolved": "https://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
               "dependencies": {
-                "redis": {
-                  "version": "0.8.6",
-                  "from": "https://registry.npmjs.org/redis/-/redis-0.8.6.tgz",
-                  "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.6.tgz"
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@>=1.4.3 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
-                "hiredis": {
-                  "version": "0.1.17",
-                  "from": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
-                  "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
+                "mapnik-reference": {
+                  "version": "5.0.9",
+                  "from": "mapnik-reference@>=5.0.7 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz"
+                },
+                "xml2js": {
+                  "version": "0.2.8",
+                  "from": "xml2js@>=0.2.4 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
                   "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                    "sax": {
+                      "version": "0.5.8",
+                      "from": "sax@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     },
-                    "nan": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 }
               }
             },
-            "mapnik-reference": {
-              "version": "5.0.9",
-              "from": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz"
-            },
             "millstone": {
-              "version": "0.6.15",
-              "from": "https://registry.npmjs.org/millstone/-/millstone-0.6.15.tgz",
-              "resolved": "https://registry.npmjs.org/millstone/-/millstone-0.6.15.tgz",
+              "version": "0.6.14",
+              "from": "millstone@0.6.14",
+              "resolved": "https://registry.npmjs.org/millstone/-/millstone-0.6.14.tgz",
               "dependencies": {
-                "underscore": {
-                  "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-                },
                 "generic-pool": {
-                  "version": "2.1.1",
-                  "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
+                  "version": "2.0.4",
+                  "from": "generic-pool@>=2.0.3 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz"
                 },
                 "request": {
-                  "version": "2.51.0",
-                  "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                  "version": "2.34.0",
+                  "from": "request@>=2.34.0 <2.35.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
                   "dependencies": {
-                    "bl": {
-                      "version": "0.9.3",
-                      "from": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.8.0",
-                      "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-                    },
-                    "forever-agent": {
-                      "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                    },
-                    "form-data": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                      "dependencies": {
-                        "async": {
-                          "version": "0.9.0",
-                          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                        },
-                        "mime-types": {
-                          "version": "2.0.7",
-                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.5.0",
-                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                     },
                     "json-stringify-safe": {
                       "version": "5.0.0",
-                      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                     },
-                    "mime-types": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "node-uuid": {
-                      "version": "1.4.2",
-                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                    },
-                    "qs": {
-                      "version": "2.3.3",
-                      "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                      "version": "1.4.3",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
                     "tough-cookie": {
                       "version": "0.12.1",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "from": "tough-cookie@>=0.12.0",
                       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                       "dependencies": {
                         "punycode": {
                           "version": "1.3.2",
-                          "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                          "from": "punycode@>=0.2.0",
                           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                         }
                       }
                     },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.7",
+                          "from": "combined-stream@>=0.0.4 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.3.0",
+                      "from": "tunnel-agent@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                    },
                     "http-signature": {
-                      "version": "0.10.0",
-                      "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "version": "0.10.1",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
-                          "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                          "version": "0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "asn1": {
                           "version": "0.1.11",
-                          "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                          "from": "asn1@0.1.11",
                           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                         },
                         "ctype": {
-                          "version": "0.5.2",
-                          "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                         }
                       }
                     },
                     "oauth-sign": {
-                      "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                      "version": "0.3.0",
+                      "from": "oauth-sign@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                     },
                     "hawk": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "version": "1.0.0",
+                      "from": "hawk@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                          "from": "hoek@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                          "from": "boom@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                          "from": "sntp@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign2": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                    },
-                    "stringstream": {
-                      "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                        }
-                      }
                     }
                   }
                 },
                 "srs": {
-                  "version": "0.4.6",
-                  "from": "https://registry.npmjs.org/srs/-/srs-0.4.6.tgz",
-                  "resolved": "https://registry.npmjs.org/srs/-/srs-0.4.6.tgz",
+                  "version": "0.4.7",
+                  "from": "srs@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/srs/-/srs-0.4.7.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "1.4.1",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
+                      "version": "1.7.0",
+                      "from": "nan@>=1.7.0 <1.8.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.1",
-                      "from": "node-pre-gyp@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.1.tgz",
+                      "version": "0.6.4",
+                      "from": "node-pre-gyp@~0.6.4",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.4.tgz",
                       "dependencies": {
                         "nopt": {
                           "version": "3.0.1",
-                          "from": "nopt@~3.0.1",
+                          "from": "nopt@>=3.0.1 <3.1.0",
                           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
                           "dependencies": {
                             "abbrev": {
                               "version": "1.0.5",
-                              "from": "abbrev@1",
+                              "from": "abbrev@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                             }
                           }
                         },
                         "npmlog": {
-                          "version": "0.1.1",
-                          "from": "npmlog@~0.1.1",
-                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+                          "version": "1.1.0",
+                          "from": "npmlog@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.1.0.tgz",
                           "dependencies": {
                             "ansi": {
                               "version": "0.3.0",
-                              "from": "ansi@~0.3.0",
+                              "from": "ansi@>=0.3.0 <0.4.0",
                               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            },
+                            "are-we-there-yet": {
+                              "version": "1.0.2",
+                              "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.2.tgz",
+                              "dependencies": {
+                                "delegates": {
+                                  "version": "0.1.0",
+                                  "from": "delegates@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                                }
+                              }
+                            },
+                            "gauge": {
+                              "version": "1.1.0",
+                              "from": "gauge@>=1.1.0 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.1.0.tgz",
+                              "dependencies": {
+                                "has-unicode": {
+                                  "version": "1.0.0",
+                                  "from": "has-unicode@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                                },
+                                "lodash.pad": {
+                                  "version": "3.0.0",
+                                  "from": "lodash.pad@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.0.0.tgz",
+                                  "dependencies": {
+                                    "lodash._basetostring": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                                    },
+                                    "lodash._createpad": {
+                                      "version": "3.0.1",
+                                      "from": "lodash._createpad@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash.padleft": {
+                                  "version": "3.0.0",
+                                  "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.0.0.tgz",
+                                  "dependencies": {
+                                    "lodash._basetostring": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                                    },
+                                    "lodash._createpad": {
+                                      "version": "3.0.1",
+                                      "from": "lodash._createpad@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash.padright": {
+                                  "version": "3.0.0",
+                                  "from": "lodash.padright@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.0.0.tgz",
+                                  "dependencies": {
+                                    "lodash._basetostring": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                                    },
+                                    "lodash._createpad": {
+                                      "version": "3.0.1",
+                                      "from": "lodash._createpad@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
                         },
                         "request": {
-                          "version": "2.48.0",
-                          "from": "request@2.x",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.48.0.tgz",
+                          "version": "2.53.0",
+                          "from": "request@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
                           "dependencies": {
                             "bl": {
-                              "version": "0.9.3",
-                              "from": "bl@~0.9.0",
-                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+                              "version": "0.9.4",
+                              "from": "bl@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                               "dependencies": {
                                 "readable-stream": {
                                   "version": "1.0.33",
-                                  "from": "readable-stream@~1.0.26",
+                                  "from": "readable-stream@>=1.0.26 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@~1.0.0",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "isarray": {
@@ -330,12 +382,12 @@
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     }
                                   }
@@ -343,55 +395,57 @@
                               }
                             },
                             "caseless": {
-                              "version": "0.7.0",
-                              "from": "caseless@~0.7.0",
-                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.7.0.tgz"
+                              "version": "0.9.0",
+                              "from": "caseless@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                             },
                             "forever-agent": {
                               "version": "0.5.2",
-                              "from": "forever-agent@~0.5.0",
+                              "from": "forever-agent@>=0.5.0 <0.6.0",
                               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                             },
                             "form-data": {
-                              "version": "0.1.4",
-                              "from": "form-data@~0.1.0",
-                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                              "version": "0.2.0",
+                              "from": "form-data@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                               "dependencies": {
-                                "mime": {
-                                  "version": "1.2.11",
-                                  "from": "mime@~1.2.11",
-                                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                                },
                                 "async": {
                                   "version": "0.9.0",
-                                  "from": "async@~0.9.0",
+                                  "from": "async@>=0.9.0 <0.10.0",
                                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                                 }
                               }
                             },
                             "json-stringify-safe": {
                               "version": "5.0.0",
-                              "from": "json-stringify-safe@~5.0.0",
+                              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                             },
                             "mime-types": {
-                              "version": "1.0.2",
-                              "from": "mime-types@~1.0.1",
-                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                              "version": "2.0.9",
+                              "from": "mime-types@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                              "dependencies": {
+                                "mime-db": {
+                                  "version": "1.7.0",
+                                  "from": "mime-db@>=1.7.0 <1.8.0",
+                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                                }
+                              }
                             },
                             "node-uuid": {
-                              "version": "1.4.1",
-                              "from": "node-uuid@~1.4.0",
-                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                              "version": "1.4.2",
+                              "from": "node-uuid@>=1.4.0 <1.5.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                             },
                             "qs": {
                               "version": "2.3.3",
-                              "from": "qs@~2.3.1",
+                              "from": "qs@>=2.3.1 <2.4.0",
                               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                             },
                             "tunnel-agent": {
                               "version": "0.4.0",
-                              "from": "tunnel-agent@~0.4.0",
+                              "from": "tunnel-agent@>=0.4.0 <0.5.0",
                               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                             },
                             "tough-cookie": {
@@ -407,14 +461,14 @@
                               }
                             },
                             "http-signature": {
-                              "version": "0.10.0",
-                              "from": "http-signature@~0.10.0",
-                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                              "version": "0.10.1",
+                              "from": "http-signature@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                               "dependencies": {
                                 "assert-plus": {
-                                  "version": "0.1.2",
-                                  "from": "assert-plus@0.1.2",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                                  "version": "0.1.5",
+                                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                                 },
                                 "asn1": {
                                   "version": "0.1.11",
@@ -422,57 +476,57 @@
                                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                                 },
                                 "ctype": {
-                                  "version": "0.5.2",
-                                  "from": "ctype@0.5.2",
-                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                                  "version": "0.5.3",
+                                  "from": "ctype@0.5.3",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                                 }
                               }
                             },
                             "oauth-sign": {
-                              "version": "0.5.0",
-                              "from": "oauth-sign@~0.5.0",
-                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                              "version": "0.6.0",
+                              "from": "oauth-sign@>=0.6.0 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                             },
                             "hawk": {
-                              "version": "1.1.1",
-                              "from": "hawk@1.1.1",
-                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                              "version": "2.3.1",
+                              "from": "hawk@>=2.3.0 <2.4.0",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                               "dependencies": {
                                 "hoek": {
-                                  "version": "0.9.1",
-                                  "from": "hoek@0.9.x",
-                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                  "version": "2.11.0",
+                                  "from": "hoek@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                                 },
                                 "boom": {
-                                  "version": "0.4.2",
-                                  "from": "boom@0.4.x",
-                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                  "version": "2.6.1",
+                                  "from": "boom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
                                 },
                                 "cryptiles": {
-                                  "version": "0.2.2",
-                                  "from": "cryptiles@0.2.x",
-                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                  "version": "2.0.4",
+                                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                                 },
                                 "sntp": {
-                                  "version": "0.2.4",
-                                  "from": "sntp@0.2.x",
-                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                  "version": "1.0.9",
+                                  "from": "sntp@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                                 }
                               }
                             },
                             "aws-sign2": {
                               "version": "0.5.0",
-                              "from": "aws-sign2@~0.5.0",
+                              "from": "aws-sign2@>=0.5.0 <0.6.0",
                               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                             },
                             "stringstream": {
                               "version": "0.0.4",
-                              "from": "stringstream@~0.0.4",
+                              "from": "stringstream@>=0.0.4 <0.1.0",
                               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                             },
                             "combined-stream": {
                               "version": "0.0.7",
-                              "from": "combined-stream@~0.0.5",
+                              "from": "combined-stream@>=0.0.5 <0.1.0",
                               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                               "dependencies": {
                                 "delayed-stream": {
@@ -481,18 +535,23 @@
                                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                                 }
                               }
+                            },
+                            "isstream": {
+                              "version": "0.1.1",
+                              "from": "isstream@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
                             }
                           }
                         },
                         "semver": {
-                          "version": "4.1.0",
-                          "from": "semver@~4.1.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.1.0.tgz"
+                          "version": "4.3.0",
+                          "from": "semver@>=4.3.0 <4.4.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
                         },
                         "tar": {
-                          "version": "1.0.2",
-                          "from": "tar@~1.0.2",
-                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.2.tgz",
+                          "version": "1.0.3",
+                          "from": "tar@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
                           "dependencies": {
                             "block-stream": {
                               "version": "0.0.7",
@@ -500,27 +559,27 @@
                               "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                             },
                             "fstream": {
-                              "version": "1.0.2",
-                              "from": "fstream@^1.0.2",
-                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.2.tgz",
+                              "version": "1.0.4",
+                              "from": "fstream@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "3.0.4",
-                                  "from": "graceful-fs@3",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@2",
+                              "from": "inherits@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
                         },
                         "tar-pack": {
                           "version": "2.0.0",
-                          "from": "tar-pack@~2.0.0",
+                          "from": "tar-pack@>=2.0.0 <2.1.0",
                           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
                           "dependencies": {
                             "uid-number": {
@@ -530,34 +589,34 @@
                             },
                             "once": {
                               "version": "1.1.1",
-                              "from": "once@~1.1.1",
+                              "from": "once@>=1.1.1 <1.2.0",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
                             },
                             "debug": {
                               "version": "0.7.4",
-                              "from": "debug@~0.7.2",
+                              "from": "debug@>=0.7.2 <0.8.0",
                               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                             },
                             "fstream": {
                               "version": "0.1.31",
-                              "from": "fstream@~0.1.22",
+                              "from": "fstream@>=0.1.22 <0.2.0",
                               "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "3.0.4",
-                                  "from": "graceful-fs@~3.0.2",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@>=3.0.2 <3.1.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.0",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "tar": {
                               "version": "0.1.20",
-                              "from": "tar@~0.1.17",
+                              "from": "tar@>=0.1.17 <0.2.0",
                               "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
                               "dependencies": {
                                 "block-stream": {
@@ -567,7 +626,7 @@
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
@@ -579,36 +638,36 @@
                               "dependencies": {
                                 "minimatch": {
                                   "version": "0.2.14",
-                                  "from": "minimatch@~0.2.0",
+                                  "from": "minimatch@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                                   "dependencies": {
                                     "lru-cache": {
                                       "version": "2.5.0",
-                                      "from": "lru-cache@2",
+                                      "from": "lru-cache@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                                     },
                                     "sigmund": {
                                       "version": "1.0.0",
-                                      "from": "sigmund@~1.0.0",
+                                      "from": "sigmund@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "readable-stream@~1.0.2",
+                              "from": "readable-stream@>=1.0.2 <1.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
@@ -618,26 +677,26 @@
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@~0.10.x",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "graceful-fs": {
                               "version": "1.2.3",
-                              "from": "graceful-fs@1.2",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                             }
                           }
                         },
                         "mkdirp": {
                           "version": "0.5.0",
-                          "from": "mkdirp@~0.5.0",
+                          "from": "mkdirp@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
@@ -648,35 +707,35 @@
                           }
                         },
                         "rc": {
-                          "version": "0.5.4",
-                          "from": "rc@~0.5.1",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.4.tgz",
+                          "version": "0.6.0",
+                          "from": "rc@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.10",
-                              "from": "minimist@~0.0.7",
+                              "from": "minimist@>=0.0.7 <0.1.0",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                             },
                             "deep-extend": {
                               "version": "0.2.11",
-                              "from": "deep-extend@~0.2.5",
+                              "from": "deep-extend@>=0.2.5 <0.3.0",
                               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                             },
                             "strip-json-comments": {
                               "version": "0.1.3",
-                              "from": "strip-json-comments@0.1.x",
+                              "from": "strip-json-comments@>=0.1.0 <0.2.0",
                               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                             },
                             "ini": {
-                              "version": "1.1.0",
-                              "from": "ini@~1.1.0",
-                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                              "version": "1.3.3",
+                              "from": "ini@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                             }
                           }
                         },
                         "rimraf": {
                           "version": "2.2.8",
-                          "from": "rimraf@~2.2.8",
+                          "from": "rimraf@>=2.2.8 <2.3.0",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                         }
                       }
@@ -684,19 +743,19 @@
                   }
                 },
                 "zipfile": {
-                  "version": "0.5.4",
-                  "from": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.4.tgz",
-                  "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.4.tgz",
+                  "version": "0.5.7",
+                  "from": "zipfile@>=0.5.2 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.7.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "1.4.1",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
+                      "version": "1.5.3",
+                      "from": "nan@>=1.5.1 <1.6.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.1",
-                      "from": "node-pre-gyp@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.1.tgz",
+                      "version": "0.6.2",
+                      "from": "node-pre-gyp@>=0.6.2 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.2.tgz",
                       "dependencies": {
                         "nopt": {
                           "version": "3.0.1",
@@ -723,9 +782,9 @@
                           }
                         },
                         "request": {
-                          "version": "2.48.0",
+                          "version": "2.51.0",
                           "from": "request@2.x",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.48.0.tgz",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                           "dependencies": {
                             "bl": {
                               "version": "0.9.3",
@@ -762,9 +821,9 @@
                               }
                             },
                             "caseless": {
-                              "version": "0.7.0",
-                              "from": "caseless@~0.7.0",
-                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.7.0.tgz"
+                              "version": "0.8.0",
+                              "from": "caseless@~0.8.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                             },
                             "forever-agent": {
                               "version": "0.5.2",
@@ -772,19 +831,26 @@
                               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                             },
                             "form-data": {
-                              "version": "0.1.4",
-                              "from": "form-data@~0.1.0",
-                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                              "version": "0.2.0",
+                              "from": "form-data@~0.2.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                               "dependencies": {
-                                "mime": {
-                                  "version": "1.2.11",
-                                  "from": "mime@~1.2.11",
-                                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                                },
                                 "async": {
                                   "version": "0.9.0",
                                   "from": "async@~0.9.0",
                                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                },
+                                "mime-types": {
+                                  "version": "2.0.7",
+                                  "from": "mime-types@~2.0.3",
+                                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+                                  "dependencies": {
+                                    "mime-db": {
+                                      "version": "1.5.0",
+                                      "from": "mime-db@~1.5.0",
+                                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -799,9 +865,9 @@
                               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                             },
                             "node-uuid": {
-                              "version": "1.4.1",
+                              "version": "1.4.2",
                               "from": "node-uuid@~1.4.0",
-                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                             },
                             "qs": {
                               "version": "2.3.3",
@@ -826,14 +892,14 @@
                               }
                             },
                             "http-signature": {
-                              "version": "0.10.0",
+                              "version": "0.10.1",
                               "from": "http-signature@~0.10.0",
-                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                               "dependencies": {
                                 "assert-plus": {
-                                  "version": "0.1.2",
-                                  "from": "assert-plus@0.1.2",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                                  "version": "0.1.5",
+                                  "from": "assert-plus@^0.1.5",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                                 },
                                 "asn1": {
                                   "version": "0.1.11",
@@ -841,9 +907,9 @@
                                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                                 },
                                 "ctype": {
-                                  "version": "0.5.2",
-                                  "from": "ctype@0.5.2",
-                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                                  "version": "0.5.3",
+                                  "from": "ctype@0.5.3",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                                 }
                               }
                             },
@@ -904,14 +970,14 @@
                           }
                         },
                         "semver": {
-                          "version": "4.1.0",
-                          "from": "semver@~4.1.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.1.0.tgz"
+                          "version": "4.2.0",
+                          "from": "semver@~4.2.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.0.tgz"
                         },
                         "tar": {
-                          "version": "1.0.2",
+                          "version": "1.0.3",
                           "from": "tar@~1.0.2",
-                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
                           "dependencies": {
                             "block-stream": {
                               "version": "0.0.7",
@@ -919,14 +985,14 @@
                               "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                             },
                             "fstream": {
-                              "version": "1.0.2",
+                              "version": "1.0.3",
                               "from": "fstream@^1.0.2",
-                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.3.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "3.0.4",
+                                  "version": "3.0.5",
                                   "from": "graceful-fs@3",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                                 }
                               }
                             },
@@ -963,9 +1029,9 @@
                               "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "3.0.4",
-                                  "from": "graceful-fs@~3.0.2",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
@@ -1042,7 +1108,7 @@
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1",
+                                  "from": "inherits@~2.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
@@ -1067,9 +1133,9 @@
                           }
                         },
                         "rc": {
-                          "version": "0.5.4",
+                          "version": "0.5.5",
                           "from": "rc@~0.5.1",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.4.tgz",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.10",
@@ -1087,9 +1153,9 @@
                               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                             },
                             "ini": {
-                              "version": "1.1.0",
-                              "from": "ini@~1.1.0",
-                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                              "version": "1.3.2",
+                              "from": "ini@~1.3.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
                             }
                           }
                         },
@@ -1103,18 +1169,19 @@
                   }
                 },
                 "sqlite3": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.0.4.tgz",
+                  "version": "2.2.7",
+                  "from": "sqlite3@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-2.2.7.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "1.4.1",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
+                      "version": "1.1.2",
+                      "from": "nan@1.1.2",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.1",
-                      "from": "node-pre-gyp@~0.6.1",
+                      "version": "0.5.22",
+                      "from": "node-pre-gyp@0.5.22",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.5.22.tgz",
                       "dependencies": {
                         "nopt": {
                           "version": "3.0.1",
@@ -1141,59 +1208,64 @@
                           }
                         },
                         "request": {
-                          "version": "2.48.0",
+                          "version": "2.39.0",
                           "from": "request@2.x",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.48.0.tgz",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.39.0.tgz",
                           "dependencies": {
-                            "bl": {
-                              "version": "0.9.3",
-                              "from": "bl@~0.9.0",
-                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
-                              "dependencies": {
-                                "readable-stream": {
-                                  "version": "1.0.33",
-                                  "from": "readable-stream@~1.0.26",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                                  "dependencies": {
-                                    "core-util-is": {
-                                      "version": "1.0.1",
-                                      "from": "core-util-is@~1.0.0",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                                    },
-                                    "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                    },
-                                    "string_decoder": {
-                                      "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
-                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                    },
-                                    "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
+                            "qs": {
+                              "version": "0.6.6",
+                              "from": "qs@~0.6.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                             },
-                            "caseless": {
-                              "version": "0.7.0",
-                              "from": "caseless@~0.7.0",
-                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.7.0.tgz"
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@~5.0.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime-types": {
+                              "version": "1.0.2",
+                              "from": "mime-types@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                             },
                             "forever-agent": {
                               "version": "0.5.2",
                               "from": "forever-agent@~0.5.0",
                               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                             },
+                            "node-uuid": {
+                              "version": "1.4.1",
+                              "from": "node-uuid@~1.4.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.3.0",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz"
+                                }
+                              }
+                            },
                             "form-data": {
                               "version": "0.1.4",
                               "from": "form-data@~0.1.0",
                               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                               "dependencies": {
+                                "combined-stream": {
+                                  "version": "0.0.5",
+                                  "from": "combined-stream@~0.0.4",
+                                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "0.0.5",
+                                      "from": "delayed-stream@0.0.5",
+                                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                    }
+                                  }
+                                },
                                 "mime": {
                                   "version": "1.2.11",
                                   "from": "mime@~1.2.11",
@@ -1206,42 +1278,10 @@
                                 }
                               }
                             },
-                            "json-stringify-safe": {
-                              "version": "5.0.0",
-                              "from": "json-stringify-safe@~5.0.0",
-                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-                            },
-                            "mime-types": {
-                              "version": "1.0.2",
-                              "from": "mime-types@~1.0.1",
-                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                            },
-                            "node-uuid": {
-                              "version": "1.4.1",
-                              "from": "node-uuid@~1.4.0",
-                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
-                            },
-                            "qs": {
-                              "version": "2.3.3",
-                              "from": "qs@~2.3.1",
-                              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                            },
                             "tunnel-agent": {
                               "version": "0.4.0",
                               "from": "tunnel-agent@~0.4.0",
                               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                            },
-                            "tough-cookie": {
-                              "version": "0.12.1",
-                              "from": "tough-cookie@>=0.12.0",
-                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-                              "dependencies": {
-                                "punycode": {
-                                  "version": "1.3.2",
-                                  "from": "punycode@>=0.2.0",
-                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                                }
-                              }
                             },
                             "http-signature": {
                               "version": "0.10.0",
@@ -1266,9 +1306,9 @@
                               }
                             },
                             "oauth-sign": {
-                              "version": "0.5.0",
-                              "from": "oauth-sign@~0.5.0",
-                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                              "version": "0.3.0",
+                              "from": "oauth-sign@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                             },
                             "hawk": {
                               "version": "1.1.1",
@@ -1306,30 +1346,18 @@
                               "version": "0.0.4",
                               "from": "stringstream@~0.0.4",
                               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                            },
-                            "combined-stream": {
-                              "version": "0.0.7",
-                              "from": "combined-stream@~0.0.5",
-                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                              "dependencies": {
-                                "delayed-stream": {
-                                  "version": "0.0.5",
-                                  "from": "delayed-stream@0.0.5",
-                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                                }
-                              }
                             }
                           }
                         },
                         "semver": {
-                          "version": "4.1.0",
-                          "from": "semver@~4.1.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.1.0.tgz"
+                          "version": "3.0.1",
+                          "from": "semver@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
                         },
                         "tar": {
-                          "version": "1.0.2",
-                          "from": "tar@~1.0.2",
-                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.2.tgz",
+                          "version": "1.0.0",
+                          "from": "tar@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
                           "dependencies": {
                             "block-stream": {
                               "version": "0.0.7",
@@ -1337,27 +1365,27 @@
                               "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                             },
                             "fstream": {
-                              "version": "1.0.2",
-                              "from": "fstream@^1.0.2",
-                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.2.tgz",
+                              "version": "1.0.1",
+                              "from": "fstream@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.1.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "3.0.4",
+                                  "version": "3.0.2",
                                   "from": "graceful-fs@3",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@2",
+                              "from": "inherits@~2.0.1",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
                         },
                         "tar-pack": {
                           "version": "2.0.0",
-                          "from": "tar-pack@~2.0.0",
+                          "from": "tar-pack@>=2.0.0 <2.1.0",
                           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
                           "dependencies": {
                             "uid-number": {
@@ -1367,34 +1395,34 @@
                             },
                             "once": {
                               "version": "1.1.1",
-                              "from": "once@~1.1.1",
+                              "from": "once@>=1.1.1 <1.2.0",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
                             },
                             "debug": {
                               "version": "0.7.4",
-                              "from": "debug@~0.7.2",
+                              "from": "debug@>=0.7.2 <0.8.0",
                               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                             },
                             "fstream": {
                               "version": "0.1.31",
-                              "from": "fstream@~0.1.22",
+                              "from": "fstream@>=0.1.22 <0.2.0",
                               "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "3.0.4",
-                                  "from": "graceful-fs@~3.0.2",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+                                  "version": "3.0.6",
+                                  "from": "graceful-fs@>=3.0.2 <3.1.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.0",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "tar": {
                               "version": "0.1.20",
-                              "from": "tar@~0.1.17",
+                              "from": "tar@>=0.1.17 <0.2.0",
                               "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
                               "dependencies": {
                                 "block-stream": {
@@ -1404,7 +1432,7 @@
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
@@ -1416,36 +1444,36 @@
                               "dependencies": {
                                 "minimatch": {
                                   "version": "0.2.14",
-                                  "from": "minimatch@~0.2.0",
+                                  "from": "minimatch@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                                   "dependencies": {
                                     "lru-cache": {
-                                      "version": "2.5.0",
-                                      "from": "lru-cache@2",
-                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                      "version": "2.6.1",
+                                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
                                     },
                                     "sigmund": {
                                       "version": "1.0.0",
-                                      "from": "sigmund@~1.0.0",
+                                      "from": "sigmund@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "readable-stream@~1.0.2",
+                              "from": "readable-stream@>=1.0.2 <1.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
@@ -1455,19 +1483,19 @@
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@~0.10.x",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "graceful-fs": {
                               "version": "1.2.3",
-                              "from": "graceful-fs@1.2",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                             }
                           }
@@ -1485,9 +1513,9 @@
                           }
                         },
                         "rc": {
-                          "version": "0.5.4",
-                          "from": "rc@~0.5.1",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.4.tgz",
+                          "version": "0.5.0",
+                          "from": "rc@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.10",
@@ -1517,39 +1545,37 @@
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                         }
                       }
+                    },
+                    "set-immediate": {
+                      "version": "0.1.1",
+                      "from": "set-immediate@0.1.1",
+                      "resolved": "https://registry.npmjs.org/set-immediate/-/set-immediate-0.1.1.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "from": "mime@>=1.2.9 <1.3.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "mkdirp": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.3 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "from": "optimist@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "from": "minimist@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
@@ -1558,218 +1584,805 @@
             }
           }
         },
-        "generic-pool": {
-          "version": "2.0.4",
-          "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz"
-        },
         "express": {
           "version": "2.5.11",
-          "from": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+          "from": "express@>=2.5.11 <2.6.0",
           "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
           "dependencies": {
             "connect": {
               "version": "1.9.2",
-              "from": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+              "from": "connect@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
               "dependencies": {
                 "formidable": {
-                  "version": "1.0.16",
-                  "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.16.tgz",
-                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.16.tgz"
+                  "version": "1.0.17",
+                  "from": "formidable@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.2.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+              "from": "mime@1.2.4",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
             },
             "qs": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
+              "from": "qs@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "from": "mkdirp@0.3.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "tilelive": {
-          "version": "4.4.3",
-          "from": "https://registry.npmjs.org/tilelive/-/tilelive-4.4.3.tgz",
-          "resolved": "https://registry.npmjs.org/tilelive/-/tilelive-4.4.3.tgz",
+          "version": "4.5.3",
+          "from": "tilelive@>=4.5.3 <4.6.0",
+          "resolved": "https://registry.npmjs.org/tilelive/-/tilelive-4.5.3.tgz",
           "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                }
-              }
-            },
-            "sphericalmercator": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.3.tgz"
-            }
-          }
-        },
-        "tilelive-mapnik": {
-          "version": "0.6.14",
-          "from": "https://registry.npmjs.org/tilelive-mapnik/-/tilelive-mapnik-0.6.14.tgz",
-          "resolved": "https://registry.npmjs.org/tilelive-mapnik/-/tilelive-mapnik-0.6.14.tgz",
-          "dependencies": {
-            "generic-pool": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
-            },
-            "mime": {
-              "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-            },
-            "sphericalmercator": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.3.tgz"
-            }
-          }
-        },
-        "mapnik": {
-          "version": "0.7.28",
-          "from": "https://registry.npmjs.org/mapnik/-/mapnik-0.7.28.tgz",
-          "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-0.7.28.tgz"
-        },
-        "semver": {
-          "version": "1.1.4",
-          "from": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
-        },
-        "redis-mpool": {
-          "version": "0.0.3",
-          "from": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.0.3.tgz",
-          "dependencies": {
-            "redis": {
-              "version": "0.8.6",
-              "from": "https://registry.npmjs.org/redis/-/redis-0.8.6.tgz",
-              "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.6.tgz"
-            },
-            "hiredis": {
-              "version": "0.1.17",
-              "from": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
-              "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
-              "dependencies": {
-                "bindings": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                },
-                "nan": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "lru-cache": {
-          "version": "2.3.1",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
-        },
-        "carto": {
-          "version": "0.9.5-cdb2",
-          "from": "http://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
-          "resolved": "http://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
-          "dependencies": {
-            "underscore": {
-              "version": "1.4.4",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-            },
-            "mapnik-reference": {
-              "version": "5.0.9",
-              "from": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz"
-            },
-            "xml2js": {
-              "version": "0.2.8",
-              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
-              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
-              "dependencies": {
-                "sax": {
-                  "version": "0.5.8",
-                  "from": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
-                }
-              }
-            },
             "optimist": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "from": "optimist@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             }
           }
         },
-        "underscore.string": {
-          "version": "1.1.6",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.6.tgz",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.6.tgz",
+        "tilelive-mapnik": {
+          "version": "0.6.15",
+          "from": "https://github.com/CartoDB/tilelive-mapnik/tarball/cdb",
+          "resolved": "https://github.com/CartoDB/tilelive-mapnik/tarball/cdb",
           "dependencies": {
-            "underscore": {
-              "version": "1.1.7",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
+            "generic-pool": {
+              "version": "2.1.1",
+              "from": "generic-pool@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             }
           }
         },
-        "pg": {
-          "version": "2.6.2",
-          "from": "https://registry.npmjs.org/pg/-/pg-2.6.2.tgz",
-          "resolved": "https://registry.npmjs.org/pg/-/pg-2.6.2.tgz",
+        "mapnik": {
+          "version": "1.4.15-cdb1",
+          "from": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb1",
+          "resolved": "https://github.com/CartoDB/node-mapnik/tarball/1.4.15-cdb1",
+          "dependencies": {
+            "nan": {
+              "version": "1.2.0",
+              "from": "nan@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+            },
+            "mapnik-vector-tile": {
+              "version": "0.5.5",
+              "from": "mapnik-vector-tile@0.5.5",
+              "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-0.5.5.tgz"
+            },
+            "node-pre-gyp": {
+              "version": "0.5.25",
+              "from": "node-pre-gyp@0.5.25",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.5.25.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "3.0.1",
+                  "from": "nopt@~3.0.1",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@1",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "0.1.1",
+                  "from": "npmlog@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.40.0",
+                  "from": "request@2.x",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "1.0.2",
+                      "from": "qs@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "from": "mime-types@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.1",
+                          "from": "punycode@>=0.2.0",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.5",
+                          "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "mime": {
+                          "version": "1.2.11",
+                          "from": "mime@~1.2.11",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@~0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "from": "tunnel-agent@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@~0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "from": "hawk@1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "3.0.1",
+                  "from": "semver@~3.0.1",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
+                },
+                "tar": {
+                  "version": "1.0.1",
+                  "from": "tar@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.1.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.7",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.2",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.2.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.2",
+                          "from": "graceful-fs@3",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "2.0.0",
+                  "from": "tar-pack@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                  "dependencies": {
+                    "uid-number": {
+                      "version": "0.0.3",
+                      "from": "uid-number@0.0.3",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "fstream": {
+                      "version": "0.1.31",
+                      "from": "fstream@~0.1.22",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.2",
+                          "from": "graceful-fs@~3.0.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "tar": {
+                      "version": "0.1.20",
+                      "from": "tar@~0.1.17",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.7",
+                          "from": "block-stream@*",
+                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "0.0.7",
+                      "from": "fstream-ignore@0.0.7",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@~0.2.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.31",
+                      "from": "readable-stream@~1.0.2",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@1.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "0.5.1",
+                  "from": "rc@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@~0.0.7",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "deep-extend@~0.2.5",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@0.1.x",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.1.0",
+                      "from": "ini@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@~2.2.8",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "canvas": {
+          "version": "1.1.6",
+          "from": "canvas@1.1.6",
+          "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.1.6.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "1.2.0",
+              "from": "nan@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+            }
+          }
+        },
+        "semver": {
+          "version": "1.1.4",
+          "from": "semver@>=1.1.4 <1.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+        },
+        "redis-mpool": {
+          "version": "0.1.0",
+          "from": "../../tmp/npm-4434-a51dd40a/1429345702736-0.7990752921905369/47510b8d4525ee24aa2e5328976372274a1d144e",
+          "resolved": "git://github.com/CartoDB/node-redis-mpool.git#47510b8d4525ee24aa2e5328976372274a1d144e",
           "dependencies": {
             "generic-pool": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
+              "version": "2.1.1",
+              "from": "generic-pool@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
             },
-            "buffer-writer": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+            "redis": {
+              "version": "0.12.1",
+              "from": "redis@>=0.12.1 <0.13.0",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
+            },
+            "hiredis": {
+              "version": "0.1.17",
+              "from": "hiredis@>=0.1.17 <0.2.0",
+              "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
+              "dependencies": {
+                "bindings": {
+                  "version": "1.2.1",
+                  "from": "bindings@*",
+                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                },
+                "nan": {
+                  "version": "1.1.2",
+                  "from": "nan@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "carto": {
+          "version": "0.14.0",
+          "from": "https://github.com/CartoDB/carto/tarball/update_to_master",
+          "resolved": "https://github.com/CartoDB/carto/tarball/update_to_master",
+          "dependencies": {
+            "mapnik-reference": {
+              "version": "6.0.5",
+              "from": "mapnik-reference@>=6.0.2 <6.1.0",
+              "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "step-profiler": {
+          "version": "0.1.0",
+          "from": "../../tmp/npm-4434-a51dd40a/1429345702716-0.7828811088111252/9b97881e450445bd8a307a9cc372b5129cb4529a",
+          "resolved": "git://github.com/CartoDB/node-step-profiler.git#9b97881e450445bd8a307a9cc372b5129cb4529a"
+        },
+        "cartodb-psql": {
+          "version": "0.4.0",
+          "from": "https://github.com/CartoDB/node-cartodb-psql/tarball/0.4.0",
+          "resolved": "https://github.com/CartoDB/node-cartodb-psql/tarball/0.4.0",
+          "dependencies": {
+            "pg": {
+              "version": "2.6.2-cdb1",
+              "from": "../../tmp/npm-4434-a51dd40a/1429345711843-0.009637400740757585/836a2dc3131e873fc4ba20cd16e7fb69a7dca98a",
+              "resolved": "git://github.com/CartoDB/node-postgres.git#836a2dc3131e873fc4ba20cd16e7fb69a7dca98a",
+              "dependencies": {
+                "generic-pool": {
+                  "version": "2.0.3",
+                  "from": "generic-pool@2.0.3",
+                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
+                },
+                "buffer-writer": {
+                  "version": "1.0.0",
+                  "from": "buffer-writer@1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+                }
+              }
             }
           }
         },
         "torque.js": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/torque.js/-/torque.js-2.2.00.tgz",
-          "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-2.2.00.tgz"
+          "version": "2.7.1",
+          "from": "https://github.com/CartoDB/torque/tarball/2.8",
+          "resolved": "https://github.com/CartoDB/torque/tarball/2.8",
+          "dependencies": {
+            "carto": {
+              "version": "0.15.1-cdb1",
+              "from": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+              "resolved": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+              "dependencies": {
+                "mapnik-reference": {
+                  "version": "6.0.5",
+                  "from": "mapnik-reference@>=6.0.2 <6.1.0",
+                  "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "request": {
+          "version": "2.48.0",
+          "from": "request@2.48.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.48.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.7.0",
+              "from": "caseless@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.7.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.11 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.5.0",
+              "from": "oauth-sign@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "hawk@1.1.1",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "abaculus": {
+          "version": "1.1.0",
+          "from": "https://github.com/CartoDB/abaculus/tarball/cdb",
+          "resolved": "https://github.com/CartoDB/abaculus/tarball/cdb"
+        },
+        "sphericalmercator": {
+          "version": "1.0.2",
+          "from": "sphericalmercator@1.0.2",
+          "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.2.tgz"
         },
         "node-statsd": {
           "version": "0.0.7",
-          "from": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.7.tgz",
+          "from": "node-statsd@>=0.0.7 <0.1.0",
           "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.7.tgz"
         }
       }

--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "lodash": "^2.4.1",
-    "windshaft": "^0.19.4"
+    "windshaft": "^0.36.0"
   },
   "devDependencies": {
     "jshint": "^2.5.11",


### PR DESCRIPTION
**This pull request is not to be merged.**

These changes upgrade Windshaft from 0.19.4 to 0.36.0. Windshaft was not upgraded to the most recent release because it appears the configuration changed it some way (relative to the configuration we're currently using).

There was also a notable battle with NPM in the upgrade process. See https://github.com/npm/npm/issues/6556 for more details.

---

Performance didn't get drastically better with 0.36.0, so I don't think upgrading right now is worthwhile. Upgrading could get more attractive if there are configuration parameters in 0.36.0 that enable tuning not exposed in 0.19.4. I have not found any as of yet.

Below is a comparison of the JMeter test plan (https://github.com/azavea/nyc-trees/pull/1248) run against 0.19.4 and 0.36.0:

![pasted_image_4_19_15__15_13](https://cloud.githubusercontent.com/assets/43639/7220921/e14c0f8a-e6a7-11e4-99ec-0457ff50012d.png)