### PR TITLE
Add missing brace to _globals.scss

### DIFF
--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -431,6 +431,7 @@ aside {
   padding: 6px 10px !important;
   &:hover {
     background-color: #eee;
+  }
 }
 
 .clear {


### PR DESCRIPTION
Git blame makes me think this brace was a victim of a funky merge commit.

Fixes #1499 