### PR TITLE
Add activation email resend workflow

### DIFF
--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.contrib.gis.db import models
 from django.core.exceptions import ValidationError
@@ -33,11 +32,6 @@ class NycUserManager(UserManager):
     def get_by_natural_key(self, username):
         # For login, make username case-insensitive
         return self.get(username__iexact=username)
-
-
-AuthenticationForm.error_messages['invalid_login'] = \
-    'Please enter a correct username and password. ' \
-    'Note that password is case-sensitive.'
 
 
 #######################################

--- a/src/nyc_trees/apps/login/forms.py
+++ b/src/nyc_trees/apps/login/forms.py
@@ -19,8 +19,37 @@ from registration.forms import RegistrationFormUniqueEmail
 
 from apps.core.models import User, Group
 
+from django.contrib.auth.forms import AuthenticationForm
+from django.template.loader import render_to_string
+
+
+class NycAuthenticationForm(AuthenticationForm):
+
+    error_messages = {
+        'invalid_login': 'Please enter a correct username and password. '
+                         'Note that password is case-sensitive',
+        'inactive': 'Please click the account activation link you received by '
+                    'email before trying to log in.'
+    }
+
+    def confirm_login_allowed(self, user):
+        # Overrides the base implementation to allow safe HTML content in the
+        # validation error message
+        if not user.is_active:
+            msg = render_to_string(
+                'login/partials/inactive_validation_message.html',
+                {'text': self.error_messages['inactive']})
+            raise forms.ValidationError(
+                mark_safe(msg),
+                code='inactive',
+            )
+
 
 class ForgotUsernameForm(forms.Form):
+    email = forms.EmailField(label='Email address')
+
+
+class SendActivationEmailForm(forms.Form):
     email = forms.EmailField(label='Email address')
 
 

--- a/src/nyc_trees/apps/login/routes.py
+++ b/src/nyc_trees/apps/login/routes.py
@@ -38,3 +38,15 @@ forgot_username = do(
 forgot_username_sent = do(
     render_template('login/forgot_username_complete.html'),
     v.forgot_username_sent)
+
+send_activation_email = do(
+    render_template('login/send_activation_email.html'),
+    route(GET=v.send_activation_email_page, POST=v.send_activation_email))
+
+activation_email_sent = do(
+    render_template('login/activation_email_sent.html'),
+    v.activation_email_sent)
+
+activated = do(
+    render_template('login/activated.html'),
+    v.activated)

--- a/src/nyc_trees/apps/login/templates/login/activated.html
+++ b/src/nyc_trees/apps/login/templates/login/activated.html
@@ -1,0 +1,10 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block registration_title %}Active Account{% endblock %}
+
+{% block registration_content %}
+<p>Your account is active. Please try to log in.</p>
+
+<p><a class="btn btn-primary btn-mobile--max" href="{% url 'auth_login' %}">Log In</a></p>
+{% endblock %}

--- a/src/nyc_trees/apps/login/templates/login/activation_email_sent.html
+++ b/src/nyc_trees/apps/login/templates/login/activation_email_sent.html
@@ -1,0 +1,8 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block registration_title %}{% trans "Sending Email" %}{% endblock %}
+
+{% block registration_content %}
+    <p>Please check your email to activate your account. If you don't see it within 15 minutes, please check your spam folder.</p>
+{% endblock %}

--- a/src/nyc_trees/apps/login/templates/login/partials/inactive_validation_message.html
+++ b/src/nyc_trees/apps/login/templates/login/partials/inactive_validation_message.html
@@ -1,0 +1,7 @@
+{{ text }}
+
+<p>
+    <a href="{% url 'send_activation_email' %}">
+        Click here to send a new account activation email.
+    </a>
+</p>

--- a/src/nyc_trees/apps/login/templates/login/send_activation_email.html
+++ b/src/nyc_trees/apps/login/templates/login/send_activation_email.html
@@ -1,0 +1,34 @@
+{% extends "../templates/registration/registration_base.html" %}
+{% load i18n %}
+{% load utils %}
+
+{% block registration_title %}Send Activation Email{% endblock %}
+
+{% block registration_content %}
+<div class="content login-signup">
+  <div class="well login-signup-panel">
+    <form method="POST" id="send-activation-email-form">
+      <fieldset>
+        {% csrf_token %}
+        <p>
+            Need us to send you and account activation email? Enter the Email address you used to register
+            with TreesCount! and click the “Send” button below.
+        </p>
+        {% include "core/partials/non_field_errors.html" %}
+        <p>
+          <div class="fieldWrapper">
+            {{ form.email.errors }}
+            {{ form.email.label_tag }}
+            {{ form.email }}
+          </div>
+        </p>
+        <input type="submit" class="btn btn-primary btn-mobile--max" value="Send" />
+      </fieldset>
+    </form>
+  </div>
+</div>
+{% endblock %}
+
+{% block page_js %}
+<script type="text/javascript" src="{{ "js/registrationBase.js"|static_url }}"></script>
+{% endblock page_js %}

--- a/src/nyc_trees/apps/login/urls/accounts.py
+++ b/src/nyc_trees/apps/login/urls/accounts.py
@@ -6,7 +6,7 @@ from __future__ import division
 from django.conf.urls import patterns, url, include
 
 from apps.login import routes as r
-
+from apps.login.forms import NycAuthenticationForm
 
 urlpatterns = patterns(
     '',
@@ -29,6 +29,10 @@ urlpatterns = patterns(
     # Shadows django-registration-redux endpoint.
     # Ref: https://github.com/macropin/django-registration/blob/master/registration/backends/default/urls.py # NOQA
     url(r'^register/$', r.register, name='registration_register'),
+
+    url(r'^login/$', 'django.contrib.auth.views.login', {
+        'template_name': 'registration/login.html',
+        'authentication_form': NycAuthenticationForm}),
 
     url(r'^', include('registration.backends.default.urls')),
     url(r'^', include('django.contrib.auth.urls')),

--- a/src/nyc_trees/apps/login/urls/login.py
+++ b/src/nyc_trees/apps/login/urls/login.py
@@ -18,4 +18,16 @@ urlpatterns = patterns(
     url(r'^forgot-username/sent/$',
         r.forgot_username_sent,
         name='forgot_username_sent'),
+
+    url(r'^send-activation-email/$',
+        r.send_activation_email,
+        name='send_activation_email'),
+
+    url(r'^send-activation-email/sent/$',
+        r.activation_email_sent,
+        name='activation_email_sent'),
+
+    url(r'^send-activation-email/activated/$',
+        r.activated,
+        name='activated')
 )


### PR DESCRIPTION
If a person has registered, but not activated their account, and they attempt to log in, we want to tell them why we can't yet log them in, and provide them a way to request another activation email.

This commit adds a workflow, similar to "forgot username," for resending activation emails. There are a few key differences.

  * If the account is already active, there is no token, so we cannot
    send an email and, instead, prompt the person to log in.

  * Adding an anchor tag to the inactive account validation message
    requires overriding the authentication form, so that the HTML
    content can be marked as "safe."

Test by registering a new account, and then attempting to log in before activation.

Fixes #647