### PR TITLE
removed margin-left on footer logo - fixes #1336

### DIFF
--- a/src/nyc_trees/sass/partials/_home.scss
+++ b/src/nyc_trees/sass/partials/_home.scss
@@ -117,7 +117,7 @@ $hero-box-side-padding: 3rem;
 }
 
 .section-about-logo {
-  margin: 0 3rem 1rem 0;
+  margin: 0 0 1rem 0;
 }
 
 .section-appeal-text {


### PR DESCRIPTION
![screen shot 2015-04-22 at 9 08 47 am](https://cloud.githubusercontent.com/assets/1928955/7274992/41181a3e-e8cf-11e4-83ac-cf036e385f04.png)
