### PR TITLE
Set an appropriately sized iOS shortcut title

### DIFF
--- a/src/nyc_trees/apps/core/templates/skeleton.html
+++ b/src/nyc_trees/apps/core/templates/skeleton.html
@@ -7,6 +7,7 @@
 
         <title>TreesCount! 2015</title>
         <link rel="apple-touch-icon" href="{{ "img/favicon/apple-touch-icon.png"|static_url }} ">
+        <meta name="apple-mobile-web-app-title" content="TreesCount">
         <link rel="icon" type="image/png" href="{{ "img/favicon/android-chrome.png"|static_url }}">
         <link rel="shortcut icon" href="{{ "img/favicon/favicon.ico"|static_url }} ">
         <link rel="manifest" href="{{ "img/favicon/manifest.json"|static_url }}">


### PR DESCRIPTION
The ! in the page title results in "TreesCoun..." as the default iOS home screen short cut label. Adding this meta tag provides a default that fits in the allowable home screen icon label space.

Before

![image1](https://cloud.githubusercontent.com/assets/17363/7322677/7bdb45b6-ea5e-11e4-882c-f1980ed2b9a6.PNG)


After

![image1-1](https://cloud.githubusercontent.com/assets/17363/7322681/806e262a-ea5e-11e4-9f9e-c36a98f7f29d.PNG)
