### PR TITLE
Add link to treecorder in main navigation

### DIFF
--- a/src/nyc_trees/apps/core/templates/core/partials/nav.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/nav.html
@@ -19,11 +19,7 @@
     {% endif %}
     <ul class="nav-side-list">
         {% flag full_access %}
-            {% if my_events_now_all|length > 0 %}
-                {% with event=my_events_now_all.0 %}
-                    <li><a href="{{ event.get_user_checkin_url }}">Start Mapping</a></li>
-                {% endwith %}
-            {% endif %}
+            <li{% if active_page == "treecorder" %} class="active"{% endif %}><a href="{% url 'treecorder' %}">Treecorder</a></li>
             <li{% if active_page == "dashboard" %} class="active"{% endif %}>
                 <a href="{% url 'home_page' %}">{% if user.is_authenticated %}Dashboard{% else %}Homepage{% endif %}</a>
             </li>

--- a/src/nyc_trees/apps/home/templates/home/individual_mapper_instructions.html
+++ b/src/nyc_trees/apps/home/templates/home/individual_mapper_instructions.html
@@ -6,7 +6,7 @@
 
 {% block main %}
 
-<p>You have been approved for individual mapper status! 
+<p>You have been approved for individual mapper status!
 <br><a href="#">Learn more.</a></p>
 
 <a href="{% url "reservations" %}" class="btn btn-primary">Reservations</a>

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -124,6 +124,9 @@ release_blockface = do(login_required,
 
 blockface = route(GET=do(json_api_call, v.blockface))
 
+redirect_to_treecorder = route(GET=do(login_required,
+                                      v.redirect_to_treecorder))
+
 #####################################
 # ADMIN ROUTES
 #####################################

--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -1,6 +1,10 @@
 {% extends "base_survey.html" %}
 {% load utils %}
 
+{% block nav %}
+{% include "core/partials/nav.html" with active_page="treecorder" %}
+{% endblock %}
+
 {% block aside %}
 
 <div class="map-sidebar">

--- a/src/nyc_trees/apps/survey/urls/survey.py
+++ b/src/nyc_trees/apps/survey/urls/survey.py
@@ -8,7 +8,7 @@ from django.conf.urls import patterns, url
 from apps.survey.routes import (survey, survey_from_event,
                                 flag_survey, survey_detail,
                                 confirm_survey, confirm_survey_from_event,
-                                release_blockface)
+                                release_blockface, redirect_to_treecorder)
 
 
 # These URLs have the prefix 'survey/'
@@ -20,6 +20,8 @@ urlpatterns = patterns(
     url(r'^(?P<group_slug>[\w-]+)/event/(?P<event_slug>[\w-]+)'
         r'/confirm/(?P<survey_id>\d+)/$',
         confirm_survey_from_event, name='confirm_survey_from_event'),
+
+    url(r'^treecorder/$', redirect_to_treecorder, name='treecorder'),
 
     # main endpoint (independent / from event)
     url(r'^$', survey, name='survey'),

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -24,7 +24,7 @@ from django.utils.timezone import now
 from apps.core.models import Group
 from apps.core.helpers import user_is_group_admin, user_is_individual_mapper
 
-from apps.event.models import Event
+from apps.event.models import Event, EventRegistration
 from apps.event.helpers import user_is_checked_in_to_event
 
 from apps.mail.tasks import notify_reservation_confirmed
@@ -431,6 +431,35 @@ def _validate_event_and_group(request, event_slug):
     if not user_is_checked_in_to_event(request.user, event):
         raise PermissionDenied('User not checked-in to this event')
     return event
+
+
+def redirect_to_treecorder(request):
+    user = request.user
+
+    # We assume you can't have RSVPed to events without completing training
+    attended_events, unattended_events = EventRegistration.my_events_now(user)
+
+    if attended_events:
+        event = attended_events[0]
+        return redirect('survey_from_event',
+                        group_slug=event.group.slug, event_slug=event.slug)
+    elif unattended_events:
+        event = unattended_events[0]
+        return redirect('event_user_check_in_page',
+                        group_slug=event.group.slug, event_slug=event.slug)
+
+    # Need to check indivdual mapper status first, to allow census admins to
+    # "skip" a users online training via the admin site easily
+    if user.individual_mapper:
+        if user.blockfacereservation_set.current().exists():
+            return redirect('survey')
+        else:
+            return redirect('reservations')
+
+    if not user.training_complete:
+        return redirect('training_instructions')
+
+    return redirect('reservations_instructions')
 
 
 def start_survey(request):


### PR DESCRIPTION
Redirects to the appropriate page based on the users training / individual
mapper status, # of reservations, and whether an event is in progress.

Lots of thanks to @RickMohr!

Fixes #1252