### PR TITLE
Update gulp-ruby-sass and add autoprefixer

### DIFF
--- a/src/nyc_trees/gulpfile.js
+++ b/src/nyc_trees/gulpfile.js
@@ -199,10 +199,14 @@ function browserifyTask(bundler) {
 }
 
 gulp.task('sass', ['clean'], function() {
-    return gulp.src('sass/main.scss')
-        .pipe(sourcemaps.init())
-        .pipe(sass({style: 'compressed'}))
-        .pipe(sourcemaps.write('./'))
+    return sass('sass/main.scss', { sourcemap: true })
+        .on('error', function (err) {
+            console.error('Sass error', err.message);
+        })
+        .pipe(gulpif(! args.debug, postcss([csswring])))
+        .pipe(sourcemaps.write('./', {
+            includeContent: true,
+        }))
         .pipe(gulp.dest(cssDir));
 });
 

--- a/src/nyc_trees/gulpfile.js
+++ b/src/nyc_trees/gulpfile.js
@@ -24,7 +24,8 @@ var gulp = require('gulp'),
     del = require('del'),
     shell = require('gulp-shell'),
     runSequence = require('run-sequence'),
-    jshint = require('gulp-jshint');
+    jshint = require('gulp-jshint'),
+    autoprefixer = require('autoprefixer-core');
 
 var args = minimist(process.argv.slice(2),
                     {default: {debug: false}}),
@@ -199,11 +200,16 @@ function browserifyTask(bundler) {
 }
 
 gulp.task('sass', ['clean'], function() {
+    var autoprefixProcessor = autoprefixer({ browsers: ['> 1% in US'] });
+
     return sass('sass/main.scss', { sourcemap: true })
         .on('error', function (err) {
             console.error('Sass error', err.message);
         })
-        .pipe(gulpif(! args.debug, postcss([csswring])))
+        // For debug mode we just use autoprefixer, but for production mode we
+        // also minify our CSS with csswring
+        .pipe(gulpif(args.debug, postcss([autoprefixProcessor])))
+        .pipe(gulpif(! args.debug, postcss([autoprefixProcessor, csswring])))
         .pipe(sourcemaps.write('./', {
             includeContent: true,
         }))

--- a/src/nyc_trees/npm-shrinkwrap.json
+++ b/src/nyc_trees/npm-shrinkwrap.json
@@ -3597,70 +3597,41 @@
       }
     },
     "gulp-ruby-sass": {
-      "version": "0.7.1",
-      "from": "https://registry.npmjs.org/gulp-ruby-sass/-/gulp-ruby-sass-0.7.1.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-ruby-sass/-/gulp-ruby-sass-0.7.1.tgz",
+      "version": "1.0.5",
+      "from": "https://registry.npmjs.org/gulp-ruby-sass/-/gulp-ruby-sass-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-ruby-sass/-/gulp-ruby-sass-1.0.5.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+        "convert-source-map": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.0.tgz"
+        },
+        "dargs": {
+          "version": "2.1.0",
+          "from": "https://registry.npmjs.org/dargs/-/dargs-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-2.1.0.tgz"
+        },
+        "each-async": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            "onetime": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
-        "dargs": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/dargs/-/dargs-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/dargs/-/dargs-0.1.0.tgz"
-        },
-        "each-async": {
-          "version": "0.1.3",
-          "from": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
-        },
         "glob": {
-          "version": "4.3.1",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.1.tgz",
+          "version": "4.5.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -3680,9 +3651,9 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "version": "2.0.4",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -3717,274 +3688,315 @@
             }
           }
         },
-        "gulp-intermediate": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/gulp-intermediate/-/gulp-intermediate-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/gulp-intermediate/-/gulp-intermediate-3.0.1.tgz",
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
-            "gulp-util": {
-              "version": "2.2.20",
-              "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-              "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
-                "dateformat": {
-                  "version": "1.0.11",
-                  "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
                     "get-stdin": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
-                    },
-                    "meow": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
-                        "camelcase-keys": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                           "dependencies": {
-                            "camelcase": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                            },
-                            "map-obj": {
+                            "is-finite": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "indent-string": {
-                          "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
-                          "dependencies": {
-                            "repeating": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.0.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                                },
-                                "meow": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/meow/-/meow-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/meow/-/meow-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "minimist": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
-                        },
-                        "object-assign": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._reinterpolate": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
-                },
-                "lodash.template": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash.defaults": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._objecttypes": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.escape": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._escapehtmlchar": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._htmlescapes": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
-                            }
-                          }
-                        },
-                        "lodash._reunescapedhtml": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._htmlescapes": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                             }
                           }
                         }
                       }
-                    },
-                    "lodash._escapestringchar": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
-                    },
-                    "lodash.keys": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        },
-                        "lodash.isobject": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._objecttypes": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                            }
-                          }
-                        },
-                        "lodash._shimkeys": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._objecttypes": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "lodash.templatesettings": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
-                    },
-                    "lodash.values": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-                },
-                "multipipe": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-                  "dependencies": {
-                    "duplexer2": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "vinyl": {
-                  "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-                  "dependencies": {
-                    "clone-stats": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                     }
                   }
                 }
               }
             },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
             },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.5.0",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.5.0.tgz",
               "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.6",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.6.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.isnative": {
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.2.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.6",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.6.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.2.tgz"
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
                 }
               }
             },
-            "through2": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.3.2",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz"
+        },
+        "slash": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+        },
+        "vinyl-fs": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
+          "dependencies": {
+            "duplexify": {
+              "version": "3.3.0",
+              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.3.0.tgz",
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
                 "readable-stream": {
                   "version": "1.0.33",
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
@@ -4011,30 +4023,232 @@
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
-                },
-                "xtend": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                 }
               }
             },
-            "uuid": {
-              "version": "1.4.2",
-              "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
+            "glob-stream": {
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "2.0.2",
+                  "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "es6-set": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.7",
+                          "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                        },
+                        "event-emitter": {
+                          "version": "0.3.3",
+                          "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                        }
+                      }
+                    },
+                    "through2-filter": {
+                      "version": "1.4.1",
+                      "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-1.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-1.4.1.tgz",
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            },
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.6.2",
+                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "merge-stream": {
+              "version": "0.1.7",
+              "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.7.tgz"
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                },
+                "is-utf8": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                }
+              }
             }
           }
-        },
-        "slash": {
-          "version": "0.1.3",
-          "from": "https://registry.npmjs.org/slash/-/slash-0.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-0.1.3.tgz"
         },
         "win-spawn": {
           "version": "2.0.0",
           "from": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            }
+          }
         }
       }
     },

--- a/src/nyc_trees/npm-shrinkwrap.json
+++ b/src/nyc_trees/npm-shrinkwrap.json
@@ -2,6 +2,52 @@
   "name": "nyc-trees",
   "version": "0.0.0",
   "dependencies": {
+    "autoprefixer-core": {
+      "version": "5.1.11",
+      "from": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.11.tgz",
+      "dependencies": {
+        "browserslist": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz"
+        },
+        "num2fraction": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
+        },
+        "caniuse-db": {
+          "version": "1.0.30000148",
+          "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000148.tgz",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000148.tgz"
+        },
+        "postcss": {
+          "version": "4.0.6",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.8",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
+            }
+          }
+        }
+      }
+    },
     "bootstrap": {
       "version": "3.3.1",
       "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.1.tgz",
@@ -1268,24 +1314,113 @@
       }
     },
     "csswring": {
-      "version": "1.3.1",
-      "from": "https://registry.npmjs.org/csswring/-/csswring-1.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/csswring/-/csswring-1.3.1.tgz",
+      "version": "3.0.4",
+      "from": "https://registry.npmjs.org/csswring/-/csswring-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/csswring/-/csswring-3.0.4.tgz",
       "dependencies": {
+        "fs-extra": {
+          "version": "0.18.2",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "jsonfile": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.3.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "onecolor": {
-          "version": "2.4.2",
-          "from": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz"
+          "version": "2.5.0",
+          "from": "https://registry.npmjs.org/onecolor/-/onecolor-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.5.0.tgz"
         },
         "postcss": {
-          "version": "2.2.6",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-2.2.6.tgz",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-2.2.6.tgz",
+          "version": "4.1.6",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-4.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.6.tgz",
           "dependencies": {
+            "es6-promise": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz"
+            },
             "source-map": {
-              "version": "0.1.40",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+              "version": "0.4.2",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
@@ -1295,9 +1430,9 @@
               }
             },
             "js-base64": {
-              "version": "2.1.5",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz"
+              "version": "2.1.8",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
             }
           }
         }
@@ -3063,19 +3198,299 @@
       }
     },
     "gulp-postcss": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-2.0.1.tgz",
+      "version": "5.1.3",
+      "from": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-5.1.3.tgz",
       "dependencies": {
-        "postcss": {
-          "version": "2.2.6",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-2.2.6.tgz",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-2.2.6.tgz",
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.5.0",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.5.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.6",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.6.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.isnative": {
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.2.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.6",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.6.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.2.tgz"
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "postcss": {
+          "version": "4.1.6",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-4.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.6.tgz",
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz"
+            },
             "source-map": {
-              "version": "0.1.40",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+              "version": "0.4.2",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
@@ -3085,9 +3500,9 @@
               }
             },
             "js-base64": {
-              "version": "2.1.5",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz"
+              "version": "2.1.8",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
             }
           }
         },
@@ -3097,9 +3512,9 @@
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
-              "version": "0.1.40",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+              "version": "0.1.43",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",

--- a/src/nyc_trees/package.json
+++ b/src/nyc_trees/package.json
@@ -44,10 +44,11 @@
     "toastr": "^2.0.4"
   },
   "devDependencies": {
+    "autoprefixer-core": "^5.1.11",
     "browserify": "^9.0.4",
     "browserify-shim": "^3.8.3",
     "chai": "^1.10.0",
-    "csswring": "~1.3.0",
+    "csswring": "^3.0.4",
     "del": "^0.1.3",
     "factor-bundle": "^2.3.3",
     "gulp": "~3.8.8",
@@ -55,7 +56,7 @@
     "gulp-if": "~1.2.5",
     "gulp-jshint": "^1.9.0",
     "gulp-livereload": "~2.1.1",
-    "gulp-postcss": "~2.0.0",
+    "gulp-postcss": "^5.1.3",
     "gulp-rev-all": "~0.6.6",
     "gulp-ruby-sass": "^1.0.5",
     "gulp-shell": "^0.2.10",

--- a/src/nyc_trees/package.json
+++ b/src/nyc_trees/package.json
@@ -57,7 +57,7 @@
     "gulp-livereload": "~2.1.1",
     "gulp-postcss": "~2.0.0",
     "gulp-rev-all": "~0.6.6",
-    "gulp-ruby-sass": "~0.7.1",
+    "gulp-ruby-sass": "^1.0.5",
     "gulp-shell": "^0.2.10",
     "gulp-sourcemaps": "~1.2.4",
     "gulp-uglify": "~1.0.1",


### PR DESCRIPTION
- Update gulp-ruby-sass to 1.0.5 to fix sourcemap and minification support.
- Use autoprefixer to add vendor prefixes to CSS selectors and properties.

Sourcemaps were broken in the version of gulp-ruby-sass we were using
because it wanted us to serve the original files and would not allow us
to choose the path to serve them from.

Minification was not implemented in favor of using a "compressed"
outputStyle because we did not have sourcemap support and I wanted to
enable debugging production issues easily.

Minification doesn't get us much (33Kb uncompressed vs. 30Kb compressed),
but it was trivial to add.

I chose to use '>1% in US' as the browsers to support with autoprefixer, though it is trivial
to tweak this if we need to.

Bringing in the latest autoprefixer also required updating gulp-postcss
and csswring, since they all need to be using the same version of postcss,
and the latest version of autoprefixer requires postcss of 4.0+

Fixes #142
Fixes #1233