### PR TITLE
Don't escape punctuation in email subject lines

### DIFF
--- a/src/nyc_trees/apps/mail/templates/mail/group_mapping_approved_subject.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/group_mapping_approved_subject.txt
@@ -1,1 +1,1 @@
-Your request to map for {{ group.name }} was approved
+{% autoescape off %}Your request to map for {{ group.name }} was approved{% endautoescape %}

--- a/src/nyc_trees/apps/mail/templates/mail/rsvp_subject.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/rsvp_subject.txt
@@ -1,1 +1,1 @@
-You are registered for {{ event.title }} on {{ event.begins_at|date:"l, F jS" }}
+{% autoescape off %}You are registered for {{ event.title }} on {{ event.begins_at|date:"l, F jS" }}{% endautoescape %}


### PR DESCRIPTION
By default Django's template engine escapes template content to protects against injection. When we are using a template to render a plain text email subject, we do not want this escaping.

Fixes #1401 