### PR TITLE
Add https:// prefix to event feed link urls

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -213,7 +213,8 @@ def events_list_feed(request):
             "long": e.location.x,
             "address": e.address,
         }],
-        'links': [{'link_url': site_domain + e.get_absolute_url()}],
+        'links': [{'link_url':
+                   'https://' + site_domain + e.get_absolute_url()}],
     } for e in events]
 
 


### PR DESCRIPTION
fixes #916 on github