### PR TITLE
Add support for C3 and C4 class instance types

### DIFF
--- a/deployment/troposphere/template_utils.py
+++ b/deployment/troposphere/template_utils.py
@@ -21,6 +21,14 @@ EC2_INSTANCE_TYPES = [
     'm3.large',
     'm3.xlarge',
     'm3.2xlarge',
+    # C3
+    'c3.large',
+    'c3.xlarge',
+    'c3.2xlarge',
+    # C4
+    'c4.large',
+    'c4.xlarge',
+    'c4.2xlarge',
 ]
 RDS_INSTANCE_TYPES = [
     # T2


### PR DESCRIPTION
This changeset allows application and tiler instances to be launched as C3 and C4 class instance types.