### PR TITLE
Cleanup HTML

### DIFF
--- a/src/nyc_trees/apps/core/templates/base.html
+++ b/src/nyc_trees/apps/core/templates/base.html
@@ -17,7 +17,7 @@
                     <span class="icon-bar"></span>
                 </button>
                 <div class="brand nav-left">
-                    <a href="{% url 'home_page' %}"><img src="{{ 'img/logo-treescount.png'|static_url }}" srcset="{{ 'img/logo-treescount@2x.png'|static_url }} 2x" alt="TreesCount! 2015 logo"></a>
+                    <a href="{% url 'home_page' %}"><img src="{{ 'img/logo-treescount.png'|static_url }}" srcset="{{ 'img/logo-treescount@2x.png'|static_url }} 2x" alt="TreesCount! 2015 logo" /></a>
                 </div>
             </div>
             <div class="nav-right nav-account">
@@ -70,7 +70,7 @@
             <div class="container text-center">
                 <div class="row">
                     <div>
-                        <img class="section-about-logo" src="{{ 'img/logo-nycparks.png'|static_url }}" srcset="{{ 'img/logo-nycparks@2x.png'|static_url }} 2x">
+                        <img class="section-about-logo" src="{{ 'img/logo-nycparks.png'|static_url }}" srcset="{{ 'img/logo-nycparks@2x.png'|static_url }} 2x" alt="NYC Parks Logo" />
                         <p>A project of New York City <strong>Department&nbsp;of&nbsp;Parks&nbsp;&amp;&nbsp;Recreation</strong></p>
                     </div>
                 </div>

--- a/src/nyc_trees/apps/core/templates/core/partials/nav.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/nav.html
@@ -4,17 +4,15 @@
 <nav class="nav-side">
     {% if user.is_authenticated %}
     <div class="nav-side-user clearfix">
-        <span>
-            <h2><a href="{% url 'user_detail_redirect' %}" class="nav-side-user-name">{{ user.username }}</a></h2>
-            <div class="nav-side-options">
-                <a href="{% url 'user_profile_settings' %}" class="btn btn-primary">
-                    Settings
-                </a>&nbsp;{% if not user.is_minor %}<a href="{{ user_settings_privacy_url }}"
-                                                       class="btn btn-primary">
-                    Privacy
-                </a>{% endif %}
-            </div>
-        </span>
+        <h2><a href="{% url 'user_detail_redirect' %}" class="nav-side-user-name">{{ user.username }}</a></h2>
+        <div class="nav-side-options">
+            <a href="{% url 'user_profile_settings' %}" class="btn btn-primary">
+                Settings
+            </a>&nbsp;{% if not user.is_minor %}<a href="{{ user_settings_privacy_url }}"
+                                                   class="btn btn-primary">
+                Privacy
+            </a>{% endif %}
+        </div>
     </div>
     {% endif %}
     <ul class="nav-side-list">
@@ -33,7 +31,7 @@
         <li{% if active_page == "about" %} class="active"{% endif %}><a href="{% url 'about_faq_page' %}">About &amp; FAQ</a></li>
     </ul>
     <div class="nav-side-sub">
-        <img src="{{ 'img/logo-nyc.png'|static_url }}" srcset="{{ 'img/logo-nyc@2x.png'|static_url }} 2x" alt="NYC">
+        <img src="{{ 'img/logo-nyc.png'|static_url }}" srcset="{{ 'img/logo-nyc@2x.png'|static_url }} 2x" alt="NYC" />
         <h6 class="color--white">Copyright 2015, The City of New York</h6>
         <a title="treescount.help@parks.nyc.gov" href="mailto:treescount.help@parks.nyc.gov">Contact Us</a>
         <!-- TODO: link to an appropriate page

--- a/src/nyc_trees/apps/core/templates/skeleton.html
+++ b/src/nyc_trees/apps/core/templates/skeleton.html
@@ -18,7 +18,6 @@
     <body>
     {% block body %}
     {% endblock body %}
-    </body>
     <script type="text/javascript">
         {% include 'core/partials/config.js' %}
     </script>
@@ -27,4 +26,5 @@
     <script type="text/javascript" src="{{ "js/base.js"|static_url }}"></script>
     {% block page_js %}
     {% endblock page_js %}
+    </body>
 </html>

--- a/src/nyc_trees/apps/event/templates/event/event_detail.html
+++ b/src/nyc_trees/apps/event/templates/event/event_detail.html
@@ -117,14 +117,19 @@
 {% block main %}
 
     <section>
+        {% if event.description %}
         <div class="description block item">
             <h4 class="section-heading">Description</h4>
             <div>{{event.description}}</div>
         </div>
+        {% endif %}
+        {% if event.location_description %}
         <div class="description block item">
             <h4 class="section-heading">How to find us</h4>
             <div>{{event.location_description}}</div>
         </div>
+        {% endif %}
+        {% if event.contact_name %}
         <div class="description block item">
             <div class="row">
                 <div class="col-xs-8">
@@ -134,6 +139,7 @@
                 <div class="col-xs-4 text-right"><a href="mailto:{{event.contact_email}}" class="btn btn-default">Email</a></div>
             </div>
         </div>
+        {% endif %}
         <div class="description block item">
             <div class="row">
                 <div class="col-xs-8 text--break">

--- a/src/nyc_trees/apps/event/templates/event/partials/teammates.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/teammates.html
@@ -1,6 +1,6 @@
 <select class="teammate" style="width: 100%;">
     {# A blank option to allow for clearing the selection #}
-    <option></option>
+    <option value="">&nbsp;</option>
     {% for teammate in teammates %}
         {% include "event/partials/teammate_item.html" %}
     {% endfor %}

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -34,7 +34,7 @@
                         <div class="row">
                             <div class="col-xs-3 col-lg-2 col-lg-offset-1 text-center">
                                 <img src="{{ "img/logo-nycparks.png"|static_url }}"
-                                     srcset="{{ "img/logo-nycparks@2x.png"|static_url }} 2x">
+                                     srcset="{{ "img/logo-nycparks@2x.png"|static_url }} 2x" alt="NYC Parks Logo" />
                             </div>
                             <div class="col-xs-9 col-sm-8">
                                 Join the Counter Culture!
@@ -74,7 +74,7 @@
                 <section class="section-appeal">
                     <div class="row">
                         <div class="col-sm-6">
-                            <img src="{{ "img/homepage-brownstone.jpg"|static_url }}">
+                            <img src="{{ "img/homepage-brownstone.jpg"|static_url }}" alt="" />
                         </div>
                         <div class="section-appeal-text col-sm-6">
                             <h2>Collecting data on street trees leads to a greener and greater NYC!</h2>
@@ -88,37 +88,37 @@
                             <h3 class="color--primary text--normal">Presenting Sponsors</h3>
                             <div class="row">
                                 <div class="sponsor col-xs-6 col-md-4">
-                                    <img src="{{ "img/sponsors/sponsors-bmw.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-bmw.png"|static_url }}" alt="BMW" />
                                 </div>
                                 <div class="sponsor col-xs-5 col-md-3">
-                                    <img src="{{ "img/sponsors/sponsors-wholefoods.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-wholefoods.png"|static_url }}" alt="Whole Foods Market" />
                                 </div>
                             </div>
                             <hr>
                             <h3 class="color--primary text--normal">Partners and Sponsors</h3>
                             <div class="row">
                                 <div class="sponsor sponsor-durst col-xs-6">
-                                    <img src="{{ "img/sponsors/sponsors-durst.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-durst.png"|static_url }}" alt="The Durst Organization" />
                                 </div>
                                 <div class="sponsor sponsor-azavea col-xs-6">
-                                    <img src="{{ "img/sponsors/sponsors-azavea.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-azavea.png"|static_url }}" alt="Azavea" />
                                 </div>
                                 <div class="sponsor sponsor-att col-xs-4 col-xs-offset-1 clearleft">
-                                    <img src="{{ "img/sponsors/sponsors-att.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-att.png"|static_url }}" alt="AT&amp;T" />
                                 </div>
                                 <div class="sponsor sponsor-aws col-xs-6">
-                                    <img src="{{ "img/sponsors/sponsors-aws.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-aws.png"|static_url }}" alt="Amazon Web Services" />
                                 </div>
                                 <div class="sponsor sponsor-nyp col-xs-10">
-                                    <img src="{{ "img/sponsors/sponsors-nyp.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-nyp.png"|static_url }}" alt="New York Presbyterian" />
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="sponsor sponsor-histree col-xs-6">
-                                    <img src="{{ "img/sponsors/sponsors-histree.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-histree.png"|static_url }}" alt="Histree" />
                                 </div>
                                 <div class="sponsor sponsor-tk col-xs-4 col-xs-offset-1">
-                                    <img src="{{ "img/sponsors/sponsors-treekit.png"|static_url }}">
+                                    <img src="{{ "img/sponsors/sponsors-treekit.png"|static_url }}" alt="TreeKIT" />
                                 </div>
                             </div>
                         </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/legend.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/legend.html
@@ -5,12 +5,10 @@
                 <button type="button" class="close visible-xs pull-right btn-link" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true"><i class="icon-cancel"></i></span>
                 </button>
-                <span>
-                    <h2 class="visible-xs">
-                    {% block legend_title %}
-                    {% endblock %}
-                    </h2>
-                </span>
+                <h2 class="visible-xs">
+                {% block legend_title %}
+                {% endblock %}
+                </h2>
                 <div>
                 {% block legend_text %}
                 {% endblock %}

--- a/src/nyc_trees/apps/home/templates/home/partials/species_modal.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/species_modal.html
@@ -10,10 +10,10 @@
           {% for common_name, count in species_by_name %}
             <li><strong class="color--primary">{{ count }}</strong> {{ common_name }}</li>
           {% endfor %}
+          </ul>
         {% else %}
           <p>No trees have been surveyed yet.</p>
         {% endif %}
-        </ul>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">OK</button>

--- a/src/nyc_trees/apps/home/templates/home/partials/training.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/training.html
@@ -23,21 +23,23 @@
 <p>You can also download a PDF of the training materials <a target="_blank" href="{{ STATIC_URL }}training/TreesCount2015Training.pdf">here.</a></p>
 
 {% for step_info in training_steps %}
-<a {% if step_info.is_visitable %}href="{{ step_info.step.pure_url }}"{% endif %}
-   class="training block item {% if not step_info.is_visitable %}inactive{% endif %}">
-    <div class="row">
-        <div class="col-xs-8">
-            <h5>{{ step_info.step.description }}</h5>
-        </div>
-        <div class="col-xs-4 text-right">
-          {% if step_info.is_complete %}
-          <i class="icon-check h4"></i>
-          {% elif step_info.is_next %}
-            <button class="btn-primary btn">Start</button>
-          {% endif %}
-        </div>
+<div class="row training block item {% if not step_info.is_visitable %}inactive{% endif %}">
+    <div class="col-xs-8">
+        <h5>
+            <a {% if step_info.is_visitable %}href="{{ step_info.step.pure_url }}"{% endif %}>
+                {{ step_info.step.description }}</a>
+        </h5>
     </div>
-</a>
+    <div class="col-xs-4 text-right">
+        <a {% if step_info.is_visitable %}href="{{ step_info.step.pure_url }}"{% endif %}>
+            {% if step_info.is_complete %}
+            <i class="icon-check h4"></i>
+            {% elif step_info.is_next %}
+            <span class="btn-primary btn">Start</span>
+            {% endif %}
+        </a>
+    </div>
+</div>
 {% endfor %}
 {% if user.online_training_complete %}
 <a href="{% url 'groups_to_follow' %}"

--- a/src/nyc_trees/apps/home/templates/home/quiz_page.html
+++ b/src/nyc_trees/apps/home/templates/home/quiz_page.html
@@ -20,7 +20,7 @@
 
 {% block main %}
 
-<form method="POST" action="" class="quiz" data-user-id="{{ user.id }}" data-quiz-slug="{{ quiz_slug }}">
+<form method="POST" action="{{ request.path }}" class="quiz" data-user-id="{{ user.id }}" data-quiz-slug="{{ quiz_slug }}">
 {% csrf_token %}
 {% for question in quiz.questions %}
 <div class="question

--- a/src/nyc_trees/apps/survey/templates/survey/partials/map_another_popup.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/map_another_popup.html
@@ -3,7 +3,6 @@
      data-no-more-reservations="{{ no_more_reservations }}"
      tabindex="-1"
      role="dialog"
-     aria-labelledby="map-another-popup-title"
      aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">

--- a/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
@@ -1,4 +1,10 @@
+{# Preserve original behavior, but allow us to opt-out of using legend tag. #}
+{# Multiple legends in a fieldset is not valid markup. #}
+{% if use_title_div %}
+<div class="field-title">{{ label }}</div>
+{% else %}
 <legend>{{ label }}</legend>
+{% endif %}
 <div class="field">
 
     <div class="btn-group btn-group-toggles">

--- a/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
@@ -56,8 +56,9 @@
             <legend>Tree Species</legend>
             <div class="field">
                 <label for="species_id">Species Name</label>
-                <select name="species_id" required>
-                  <option></option>
+                <select name="species_id" id="species_id" required>
+                  {# A blank option so first species is not preselected #}
+                  <option value="">&nbsp;</option>
                   {% for species in choices.species %}
                   <option value="{{ species.pk }}" data-scientific-name="{{ species.scientific_name }}" data-cultivar="{{ species.cultivar }}">
                     {{ species.common_name }}
@@ -66,7 +67,7 @@
                 </select>
             </div>
 
-            {% include "survey/partials/radios.html" with label="Are you confident in this answer?" field="species_certainty" choices=choices.species_certainty %}
+            {% include "survey/partials/radios.html" with label="Are you confident in this answer?" field="species_certainty" choices=choices.species_certainty use_title_div=True %}
         </fieldset>
         <fieldset>
             {% include "survey/partials/radios.html" with label="Perception of Tree Health" field="health" choices=choices.health %}
@@ -75,7 +76,7 @@
             {% include "survey/partials/radios.html" with label="Tree Guards" field="guard_installation" choices=choices.guard_installation %}
 
             <div data-guard_installation="Yes">
-                {% include "survey/partials/radios.html" with label="Is the tree guard:" field="guards" choices=choices.guards %}
+                {% include "survey/partials/radios.html" with label="Is the tree guard:" field="guards" choices=choices.guards use_title_div=True %}
             </div>
         </fieldset>
         <fieldset>

--- a/src/nyc_trees/apps/survey/templates/survey/progress.html
+++ b/src/nyc_trees/apps/survey/templates/survey/progress.html
@@ -9,39 +9,40 @@
 
     <div class="map-sidebar">
         <div class="map-sidebar-context block">
-            <h2>Progress
-                <div class="dropdown pull-right">
-                    <button type="button" class="btn btn-default dropdown-toggle progress-toggle" data-toggle="dropdown">
-                        All Users
-                    </button>
-                    <ul class="dropdown-menu dropdown-menu-right" role="menu">
-                        <li class="text-right" role="presentation">
-                            <a role="menuitem" href="#all"
-                               data-tile-url="{{ layer_all.tile_url }}"
-                               data-grid-url="{{ layer_all.grid_url }}"
-                            >All Users</a>
-                        </li>
+            <h2 class="pull-left">Progress</h2>
+            <div class="dropdown pull-right">
+                <button type="button" class="btn btn-default dropdown-toggle progress-toggle" data-toggle="dropdown">
+                    All Users
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                    <li class="text-right" role="presentation">
+                        <a role="menuitem" href="#all"
+                           data-tile-url="{{ layer_all.tile_url }}"
+                           data-grid-url="{{ layer_all.grid_url }}"
+                        >All Users</a>
+                    </li>
 {% comment %}
 TODO: Uncomment before May 19
-                        {% if request.user.is_authenticated %}
-                        <li class="text-right" role="presentation">
-                            <a role="menuitem" href="#my"
-                               data-tile-url="{{ layer_my.tile_url }}"
-                               data-grid-url="{{ layer_my.grid_url }}"
-                               {% if bounds %}data-bounds="{{ bounds }}"{% endif %}
-                            >My Progress</a>
-                        </li>
-                        {% endif %}
+                    {% if request.user.is_authenticated %}
+                    <li class="text-right" role="presentation">
+                        <a role="menuitem" href="#my"
+                           data-tile-url="{{ layer_my.tile_url }}"
+                           data-grid-url="{{ layer_my.grid_url }}"
+                           {% if bounds %}data-bounds="{{ bounds }}"{% endif %}
+                        >My Progress</a>
+                    </li>
+                    {% endif %}
 {% endcomment %}
-                        <li class="text-right" role="presentation">
-                            <a role="menuitem" href="#group"
-                               data-geojson-url="{% url 'group_borders' %}"
-                            >Groups</a>
-                        </li>
-                    </ul>
-                </div>
-            </h2>
-            {% include 'survey/partials/progress_legend.html' %}
+                    <li class="text-right" role="presentation">
+                        <a role="menuitem" href="#group"
+                           data-geojson-url="{% url 'group_borders' %}"
+                        >Groups</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="clear">
+                {% include 'survey/partials/progress_legend.html' %}
+            </div>
         </div>
         <div class="action-bar" id="action-bar"></div>
     </div>

--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -62,7 +62,7 @@
             </div>
             <div class="block" id="treeform-sponsor">
                 <span>Powered By</span>
-                <img src="{{ "img/logo-treekit.png"|static_url }}" alt="TreeKit">
+                <img src="{{ "img/logo-treekit.png"|static_url }}" alt="TreeKit" />
             </div>
         </div>
     </div>

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -47,6 +47,7 @@
             <h4 class="section-heading">Description</h4>
             <div>{{group.description}}</div>
         </div>
+        {% if group.contact_name %}
         <div class="description block item">
             <div class="row">
                 <div class="col-xs-8">
@@ -56,6 +57,7 @@
                 <div class="col-xs-4 text-right"><a href="mailto:{{group.contact_email}}" class="btn btn-default">Email</a></div>
             </div>
         </div>
+        {% endif %}
         {% if group.contact_url %}
             <div class="description block item">
                 <div class="row">

--- a/src/nyc_trees/apps/users/templates/groups/list.html
+++ b/src/nyc_trees/apps/users/templates/groups/list.html
@@ -29,7 +29,7 @@
 <div class="block">
     <div class="input-group">
       <span class="input-group-addon"><i class="icon-search"></i></span>
-      <input type="text" class="form-control" placeholder="Filter groups" aria-describedby="basic-addon1" data-class="group-search">
+      <input type="text" class="form-control" placeholder="Filter groups" data-class="group-search">
     </div>
 </div>
 

--- a/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
@@ -63,12 +63,12 @@
             <div class="dropdown text-right">
                 <button class="btn btn-default dropdown-toggle"
                         type="button"
-                        id="group-detail-event-info-submenu"
+                        id="group-detail-event-info-submenu-{{ event.id }}"
                         data-toggle="dropdown"
                         aria-expanded="true">
                     <span class="caret"></span>
                 </button>
-                <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="group-detail-event-info-submenu">
+                <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="group-detail-event-info-submenu-{{ event.id }}">
                     <li><a role="menuitem" tabindex="-1" href="{{ event.get_absolute_url }}">View event</a></li>
                     <li><a role="menuitem" tabindex="-1" href="{% url 'event_edit' group_slug=event.group.slug event_slug=event.slug %}">Edit details</a></li>
                     <li><a role="menuitem" tabindex="-1" href="{% url 'event_email' group_slug=event.group.slug event_slug=event.slug %}">Email attendees</a></li>

--- a/src/nyc_trees/apps/users/templates/users/partials/achievement.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/achievement.html
@@ -14,7 +14,7 @@
             {% endif %}
         </div>
         <div class="col-xs-4 text-right">
-            <img class="badge" src="{{ achievement.badge|static_url }}" />
+            <img class="badge" src="{{ achievement.badge|static_url }}" alt="" />
         </div>
     </div>
 </div>

--- a/src/nyc_trees/apps/users/templates/users/partials/profile/section.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/section.html
@@ -4,7 +4,5 @@
     </a>
 </h4>
 
-<div id="{{ section_id }}" class="collapse in">
-    {% block section_content %}
-    {% endblock section_content %}
-</div>
+{% block section_content %}
+{% endblock section_content %}

--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -400,3 +400,7 @@ aside {
 .achievement-sponsor {
   color: #bbb;
 }
+
+.clear {
+    clear: both;
+}

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -205,9 +205,10 @@
         border-bottom: 2px solid $gray-lightest;
         margin-bottom: 1rem;
     }
-    legend {
+    legend, .field-title {
         font-size: $font-size-h5;
         font-weight: 600;
+        color: $legend-color;
         margin: 0;
         border: none;
     }

--- a/src/nyc_trees/templates/registration/login.html
+++ b/src/nyc_trees/templates/registration/login.html
@@ -11,7 +11,7 @@
 
 {% block registration_content %}
 
-<form method="post" action="">
+<form method="post" action="{{ request.path }}">
     {% csrf_token %}
 
     {% include "core/partials/non_field_errors.html" %}

--- a/src/nyc_trees/templates/registration/password_change_form.html
+++ b/src/nyc_trees/templates/registration/password_change_form.html
@@ -5,7 +5,7 @@
 {% block registration_title %}{% trans "Change password" %}{% endblock %}
 
 {% block registration_content %}
-<form method="post" action="">
+<form method="post" action="{{ request.path }}">
     {% csrf_token %}
 
     {% include "core/partials/non_field_errors.html" %}

--- a/src/nyc_trees/templates/registration/password_reset_confirm.html
+++ b/src/nyc_trees/templates/registration/password_reset_confirm.html
@@ -5,7 +5,7 @@
 
 {% block registration_content %}
 <p>{% trans "Enter your new password below to reset your password:" %}</p>
-<form method="post" action="">
+<form method="post" action="{{ request.path }}">
     {% csrf_token %}
 
     {% include "core/partials/non_field_errors.html" %}

--- a/src/nyc_trees/templates/registration/password_reset_form.html
+++ b/src/nyc_trees/templates/registration/password_reset_form.html
@@ -8,7 +8,7 @@
 <p>
     Forgot your password? Enter your TreesCount! username or email address and click the "Reset" button below.
 </p>
-<form method="post" action="">
+<form method="post" action="{{ request.path }}">
     {% csrf_token %}
 
     {% include "core/partials/non_field_errors.html" %}

--- a/src/nyc_trees/templates/registration/registration_form.html
+++ b/src/nyc_trees/templates/registration/registration_form.html
@@ -5,7 +5,7 @@
 {% block registration_title %}{% trans "Register" %}{% endblock %}
 
 {% block registration_content %}
-<form method="post" action="">
+<form method="post" action="{{ request.path }}">
     {% csrf_token %}
 
     {% include "core/partials/non_field_errors.html" %}


### PR DESCRIPTION
Various changes to produce W3C valid markup.

This only fixes errors, not warnings, and does not alter any flatpages
markup.

Summary of changes:

* Add alt attribute to images
* Add form actions
* Fix invalid element nesting (block level elems inside inline elems)
* Fix stray script tags (declare scripts inside body)
* Fix stray closing tags

Fixes #1415