### PR TITLE
Remove time estimate from follow groups task

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/partials/training.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/training.html
@@ -45,7 +45,6 @@
     <div class="row">
         <div class="col-xs-8">
             <h5>Groups to Follow</h5>
-            <div class="h6">5 minutes</div>
         </div>
         <div class="col-xs-4 text-right">
           {% if user.training_finished_groups_to_follow %}


### PR DESCRIPTION
The estimates were removed from the other tasks on the training checklist, but this entry was mistakenly omitted.

Fixes #1361