### PR TITLE
Store quiz state per user

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/quiz_complete_page.html
+++ b/src/nyc_trees/apps/home/templates/home/quiz_complete_page.html
@@ -21,6 +21,7 @@
 {% block main %}
 
 <input type="hidden" name="quiz-slug" value="{{ quiz_slug }}" />
+<input type="hidden" name="user-id" value="{{ user.id }}" />
 <input type="hidden" name="correct-answers" value="{{ correct_answers|join:"," }}" />
 
 <h3>

--- a/src/nyc_trees/apps/home/templates/home/quiz_page.html
+++ b/src/nyc_trees/apps/home/templates/home/quiz_page.html
@@ -20,7 +20,7 @@
 
 {% block main %}
 
-<form method="POST" action="" class="quiz" data-quiz-slug="{{ quiz_slug }}">
+<form method="POST" action="" class="quiz" data-user-id="{{ user.id }}" data-quiz-slug="{{ quiz_slug }}">
 {% csrf_token %}
 {% for question in quiz.questions %}
 <div class="question

--- a/src/nyc_trees/apps/home/training/views.py
+++ b/src/nyc_trees/apps/home/training/views.py
@@ -67,6 +67,7 @@ def complete_quiz(request):
         send_online_training_complete(user)
 
     return {
+        'user': request.user,
         'quiz': quiz,
         'quiz_slug': quiz_slug,
         'quiz_summary': quiz_summary,

--- a/src/nyc_trees/js/src/lib/states.js
+++ b/src/nyc_trees/js/src/lib/states.js
@@ -7,9 +7,9 @@ var $ = require('jquery'),
 // Factory functions for various states.
 
 module.exports = {
-    quizProgressState: function(slug) {
+    quizProgressState: function(slug, userId) {
         return new SavedState({
-            key: 'quiz-progress-' + slug,
+            key: 'quiz-progress-' + slug + '-user-' + userId,
             validate: function(state) {
                 if (util.isNullOrUndefined(state)) {
                     throw new Error('Unable to parse serialized state');
@@ -24,9 +24,9 @@ module.exports = {
         });
     },
 
-    quizSubmissionState: function(slug) {
+    quizSubmissionState: function(slug, userId) {
         return new SavedState({
-            key: 'quiz-submission-' + slug,
+            key: 'quiz-submission-' + slug + '-user-' + userId,
             validate: function(state) {
                 if (!$.isArray(state)) {
                     throw new Error('Expected `state` to be an array');

--- a/src/nyc_trees/js/src/quizCompletePage.js
+++ b/src/nyc_trees/js/src/quizCompletePage.js
@@ -5,12 +5,14 @@ var $ = require('jquery'),
 
 var dom = {
     quizSlug: '[name="quiz-slug"]',
+    userId:  '[name="user-id"]',
     correctAnswers: '[name="correct-answers"]'
 };
 
 function saveCorrectAnswers() {
     var slug = $(dom.quizSlug).val(),
-        progress = states.quizSubmissionState(slug),
+        userId = $(dom.userId).val(),
+        progress = states.quizSubmissionState(slug, userId),
         newState = numberArray($(dom.correctAnswers).val().split(','));
     progress.save(newState);
 }
@@ -26,7 +28,8 @@ function parseIntBase10(n) {
 // Reset quiz progress back to the first question.
 function resetQuizProgress() {
     var slug = $(dom.quizSlug).val(),
-        progress = states.quizProgressState(slug),
+        userId = $(dom.userId).val(),
+        progress = states.quizProgressState(slug, userId),
         state = progress.load();
     if (state) {
         progress.save($.extend(state, {

--- a/src/nyc_trees/js/src/quizPage.js
+++ b/src/nyc_trees/js/src/quizPage.js
@@ -15,8 +15,9 @@ var dom = {
     activeQuestion: '.quiz .active.question'
 };
 
-var slug = $(dom.quizSlug).data('quiz-slug'),
-    progress = states.quizProgressState(slug),
+var userId = $(dom.quizSlug).data('user-id'),
+    slug = $(dom.quizSlug).data('quiz-slug'),
+    progress = states.quizProgressState(slug, userId),
     submission = states.quizSubmissionState(slug),
     correctAnswers = submission.load() || [];
 


### PR DESCRIPTION
Fixes the issue where multiple users of the same device (library, classroom, etc.) see the first user's quiz status and/or results.

Fixes #1399