### PR TITLE
Move training to top of the dash

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -27,6 +27,17 @@
         <div class="row">
             <main class="col-sm-12 main-dashboard">
                 {% flag full_access %}
+
+                    {% if not user.online_training_complete %}
+                        <div class="home-container">
+                            <section class="trainings">
+                                <div class="home-container">
+                                    {% include "home/partials/training.html" %}
+                                </div>
+                            </section>
+                        </div>
+                    {% endif %}
+
                     <section class="section-home">
                         <div class="home-container clearfix">
                             <h4 class="section-heading">Progress</h4>
@@ -88,8 +99,8 @@
                         </div>
                     </section>
 
-                    <div class="dashboard-columns">
-                        {% if user.online_training_complete %}
+                    {% if user.online_training_complete %}
+                        <div class="dashboard-columns">
                             <section class="events">
                                 <div class="home-container">
                                     <h4 class="section-heading">Events</h4>
@@ -99,14 +110,8 @@
                                 </div>
                             </section>
                             {% include "users/partials/activity.html" %}
-                        {% else %}
-                            <section class="trainings">
-                                <div class="home-container">
-                                    {% include "home/partials/training.html" %}
-                                </div>
-                            </section>
-                        {% endif %}
-                    </div>
+                        </div>
+                    {% endif %}
 
                 {% else %}
                     <section class="soft-launch">


### PR DESCRIPTION
This commit changes the heading and copy of the training section and moves it to the top of the dashboard, so it is the first thing a new user sees when logging in.

First login:

![screen shot 2015-04-21 at 9 55 11 am](https://cloud.githubusercontent.com/assets/17363/7257950/3ba2a3ce-e80e-11e4-9ab3-3b69c61d5d8f.png)

After some training:

![screen shot 2015-04-21 at 9 56 01 am](https://cloud.githubusercontent.com/assets/17363/7257955/4471b8aa-e80e-11e4-9ba9-3ffbdef3feac.png)

Training complete:

![screen shot 2015-04-21 at 9 56 24 am](https://cloud.githubusercontent.com/assets/17363/7257957/48cfaa42-e80e-11e4-8f8a-918c196988e4.png)

Fixes #1275 