### PR TITLE
Fix "species" progress circle on profile page

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/partials/circle.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/circle.html
@@ -1,9 +1,9 @@
 <div class="col-xs-4 col-circle{% if xs3col %} col-sm-3{% endif %}{% if hide_xs %} hidden-xs{% endif %}">
     <a class="progress-circle color--{{ color }}"
-        {% if url %}
-            href="{{ url }}"
-        {% elif modal %}
+        {% if modal %}
             data-toggle="modal" data-target="{{ modal }}"
+        {% elif url %}
+            href="{{ url }}"
         {% endif %}>
         <div class="progress-circle-content">
             <div class="progress-circle-number">{{ n }}</div>


### PR DESCRIPTION
Changed the order of `if` clauses to prevent capturing incorrect `url` in context

Fixes #1375