### PR TITLE
Stop modifying training pages during setup

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -28,9 +28,6 @@ if ! envdir /etc/nyc-trees.d/env /opt/app/manage.py flag -l | grep full_access; 
     envdir /etc/nyc-trees.d/env /opt/app/manage.py flag full_access --create
 fi
 
-# Create training flatpages
-envdir /etc/nyc-trees.d/env /opt/app/manage.py make_training_flatpages || true
-
 # If a domain is not provided, default to treescount.nycgovparks.org
 DJANGO_SITE_DOMAIN=${DJANGO_SITE_DOMAIN:-treescount.nycgovparks.org}
 


### PR DESCRIPTION
Now that this app is live, there's not ever going to be a case where we
want to load training pages from version control without a one-off
manual review. This line could now only hurt us.