### PR TITLE
Avoid unnecessary tiler requests

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/progress.html
+++ b/src/nyc_trees/apps/survey/templates/survey/progress.html
@@ -21,18 +21,21 @@
                            data-grid-url="{{ layer_all.grid_url }}"
                         >All Users</a>
                     </li>
-{% comment %}
-TODO: Uncomment before May 19
                     {% if request.user.is_authenticated %}
                     <li class="text-right" role="presentation">
-                        <a role="menuitem" href="#my"
-                           data-tile-url="{{ layer_my.tile_url }}"
-                           data-grid-url="{{ layer_my.grid_url }}"
-                           {% if bounds %}data-bounds="{{ bounds }}"{% endif %}
+                        <a role="menuitem" class="js-my-progress"
+                           {% if bounds %}
+                               href="#my"
+                               data-tile-url="{{ layer_my.tile_url }}"
+                               data-grid-url="{{ layer_my.grid_url }}"
+                               data-bounds="{{ bounds }}"
+                           {% else %}
+                               style="color: #bbb"
+                               title="Map a block edge to enable"
+                           {% endif %}
                         >My Progress</a>
                     </li>
                     {% endif %}
-{% endcomment %}
                     <li class="text-right" role="presentation">
                         <a role="menuitem" href="#group"
                            data-geojson-url="{% url 'group_borders' %}"

--- a/src/nyc_trees/js/src/adminTerritoryPage.js
+++ b/src/nyc_trees/js/src/adminTerritoryPage.js
@@ -89,7 +89,7 @@ function initAllLayers(blockDataAndTilerUrls) {
     }
     var blockDataList = blockDataAndTilerUrls.blockDataList,
         urls = blockDataAndTilerUrls.tilerUrls;
-    tileLayer = mapModule.addTileLayer(territoryMap, urls.tile_url);
+    tileLayer = mapModule.addTileLayer(territoryMap, { url: urls.tile_url });
     grid = mapModule.addGridLayer(territoryMap, { url: urls.grid_url });
 
     blockDataListForRevert = blockDataList;

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -81,8 +81,10 @@ function create(options) {
 function fitBounds(map, bounds) {
     // GeoDjango bounds are [xmin, ymin, xmax, ymax]
     // Leaflet wants [ [ymin, xmin], [ymax, xmax] ]
-    var b = [[bounds[1], bounds[0]], [bounds[3], bounds[2]]];
+    var b = [[bounds[1], bounds[0]], [bounds[3], bounds[2]]],
+        zooming = (map.getZoom() !== map.getBoundsZoom(b));
     map.fitBounds(b);
+    return zooming;
 }
 
 function isRetinaDevice() {
@@ -150,12 +152,14 @@ function hideCrosshairs() {
     $('.crosshair-x, .crosshair-y').hide();
 }
 
-function addTileLayer(map, url) {
-    var tileUrl = url || getDomMapAttribute('tile-url'),
+function addTileLayer(map, options) {
+    options = options || {};
+    var tileUrl = options.url || getDomMapAttribute('tile-url'),
         layer = L.tileLayer(tileUrl, {
             minZoom: zoom.MIN,
             maxZoom: zoom.MAX
-        }).addTo(map);
+        });
+    _addLayer(map, layer, options.waitForZoom);
     return layer;
 }
 
@@ -169,8 +173,26 @@ function addGridLayer(map, options) {
             crosshairs: options.crosshairs || false,
             pointerCursor: !options.crosshairs
         });
-    map.addLayer(layer);
+    _addLayer(map, layer, options.waitForZoom);
     return layer;
+}
+
+function _addLayer(map, layer, waitForZoom) {
+    if (waitForZoom) {
+        _addAfterZoom(map, layer);
+    } else {
+        map.addLayer(layer);
+    }
+}
+
+function _addAfterZoom(map, layer) {
+    // Add layer to map after zoom animation completes.
+    // (Otherwise spurious tile requests will be issued at the old zoom level.)
+    function addLayer() {
+        map.addLayer(layer);
+        map.off('zoomend', addLayer);
+    }
+    map.on('zoomend', addLayer);
 }
 
 function getDomMapAttribute(dataAttName, domId) {

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -42,8 +42,11 @@ function onModeChanged(e) {
         return;
     }
     $mode = $(e.currentTarget);
+    if ($mode.hasClass('js-my-progress') && !$mode.attr('href')) {
+        return;
+    }
 
-    // Shown chosen mode on dropdown button
+    // Show chosen mode on dropdown button
     $mode.parents(dom.modeDropdown).find(dom.modeButton).text($mode.text());
 
     // Show appropriate legend entries

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -77,13 +77,7 @@ function loadLayers($mode) {
         progressMap.removeLayer(geojsonLayer);
     }
     if (tileUrl) {
-        tileLayer = mapModule.addTileLayer(progressMap, tileUrl);
-
-        createSelectableLayer();
-
-        if (bounds) {
-            mapModule.fitBounds(progressMap, bounds);
-        }
+        addLayers(bounds, tileUrl, gridUrl);
     }
     if (geojsonUrl) {
         $.getJSON(geojsonUrl, function(geojson) {
@@ -91,19 +85,17 @@ function loadLayers($mode) {
                 style: function() {
                     return {
                         color: '#36b5db',
-                        weight: 3,
+                        weight: 3
                     };
                 },
                 onEachFeature: function(feature, layer) {
                     layer.on('click', function showGroupBlockfaces() {
                         progressMap.removeLayer(tileLayer);
 
-                        tileLayer = mapModule.addTileLayer(progressMap, feature.properties.tileUrl);
+                        var p = feature.properties;
+                        addLayers(p.bounds, p.tileUrl, p.gridUrl);
 
-                        createSelectableLayer();
-
-                        mapModule.fitBounds(progressMap, feature.properties.bounds);
-                        $actionBar.load(feature.properties.popupUrl);
+                        $actionBar.load(p.popupUrl);
                         $('body').addClass('actionbar-triggered');
                     });
                 }
@@ -111,6 +103,19 @@ function loadLayers($mode) {
             geojsonLayer.addTo(progressMap);
         });
     }
+}
+
+function addLayers(bounds, tileUrl, gridUrl) {
+    var zooming = false;
+    if (bounds) {
+        zooming = mapModule.fitBounds(progressMap, bounds);
+    }
+    tileLayer = mapModule.addTileLayer(progressMap, {
+        url: tileUrl,
+        waitForZoom: zooming
+    });
+
+    createSelectableLayer();
 }
 
 function createSelectableLayer() {


### PR DESCRIPTION
Fixes #1491 
Fixes #1494

These map pages were generating spurious tiler requests (fixed by this PR):
* Progress - My Progress
* Progress - Groups

These were fine:
* Group Detail
* Event PDF
* Reservations
* Reservations PDF
* Treecorder
* Admin Territory

