### PR TITLE
Add group.territory_updated_at field and use for territory cache buster

### DIFF
--- a/src/nyc_trees/apps/core/migrations/0025_group_territory_updated_at.py
+++ b/src/nyc_trees/apps/core/migrations/0025_group_territory_updated_at.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0024_auto_20150416_1136'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='group',
+            name='territory_updated_at',
+            field=models.DateTimeField(db_index=True, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -196,6 +196,12 @@ class Group(NycModel, models.Model):
     allows_individual_mappers = models.BooleanField(default=False)
     affiliation = models.CharField(max_length=255, default='', blank=True)
     border = models.MultiPolygonField(null=True, blank=True)
+    # Territory is one of the few models used in our tiler queries for which we
+    # expect deletions to regularly occur.  Since the 'updated_at' field won't
+    # change on any Territory rows, we record territory changes on the Group
+    # and check the group when trying to find out the Territory cache buster
+    territory_updated_at = models.DateTimeField(null=True, blank=True,
+                                                db_index=True)
 
     objects = models.GeoManager()
 

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -302,6 +302,11 @@ def _update_territory(group, request):
         .filter(blockface_id__in=ids_to_kill) \
         .delete()
 
+    # Record the current time on the group so we can use that as a cache buster
+    # when making tile requests for the territory table
+    group.territory_updated_at = now()
+    group.clean_and_save()
+
 
 def _update_event_maps(request, group):
     events = Event.objects \


### PR DESCRIPTION
Add `group.territory_updated_at` field and use for territory cache buster

Ensures that the cache buster is updated when blockfaces are unassigned
from a group's territory without any other changes taking place.

To test, remove a blockface from a group's territory and save without
making any other changes.  The color of the removed blockface should
change to indicate that it is now unavailable.

Fixes #791