### PR TITLE
Prevent scrolls being swallowed up by leaflet on Chrome for Android

### DIFF
--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -33,6 +33,7 @@ function create(options) {
         mapOptions.scrollWheelZoom = false;
         mapOptions.doubleClickZoom = false;
         mapOptions.boxZoom = false;
+        mapOptions.tap = false;
     }
 
     var map = L.map(options.domId, mapOptions),


### PR DESCRIPTION
Fixes #631