### PR TITLE
Update language in reservation confirmation screens

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/blockface_cart.html
+++ b/src/nyc_trees/apps/survey/templates/survey/blockface_cart.html
@@ -7,33 +7,46 @@
 {% block main %}
     <h3>Confirm</h3>
     {% if num_reserved > 0 %}
-    <p>You have requested {{ num_reserved }} block edge reservation{{ num_reserved|pluralize }}.</p>
+    <p>You are adding {{ num_reserved }} block edge reservation{{ num_reserved|pluralize }}.</p>
     {% endif %}
 
     {% if num_cancelled > 0 %}
     <p>You are cancelling {{ num_cancelled }} block edge reservation{{ num_cancelled|pluralize }}.</p>
     {% endif %}
 
-    <p>Indicate whether you will be using the app or paper worksheets to collect data on these block edges. Click the “Confirm Blocks” button to finalize your reservation.</p>
-
     <form method="post" action="{% url 'blockface_reservations_confirmation_page' %}">
         {% csrf_token %}
+
         <input type="hidden" name="ids" value="{{ blockface_ids }}" />
 
-        <h4>How will you map these blocks?</h4>
-        <label>
-            <input type="radio" name="is_mapping_with_paper" value="False" checked="checked" />
-            Mobile App
-        </label>
-        <p>Map blocks online using the Treecorder! Just log in as usual into the TreesCount! Web App.</p>
+        {% if num_reserved > 0 %}
+            <p>Indicate whether you will be using the app or paper worksheets to collect data
+                on {{ num_reserved|pluralize:"this block edge,these block edges" }}.
+                Click the “Confirm” button to finalize your reservation.</p>
 
-        <label>
-            <input type="radio" name="is_mapping_with_paper" value="True" />
-            Paper Worksheets
-        </label>
-        <p>You will be emailed a data collection worksheet to print at home. After you have collected data on the block edges you have reserved, login to the TreesCount! Web App to enter the information online into the Treecorder.</p>
+            <h4>How will you map {{ num_reserved|pluralize:"this block edge,these block edges" }}?</h4>
+            <label>
+                <input type="radio" name="is_mapping_with_paper" value="False" checked="checked" />
+                Mobile App
+            </label>
+            <p>Map online using the Treecorder! Just log in as usual into the TreesCount! Web App.</p>
 
-        <a href="{% url 'reservations' %}">Cancel</a>
-        <input type="submit" value="Confirm Blocks" class="btn btn-primary pull-right" />
+            <label>
+                <input type="radio" name="is_mapping_with_paper" value="True" />
+                Paper Worksheets
+            </label>
+            <p>You will be emailed a data collection worksheet to print at home. After you have collected data on the block edges you have reserved, login to the TreesCount! Web App to enter the information online into the Treecorder.</p>
+
+            <a href="{% url 'reservations' %}">Cancel</a>
+            <input type="submit" value="Confirm" class="btn btn-primary pull-right" />
+
+        {% else %}
+            <p>Are you sure?</p>
+            <a class="btn btn-default" href="{% url 'reservations' %}">No, don't cancel</a>
+            <input type="submit" value="Yes, cancel" class="btn btn-primary pull-right" />
+        {% endif %}
+
     </form>
+
+
 {% endblock main %}

--- a/src/nyc_trees/apps/survey/templates/survey/reserve_blockface_confirmation.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reserve_blockface_confirmation.html
@@ -7,33 +7,52 @@
 {% endblock aside %}
 
 {% block main %}
-    <h3>Blocks Reserved</h3>
-    {% if blockfaces_requested == blockfaces_reserved %}
-
-    <p>Your block edges were successfully reserved!
-        Check your inbox for your reservation confirmation.</p>
-
-    <p>You can start mapping the trees on these blocks whenever you are ready.
-        Remember to contact a Loaning Hub to reserve mapping gear!</p>
-
-    {% elif blockfaces_requested > blockfaces_reserved %}
-
-    <p>
-      You requested {{ blockfaces_requested }} block edge{{blockfaces_requested|pluralize }},
-      but we could only reserve {{ blockfaces_reserved }} block edge{{ blockfaces_reserved|pluralize }} for you.
-    </p>
-
-    <p>Check the <a href="{% url 'reservations' %}">Reservations Page</a> to see which block edges you have reserved.</p>
-    {% endif %}
-    {% if blockfaces_cancelled %}
-    <p>
-      Per your request, {{ blockfaces_cancelled }} of your block edge
-      reservation{{ blockfaces_cancelled|pluralize }} were cancelled.
-    </p>
+    {% if n_reserved %}
+        <h3>Block Edge{{ n_requested|pluralize }} Reserved</h3>
+    {% elif n_cancelled %}
+        <h3>Block Edge{{ n_cancelled|pluralize }} Cancelled</h3>
+    {% else %}
+        <h3>No Changes</h3>
     {% endif %}
 
-    <p>These blocks will be reserved for you until <b>{{ expiration_date|date }}</b>.</p>
+    {% if n_requested %}
+        {% if n_requested == n_reserved %}
 
-    <a class="btn btn-primary" href="{% url 'survey' %}">Start Mapping</a>
+            <p>Your block edge{{ n_reserved|pluralize:" was,s were" }} successfully reserved!
+                Check your inbox for your reservation confirmation.</p>
+
+            <p>You can start mapping the trees on
+                {{ n_reserved|pluralize:"this block edge,these block edges" }}
+                whenever you are ready.
+                Remember to contact a Loaning Hub to reserve mapping gear!</p>
+
+        {% else %}
+
+            <p>
+                You requested {{ n_requested }} block edge{{ n_requested|pluralize }},
+                but we could only reserve {{ n_reserved }}
+                block edge{{ n_reserved|pluralize }} for you.
+            </p>
+
+            <p>Check the <a href="{% url 'reservations' %}">Reservations Page</a> to see which block edges you have reserved.</p>
+
+        {% endif %}
+
+        {% if n_reserved %}
+            <p>{{ n_reserved|pluralize:"This block edge,These block edges" }}
+                will be reserved for you until <b>{{ expiration_date|date }}</b>.</p>
+        {% endif %}
+    {% endif %}
+
+    {% if n_cancelled %}
+        <p>
+          Per your request, {{ n_cancelled }} of your block edge
+          reservations {{ n_cancelled|pluralize:"was,were" }} cancelled.
+        </p>
+    {% endif %}
+
+    {% if n_reserved %}
+        <a class="btn btn-primary" href="{% url 'survey' %}">Start Mapping</a>
+    {% endif %}
 
 {% endblock main %}

--- a/src/nyc_trees/apps/survey/tests.py
+++ b/src/nyc_trees/apps/survey/tests.py
@@ -148,10 +148,10 @@ class ConfirmBlockfaceReservationTests(SurveyTestCase):
             'ids': ids, 'is_mapping_with_paper': 'False'}, method="POST")
 
         context = confirm_blockface_reservations(req)
-        self.assertIn('blockfaces_requested', context)
-        self.assertIn('blockfaces_reserved', context)
+        self.assertIn('n_requested', context)
+        self.assertIn('n_reserved', context)
         self.assertIn('expiration_date', context)
-        self.assertEqual(num, context['blockfaces_reserved'])
+        self.assertEqual(num, context['n_reserved'])
 
     def test_can_reserve_available_block(self):
         self.assert_blocks_reserved(1, self.block)
@@ -165,7 +165,7 @@ class ConfirmBlockfaceReservationTests(SurveyTestCase):
         reservation = BlockfaceReservation.objects.get(blockface=self.block)
         self.assertEqual(self.user.pk, reservation.user_id)
 
-        self.assert_blocks_reserved(2, self.block, self.block2)
+        self.assert_blocks_reserved(1, self.block2)
 
         self.assertEqual(1, BlockfaceReservation.objects
                          .filter(blockface=self.block).count())


### PR DESCRIPTION
* Pages now make sense if you cancel blocks without reserving any
* Language now reflects **new** rather than **all** reservations
* Make language consistent for 1 vs. more than one block
* Refer to "block edges" instead of "blocks"

Fixes #1265

# *Add 1 block edge:*
![add1a](https://cloud.githubusercontent.com/assets/2162993/7415606/1a9551d8-ef28-11e4-9fcf-b85e18a919fa.PNG)
![add1b](https://cloud.githubusercontent.com/assets/2162993/7415609/1a9705b4-ef28-11e4-8bf7-82c655fab133.PNG)
# *Cancel 1 block edge:*
![cancel1a](https://cloud.githubusercontent.com/assets/2162993/7415610/1a973804-ef28-11e4-8bd2-a61836bed706.PNG)
![cancel1b](https://cloud.githubusercontent.com/assets/2162993/7415611/1a9cdb1a-ef28-11e4-9248-4e7aa3bd3e1b.PNG)
# *Add 2, cancel 2:*
![add2cancel2a](https://cloud.githubusercontent.com/assets/2162993/7415608/1a95df5e-ef28-11e4-971f-f08ce19a3aa0.PNG)
![add2cancel2b](https://cloud.githubusercontent.com/assets/2162993/7415607/1a9562ea-ef28-11e4-9904-05daf0f34dc9.PNG)
