### PR TITLE
Only allow user to select reserved blocks on survey page

### DIFF
--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -122,7 +122,13 @@ flag_survey = do(login_required,
 release_blockface = do(login_required,
                        route(POST=do(json_api_call, v.release_blockface)))
 
-blockface = route(GET=do(json_api_call, v.blockface))
+fetch_user_blockface = route(GET=individual_mapper_do(
+                             json_api_call, v.fetch_user_blockface))
+
+fetch_event_blockface = route(GET=do(
+                              login_required,
+                              group_request,
+                              json_api_call, v.fetch_event_blockface))
 
 redirect_to_treecorder = route(GET=do(login_required,
                                       v.redirect_to_treecorder))

--- a/src/nyc_trees/apps/survey/urls/blockface.py
+++ b/src/nyc_trees/apps/survey/urls/blockface.py
@@ -7,7 +7,7 @@ from django.conf.urls import patterns, url
 
 from apps.survey.routes import (
     reserve_blockface_page, reserve_blockfaces, reservations_instructions,
-    blockface, progress_page, blockface_reservations_confirmation_page,
+    progress_page, blockface_reservations_confirmation_page,
     progress_page_blockface_popup, printable_reservations_map,
     reservations_map_pdf_poll, user_reserved_blockfaces_geojson,
     group_borders_geojson, group_popup
@@ -40,11 +40,6 @@ urlpatterns = patterns(
 
     url(r'^checkout-confirmation/$', blockface_reservations_confirmation_page,
         name='blockface_reservations_confirmation_page'),
-
-    # Note: this must be kept in sync with the hardcoded url in
-    # js/src/mapUtil.js
-    url(r'^(?P<blockface_id>\d+)/$', blockface,
-        name='blockface'),
 
     url(r'^map-poll/$', reservations_map_pdf_poll,
         name='reservations_map_pdf_poll'),

--- a/src/nyc_trees/apps/survey/urls/survey.py
+++ b/src/nyc_trees/apps/survey/urls/survey.py
@@ -8,7 +8,8 @@ from django.conf.urls import patterns, url
 from apps.survey.routes import (survey, survey_from_event,
                                 flag_survey, survey_detail,
                                 confirm_survey, confirm_survey_from_event,
-                                release_blockface, redirect_to_treecorder)
+                                release_blockface, redirect_to_treecorder,
+                                fetch_user_blockface, fetch_event_blockface)
 
 
 # These URLs have the prefix 'survey/'
@@ -22,6 +23,15 @@ urlpatterns = patterns(
         confirm_survey_from_event, name='confirm_survey_from_event'),
 
     url(r'^treecorder/$', redirect_to_treecorder, name='treecorder'),
+
+    # Keep in sync with js/src/lib/mapUtil.js
+    url(r'^blockedge/(?P<blockface_id>\d+)/$', fetch_user_blockface,
+        name='fetch_user_blockface'),
+
+    # Keep in sync with js/src/lib/mapUtil.js
+    url(r'^(?P<group_slug>[\w-]+)/event/(?P<event_slug>[\w-]+)'
+        r'/blockedge/(?P<blockface_id>\d+)/$',
+        fetch_event_blockface, name='fetch_event_blockface'),
 
     # main endpoint (independent / from event)
     url(r'^$', survey, name='survey'),

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -422,12 +422,49 @@ def _get_reservations_to_cancel(ids, user):
         .current()
 
 
-def blockface(request, blockface_id):
+def fetch_user_blockface(request, blockface_id):
+    """Return blockface if user has reserved it"""
     blockface = get_object_or_404(Blockface, id=blockface_id)
+    reservation = BlockfaceReservation.objects.filter(
+                      blockface=blockface,
+                      user=request.user).current()
+
+    if reservation.exists():
+        return _blockface_context(blockface)
+
+    return {
+        'success': False,
+        'message': 'User has not reserved this blockface'
+    }
+
+
+def fetch_event_blockface(request, event_slug, blockface_id):
+    """Return blockface if it is part of this event"""
+    blockface = get_object_or_404(Blockface, id=blockface_id)
+    event = get_object_or_404(Event, slug=event_slug)
+
+    if not event.in_progress:
+        return {
+            'success': False,
+            'message': 'Event is not in progress'
+        }
+
+    if not Territory.objects.filter(group=request.group,
+                                    blockface=blockface).exists():
+        return {
+            'success': False,
+            'message': 'Blockface is not a part of this event'
+        }
+
+    return _blockface_context(blockface)
+
+
+def _blockface_context(blockface):
     return {
         'id': blockface.id,
         'extent': blockface.geom.extent,
-        'geojson': blockface.geom.geojson
+        'geojson': blockface.geom.geojson,
+        'success': True
     }
 
 

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -110,7 +110,9 @@ var dom = {
 
     formTemplate = Handlebars.compile($(dom.treeFormTemplate).html()),
 
-    blockfaceId = undefined,
+    // ID of currently selected blockface
+    blockfaceId,
+
     blockfaceMap = mapModule.create({
         legend: false,
         search: false,

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -110,7 +110,7 @@ var dom = {
 
     formTemplate = Handlebars.compile($(dom.treeFormTemplate).html()),
 
-    blockfaceId = mapUtil.getBlockfaceIdFromUrl(),
+    blockfaceId = undefined,
     blockfaceMap = mapModule.create({
         legend: false,
         search: false,
@@ -196,9 +196,21 @@ $(dom.btnToTeammate).click(function(e) {
     showSelectTeammate();
 });
 
-mapUtil.fetchBlockface(blockfaceId).done(function(blockface) {
-    selectedLayer.addBlockface(blockface);
-});
+// Keep this URL in sync with src/nyc_trees/apps/survey/urls/blockface.py
+$.getJSON("/blockedge/reserved-blockedges.json")
+    .then(function(data) {
+        var id = parseInt(mapUtil.getBlockfaceIdFromUrl(), 10);
+        for (var i = 0; i < data.length; i++) {
+            var item = data[i];
+            if (item.properties.id === id) {
+                return id;
+            }
+        }
+    }).then(function(blockfaceId) {
+        mapUtil.fetchBlockface(blockfaceId).done(function(blockface) {
+            selectedLayer.addBlockface(blockface);
+        });
+    });
 
 // There is no attribute for requiring "one or more" of a group of checkboxes to
 // be selected, so we have to handle it ourselves.

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -110,9 +110,7 @@ var dom = {
 
     formTemplate = Handlebars.compile($(dom.treeFormTemplate).html()),
 
-    // ID of currently selected blockface
-    blockfaceId,
-
+    blockfaceId = mapUtil.getBlockfaceIdFromUrl(),
     blockfaceMap = mapModule.create({
         legend: false,
         search: false,
@@ -198,21 +196,11 @@ $(dom.btnToTeammate).click(function(e) {
     showSelectTeammate();
 });
 
-// Keep this URL in sync with src/nyc_trees/apps/survey/urls/blockface.py
-$.getJSON("/blockedge/reserved-blockedges.json")
-    .then(function(data) {
-        var id = parseInt(mapUtil.getBlockfaceIdFromUrl(), 10);
-        for (var i = 0; i < data.length; i++) {
-            var item = data[i];
-            if (item.properties.id === id) {
-                return id;
-            }
-        }
-    }).then(function(blockfaceId) {
-        mapUtil.fetchBlockface(blockfaceId).done(function(blockface) {
-            selectedLayer.addBlockface(blockface);
-        });
+if (blockfaceId) {
+    mapUtil.fetchBlockface(blockfaceId).done(function(blockface) {
+        selectedLayer.addBlockface(blockface);
     });
+}
 
 // There is no attribute for requiring "one or more" of a group of checkboxes to
 // be selected, so we have to handle it ourselves.


### PR DESCRIPTION
This removes the ability to select any blockface on the survey page by
changing the blockface ID in the URL hash. The blockface present in the
URL hash will only be selected if the user has reserved that block.

Fixes #834