### PR TITLE
Remove progress UTF grid, add fetch by lat/lng

### DIFF
--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -124,6 +124,8 @@ release_blockface = do(login_required,
 
 blockface = route(GET=do(json_api_call, v.blockface))
 
+blockface_near_point = route(GET=do(json_api_call, v.blockface_near_point))
+
 redirect_to_treecorder = route(GET=do(login_required,
                                       v.redirect_to_treecorder))
 

--- a/src/nyc_trees/apps/survey/urls/blockface.py
+++ b/src/nyc_trees/apps/survey/urls/blockface.py
@@ -10,7 +10,7 @@ from apps.survey.routes import (
     blockface, progress_page, blockface_reservations_confirmation_page,
     progress_page_blockface_popup, printable_reservations_map,
     reservations_map_pdf_poll, user_reserved_blockfaces_geojson,
-    group_borders_geojson, group_popup
+    group_borders_geojson, group_popup, blockface_near_point
 )
 
 
@@ -35,6 +35,8 @@ urlpatterns = patterns(
     # src/nyc_trees/js/src/progressPage.js
     url(r'^(?P<blockface_id>\d+)/progress-page-blockedge-popup/$',
         progress_page_blockface_popup, name='progress_blockface_popup'),
+
+    url(r'^near/$', blockface_near_point, name='blockface_near_point'),
 
     url(r'^checkout/$', reserve_blockfaces, name='reserve_blockfaces'),
 

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -11,13 +11,13 @@ from pytz import timezone
 from celery import chain
 
 from django.conf import settings
-from django.contrib.gis.geos import GeometryCollection
+from django.contrib.gis.geos import Point, GeometryCollection
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.urlresolvers import reverse
 from django.db import transaction, connection
 from django.db.models import Prefetch
 from django.http import (HttpResponse, HttpResponseForbidden,
-                         HttpResponseBadRequest)
+                         HttpResponseBadRequest, Http404)
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.timezone import now
 
@@ -420,13 +420,34 @@ def _get_reservations_to_cancel(ids, user):
         .current()
 
 
-def blockface(request, blockface_id):
-    blockface = get_object_or_404(Blockface, id=blockface_id)
+def _blockface_context(blockface):
     return {
         'id': blockface.id,
         'extent': blockface.geom.extent,
         'geojson': blockface.geom.geojson
     }
+
+
+def blockface(request, blockface_id):
+    blockface = get_object_or_404(Blockface, id=blockface_id)
+    return _blockface_context(blockface)
+
+
+def blockface_near_point(request):
+    p = Point(float(request.GET.get('lng', 0)),
+              float(request.GET.get('lat', 0)),
+              srid=4326)
+
+    # The size of the distance filter was chosen through trial and
+    # error by testing tap precision on a mobile device
+    qs = Blockface.objects.filter(geom__dwithin=(p, 0.0002))\
+                          .distance(p)\
+                          .order_by('distance')
+    blockfaces = qs[:1]  # We only want the closest blockface
+    if blockfaces:
+        return _blockface_context(blockfaces[0])
+    else:
+        raise Http404
 
 
 def _validate_event_and_group(request, event_slug):

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -17,7 +17,7 @@ from django.core.urlresolvers import reverse
 from django.db import transaction, connection
 from django.db.models import Prefetch
 from django.http import (HttpResponse, HttpResponseForbidden,
-                         HttpResponseBadRequest, Http404)
+                         HttpResponseBadRequest)
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.timezone import now
 
@@ -447,7 +447,9 @@ def blockface_near_point(request):
     if blockfaces:
         return _blockface_context(blockfaces[0])
     else:
-        raise Http404
+        return {
+            'error': 'Block edge not found near lat:%f lon:%f' % (p.y, p.x)
+        }
 
 
 def _validate_event_and_group(request, event_slug):

--- a/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
+++ b/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
@@ -50,26 +50,37 @@ module.exports = BlockfaceLayer.extend({
             });
         };
 
-        grid.on('click', function(e) {
-            if (self.clicksEnabled) {
-                self.addBlockface(e.data, e.latlng);
-            }
-        });
+        if (grid) {
+            grid.on('click', function(e) {
+                if (self.clicksEnabled) {
+                    self.addBlockface(e.data, e.latlng);
+                }
+            });
+        } else {
+            map.on('click', function(e) {
+                if (self.clicksEnabled) {
+                    self.addBlockface(null, e.latlng);
+                }
+            });
+        }
     },
 
     addBlockface: function(data, latlng) {
-        var self = this;
-        if (!data || !data.id) {
-            return;
-        }
+        var self = this,
+            fetch;
         if (self.options.onAdd(data, latlng)) {
-            mapUtil.fetchBlockface(data.id).then(function(blockfaceData) {
+            if (data && data.id) {
+                fetch = mapUtil.fetchBlockface(data.id);
+            } else {
+                fetch = mapUtil.fetchBlockfaceNearLatLng(latlng);
+            }
+            fetch.then(function(blockfaceData) {
                 if (blockfaceData && blockfaceData.geojson) {
                     var geom = mapUtil.parseGeoJSON(blockfaceData.geojson);
                     self.addData({
                         "type": "Feature",
                         "geometry": geom,
-                        "properties": data
+                        "properties": data || { id: blockfaceData.id }
                     });
                 }
             });

--- a/src/nyc_trees/js/src/lib/mapUtil.js
+++ b/src/nyc_trees/js/src/lib/mapUtil.js
@@ -27,6 +27,9 @@ function getLatLngs(geom) {
 }
 
 function blockfaceResponseToFetchResult(blockface) {
+    if (blockface.error) {
+        return blockface;
+    }
     var e = blockface.extent,
         sw = L.latLng(e[1], e[0]),
         ne = L.latLng(e[3], e[2]),


### PR DESCRIPTION
It is expensive to render UTF grids for the entire city. This commit removes the grid layer from the progress page, and keeps the click-to-select functionality by adding an endpoint that fetches the feature closest to a point.

Connects to #1492 
