### PR TITLE
Show group border even if territory is not defined

### DIFF
--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -228,10 +228,11 @@ def group_borders_geojson(request):
                 'bounds': GeometryCollection(
                     [territory.blockface.geom
                      for territory in group.turf]).extent
+                if group.turf else group.border.extent
             }
         }
         for group in groups
-        if group.border and group.turf
+        if group.border
     ]
 
 


### PR DESCRIPTION
If a group has a border polygon defined, we can show it on the group map even if the territory for the group has not been defined.

Fixes #1407