### PR TITLE
Add style for low height device

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/partials/event_popup.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/event_popup.html
@@ -2,7 +2,7 @@
     <div class="row">
         {% include 'event/partials/event_calendar.html' %}
         <div class="event-details col-xs-6">
-            <h5 class="event-detail event-detail--title">{{ event.title }}</h5>
+            <h5 class="event-detail--title">{{ event.title }}</h5>
             <div class="event-detail">{{ event.group.name }}</div>
         </div>
         <div class="event-action col-xs-3"></div>

--- a/src/nyc_trees/apps/event/templates/event/partials/event_section.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/event_section.html
@@ -3,7 +3,7 @@
     <div class="row">
         {% include 'event/partials/event_calendar.html' %}
         <div class="event-details col-xs-7">
-            <h5 class="event-detail event-detail--title">{{ event.title }}</h5>
+            <h5 class="event-detail--title">{{ event.title }}</h5>
             <table>
                 <tr class="event-detail">
                     <td>

--- a/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reserve_blockface.html
@@ -12,12 +12,12 @@
       {% include 'survey/partials/reservations_legend.html' %}
       <div class="action-bar reservations-action-bar">
           {% if reservations.current > 0 %}
-          <div id="reservations-start" class="row">
+          <div id="reservations-start">
               <a class="btn btn-primary pull-left" href="{% url 'survey' %}">Start Mapping</a>
               <a id="reservations-add-remove" class="btn btn-primary pull-right" href="javascript:">Add / Remove</a>
           </div>
           {% endif %}
-          <div id="reservations-cart-action" class="reservation-action-item row {% if reservations.current == 0 %}active{% else %}hidden{% endif %}">
+          <div id="reservations-cart-action" class="reservation-action-item {% if reservations.current == 0 %}active{% else %}hidden{% endif %}">
               <div class="col-xs-5">
                   <h1 class="rsvp-count-total pull-left color--primary nomargin" id="current-reservations">{{ reservations.current }}</h1>
                   <div class="rsvp-count-context">
@@ -36,9 +36,13 @@
                   </form>
               </div>
           </div>
-          <div id="reservations-blockface-action" class="reservation-action-item">
-              <i id="close-blockface-action" class="icon-left-open-big"></i>
-              <div id="reservations-blockface-popup-container"></div>
+          <div id="reservations-blockface-action" class="reservation-action-item reservations-padding">
+              <div class="reservations-left">
+                  <i id="close-blockface-action" class="icon-left-open-big"></i>
+              </div>
+              <div class="reservations-right">
+                  <div id="reservations-blockface-popup-container"></div>
+              </div>
           </div>
       </div>
   </div>
@@ -61,15 +65,17 @@
 {% include "survey/partials/reserve_blockface_modals.html" %}
 
 <script type="html/template" id="reservations-blockface-popup-template">
-<div class="row reservations-popup">
-    <div class="col-xs-7">
-        <h5>Block Edge <span data-blockface-id></span></h5>
-        <p>
-            <span data-blockface-status></span>
-        </p>
-    </div>
-    <div class="col-xs-5">
-        <a class="btn btn-primary" data-blockface-id data-blockface-action></a>
+<div class="reservations-popup">
+    <div class="row">
+        <div class="col-xs-7 col-sm-6">
+            <h5>Block Edge <span data-blockface-id></span></h5>
+            <p>
+                <span data-blockface-status></span>
+            </p>
+        </div>
+        <div class="col-xs-5 col-sm-6 text-right">
+            <a class="btn btn-primary" data-blockface-id data-blockface-action></a>
+        </div>
     </div>
 </div>
 </script>

--- a/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
@@ -20,7 +20,7 @@
             {% if event_list.user_can_edit_group %}
             <a href="{{ event.get_absolute_url }}">{{ event.title }}</a>
             {% else %}
-            <h5 class="event-detail event-detail--title">{{ event.title }}</h5>
+            <h5 class="event-detail--title">{{ event.title }}</h5>
             {% endif %}
             <table>
                 <tr class="event-detail">

--- a/src/nyc_trees/apps/users/templates/users/partials/event_email_opt_in.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/event_email_opt_in.html
@@ -3,7 +3,7 @@
     <div class="row">
         {% include 'event/partials/event_calendar.html' %}
         <div class="event-details col-xs-6">
-            <h5 class="event-detail event-detail--title"><a href="{{ event.get_absolute_url }}">{{ event.title }}</a></h5>
+            <h5 class="event-detail--title"><a href="{{ event.get_absolute_url }}">{{ event.title }}</a></h5>
             <table>
                 <tr class="event-detail">
                     <td>

--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -215,6 +215,13 @@ aside {
   }
 }
 
+.pageheading-details.block {
+  @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+}
+
 .block--bottom {
   padding-bottom: $block-unit;
 }
@@ -334,6 +341,12 @@ aside {
   }
 }
 
+@media (max-width: $screen-sm) {
+  html {
+    font-size: 60%;
+  }
+}
+
 @media (min-width: $screen-md) {
   .two-frames {
     aside {
@@ -354,6 +367,18 @@ aside {
     }
     aside {
       padding-top: 0;
+    }
+  }
+}
+
+@media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+  .pageheading-details {
+    h2 {
+      font-size: 1.8rem;
+    }
+    .dropdown-toggle {
+      padding: 0 2.8rem 0 1rem;
+      margin-top: -.4rem;
     }
   }
 }

--- a/src/nyc_trees/sass/partials/_header.scss
+++ b/src/nyc_trees/sass/partials/_header.scss
@@ -4,6 +4,10 @@
   color: #fff;
   padding: 1rem 0;
   height: $navbar-height;
+  @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+    padding: .5rem 0;
+    height: 4.5rem;
+  }
 }
 
 .nav-right {
@@ -110,7 +114,7 @@
   background-color: $nav-side-color;
   width: 30rem;
   left: -30rem;
-  z-index: 1;
+  z-index: 2;
   transition: all 400ms $transition;
   .menu-active & {
     left: 0;
@@ -124,6 +128,9 @@
   left: 0;
   top: 0;
   transition: all 400ms $transition;
+  @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+    padding-top: 4.5rem;
+  }
 }
 
 .menu-active .right-content, .menu-active footer, .menu-active .main-header, .menu-active .overlay-menued {

--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -1,8 +1,13 @@
 .map-action-sidebar {
-  padding-bottom: 0;
+  padding-bottom: 0 !important;
   .tab-status-map-tab &, .page-new-reservation & {
     position: static;
     height: 7rem;
+    @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+      height: 4rem;
+      font-size: 12px;
+      padding-top: 1rem;
+    }
   }
   .dropdown-menu {
     z-index: $zindex-modal + 1;
@@ -16,6 +21,10 @@
     top: 15.9rem;
     right: 0;
     left: 0;
+    @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+      top: 12.6rem;
+      bottom: 7rem;
+    }
   }
   .page-new-reservation & {
     position: fixed;
@@ -26,6 +35,10 @@
     @media (min-width: $screen-sm) {
       top: $navbar-height;
       bottom: 0;
+    }
+    @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+      top: 8.5rem;
+      bottom: 7rem;
     }
   }
   .nav-tabs {
@@ -39,10 +52,20 @@
   bottom: 0;
   width: 100%;
   height: 8rem;
-  padding: 0 $grid-gutter-width/2;
+  padding: $grid-gutter-width/2 $grid-gutter-width/2;
   z-index: 1;
   .tab-status-list & {
     display: none;
+  }
+  & > .event {
+    padding: 0;
+
+  }
+  @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+    height: 7rem;
+    .event-detail {
+      display: none;
+    }
   }
 }
 
@@ -243,10 +266,22 @@
     border-left: 4px solid transparent;
     right: 1rem;
     top: 1.75rem;
+    @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+      top: 1rem;
+    }
+  }
+}
+
+.nav-tabs-event {
+  @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+    margin-top: -.3rem;
   }
 }
 
 @media (min-width: $screen-sm) {
+  .reservation-action-item {
+    margin: 0 $grid-gutter-width/-2;
+  }
   .map-sidebar .modal-dialog {
     width: auto;
   }
@@ -348,4 +383,23 @@
   #reservations-blockface-action {
       display: none;
   }
+}
+
+#reservations-help-text {
+  line-height: 1.2;
+}
+
+.reservations-left {
+  width: 13%;
+  float: left;
+}
+
+.reservations-right {
+  width: 87%;
+  float: left;
+}
+
+.reservations-padding {
+  padding-left: $grid-gutter-width/2;
+  padding-right: $grid-gutter-width/2;
 }

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -20,6 +20,9 @@
     @media (max-width: $screen-sm - 1) {
         bottom: 15rem;
     }
+    @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+        top: 4.5rem;
+    }
 }
 
 .action-bar-survey {
@@ -51,6 +54,9 @@
             display: block;
             height: auto;
             padding: 0;
+            @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
+                top: 4.5rem;
+            }
         }
     }
 

--- a/src/nyc_trees/sass/partials/_variables.scss
+++ b/src/nyc_trees/sass/partials/_variables.scss
@@ -329,6 +329,10 @@ $zindex-leaflet-controls: 1000;  // From the leaflet CSS
 //
 //## Define the breakpoints at which your layout will change, adapting to different screen sizes.
 
+
+// Really short screen, like iPhone 4.
+$screen-xs-height:           415px;
+
 // Extra small screen / phone
 //** Deprecated `$screen-xs` as of v3.0.1
 $screen-xs:                  480px;


### PR DESCRIPTION
Fixes #1239 and fixes #1241.

Adds media queries around height. Shrinks headers and actionbar on shorter devices.

![image](https://cloud.githubusercontent.com/assets/1809908/7232157/0e472a38-e748-11e4-9b2e-c7224c312dfc.png)