### PR TITLE
Prevent editing index fields via the Django admin site.

### DIFF
--- a/src/nyc_trees/apps/core/migrations/0027_auto_20150428_1529.py
+++ b/src/nyc_trees/apps/core/migrations/0027_auto_20150428_1529.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0026_merge'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='group',
+            name='territory_updated_at',
+            field=models.DateTimeField(db_index=True, null=True, editable=False, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -196,7 +196,7 @@ class Group(NycModel, models.Model):
     # change on any Territory rows, we record territory changes on the Group
     # and check the group when trying to find out the Territory cache buster
     territory_updated_at = models.DateTimeField(null=True, blank=True,
-                                                db_index=True)
+                                                db_index=True, editable=False)
 
     objects = models.GeoManager()
 

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -20,8 +20,9 @@ class Blockface(models.Model):
     source = models.CharField(max_length=255, default='unknown')
 
     # We can't use the NycModel mixin, because we want to add db indexes
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True, db_index=True)
+    created_at = models.DateTimeField(auto_now_add=True, editable=False)
+    updated_at = models.DateTimeField(auto_now=True, db_index=True,
+                                      editable=False)
 
     objects = models.GeoManager()
 

--- a/src/nyc_trees/libs/mixins.py
+++ b/src/nyc_trees/libs/mixins.py
@@ -7,8 +7,8 @@ from django.db import models
 
 
 class NycModel(models.Model):
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    created_at = models.DateTimeField(auto_now_add=True, editable=False)
+    updated_at = models.DateTimeField(auto_now=True, editable=False)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
It's unclear to me why Django won't pick up the changes to fields other than `Group.territory_updated_at` when I run `makemigrations`.  Since they do not reflect DB changes,
I am not overly worried about it.

Fixes #1413