### PR TITLE
Patch the select2 library to fix a bug on some Android browsers

### DIFF
--- a/src/nyc_trees/js/shim/select2.js
+++ b/src/nyc_trees/js/shim/select2.js
@@ -2213,7 +2213,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             }));
 
-            selection.on("mousedown touchstart", "abbr", this.bind(function (e) {
+            selection.on("click touch", "abbr", this.bind(function (e) {
                 if (!this.isInterfaceEnabled()) {
                     return;
                 }
@@ -2227,7 +2227,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             }));
 
-            selection.on("mousedown touchstart", this.bind(function (e) {
+            selection.on("click touch", this.bind(function (e) {
                 // Prevent IE from generating a click event on the body
                 reinsertElement(selection);
 
@@ -2244,7 +2244,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 killEvent(e);
             }));
 
-            dropdown.on("mousedown touchstart", this.bind(function() {
+            dropdown.on("click touch", this.bind(function() {
                 if (this.opts.shouldFocusInput(this)) {
                     this.search.focus();
                 }


### PR DESCRIPTION
There is a known bug with the 3.x version of Select2 that causes the
dropdown menu to sometimes immediately close after opening:
https://github.com/select2/select2/issues/2300
https://github.com/select2/select2/issues/2061

This only seems to occur on firefox for Android and the default Android
browser.

It seems to have been fixed in the 4.0 version of Select2, which was
released 2 days ago, but there are a number of breaking changes, so I'm
wary of upgrading to it.

Instead, I'm bringing in a fix I found in a fork of of the library, which
seems to fix the issue without causing any other effects.

Connects to #885