### PR TITLE
Remove outline on tab click on Firefox

### DIFF
--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -272,6 +272,7 @@ aside {
       border: 0 !important;
       padding-left: 0;
       text-transform: uppercase;
+      outline: none;
     }
   }
 }


### PR DESCRIPTION
Fixes #1398.

![image](https://cloud.githubusercontent.com/assets/1809908/7300093/0be4a768-e9a8-11e4-817c-a11b75a5eddb.png)
