### PR TITLE
Hide private events on the map page

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -169,7 +169,9 @@ def events_list_page(request):
 
 def future_events_geojson(request):
     events = Event.objects.filter(
-        ends_at__gt=now(), group__is_active=True).select_related('group')
+        ends_at__gt=now(),
+        group__is_active=True,
+        is_private=False).select_related('group')
 
     return [_event_geojson(e) for e in events]
 


### PR DESCRIPTION
They are hidden on the list view and should also be hidden on the map.

Fixes #1379