### PR TITLE
Fix long group names in actionbar

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/partials/group_popup.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/group_popup.html
@@ -1,7 +1,7 @@
-<a href="{{ group.get_absolute_url }}" class="event block item rightarrow">
+<a href="{{ group.get_absolute_url }}" class="group block item nopadding--top rightarrow">
     <div class="row">
-        <div class="col-xs-12">
-            <h3>{{ group.name }}</h3>
+        <div class="col-xs-11">
+            <h4 class="nomargin">{{ group.name }}</h4>
             <p>{{ completed }} Complete</p>
         </div>
     </div>

--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -334,7 +334,7 @@
     position: static;
     height: auto;
     border-top: 1px solid #eee;
-    padding: 1rem 0 0 0;
+    padding: 2rem 0 0 0;
     margin-top: 1rem;
   }
   .map-full {


### PR DESCRIPTION
Fixes #1387.

![image](https://cloud.githubusercontent.com/assets/1809908/7305361/32415514-e9cb-11e4-8d0a-59b990db7e0d.png)
