### PR TITLE
Fix styling on surveyed blocks

### DIFF
--- a/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
+++ b/src/nyc_trees/js/src/lib/SelectableBlockfaceLayer.js
@@ -52,7 +52,7 @@ module.exports = BlockfaceLayer.extend({
 
         if (grid) {
             grid.on('click', function(e) {
-                if (self.clicksEnabled) {
+                if (self.clicksEnabled && e.data) {
                     self.addBlockface(e.data, e.latlng);
                 }
             });

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -19,7 +19,8 @@
   CASE
     WHEN NOT block.is_available THEN 'unavailable'
     WHEN (core_group.id IS NOT NULL
-          AND NOT core_group.allows_individual_mappers) THEN 'unavailable'
+          AND NOT core_group.allows_individual_mappers
+          AND NOT core_group.admin_id = <%= user_id %>) THEN 'unavailable'
     WHEN reservation.id IS NOT NULL AND reservation.user_id <> <%= user_id %> THEN 'reserved'
     -- Designate as "group_territory" if block belongs to a group and the user
     -- is neither a trusted mapper nor a group admin.

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -12,7 +12,8 @@
     -- 'available'.  We use a GeoJSON layer in the UI for the user's
     -- reserved blockfaces, and when a blockface is deselected we want to
     -- be able to reselect it
-    WHEN reservation.user_id IS NOT DISTINCT FROM <%= user_id %> THEN 'available'
+    WHEN (block.is_available
+          AND reservation.user_id IS NOT DISTINCT FROM <%= user_id %>) THEN 'available'
     ELSE 'unavailable'
   END AS survey_type,
   CASE

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -21,18 +21,13 @@
     WHEN (core_group.id IS NOT NULL
           AND NOT core_group.allows_individual_mappers) THEN 'unavailable'
     WHEN reservation.id IS NOT NULL AND reservation.user_id <> <%= user_id %> THEN 'reserved'
-    -- We should only allow requesting access to active groups that you are
-    -- not already a trusted mapper or admin of
+    -- Designate as "group_territory" if block belongs to a group and the user
+    -- is neither a trusted mapper nor a group admin.
+    -- Don't filter out inactive groups or else non trusted mappers will be
+    -- able to reserve blocks in the "expert" group.
     WHEN (turf.id IS NOT NULL
-          AND (core_group.is_active = TRUE
-               AND trustedmapper.id IS NULL
-               AND core_group.admin_id <> <%= user_id %>)) THEN 'group_territory'
-    -- If a group is inactive, it is unavailable unless you are an admin or
-    -- a trusted mapper of that group
-    WHEN (turf.id IS NOT NULL
-          AND core_group.is_active = FALSE
           AND trustedmapper.id IS NULL
-          AND core_group.admin_id <> <%= user_id %>) THEN 'unavailable'
+          AND core_group.admin_id <> <%= user_id %>) THEN 'group_territory'
     ELSE 'none'
   END AS restriction
   FROM survey_blockface AS block

--- a/src/tiler/sql/user_reservable.sql
+++ b/src/tiler/sql/user_reservable.sql
@@ -17,10 +17,10 @@
     ELSE 'unavailable'
   END AS survey_type,
   CASE
-    WHEN reservation.id IS NOT NULL AND reservation.user_id <> <%= user_id %> THEN 'reserved'
+    WHEN NOT block.is_available THEN 'unavailable'
     WHEN (core_group.id IS NOT NULL
           AND NOT core_group.allows_individual_mappers) THEN 'unavailable'
-    WHEN NOT block.is_available THEN 'unavailable'
+    WHEN reservation.id IS NOT NULL AND reservation.user_id <> <%= user_id %> THEN 'reserved'
     -- We should only allow requesting access to active groups that you are
     -- not already a trusted mapper or admin of
     WHEN (turf.id IS NOT NULL

--- a/src/tiler/sql/user_reservations.sql
+++ b/src/tiler/sql/user_reservations.sql
@@ -6,7 +6,8 @@
   CASE
     WHEN block.is_available AND reservation.user_id = <%= user_id %> THEN 'available'
     ELSE 'unavailable'
-  END as survey_type
+  END as survey_type,
+  'none' as restriction
   FROM survey_blockface AS block
   LEFT OUTER JOIN survey_blockfacereservation AS reservation
     ON (block.id = reservation.blockface_id

--- a/src/tiler/style/default.mss
+++ b/src/tiler/style/default.mss
@@ -33,4 +33,9 @@
   [survey_type = 'unavailable'] {
     line-color: @unavailable;
   }
+
+  /* restriction rules must come after the survey_type rules so they can override styling */
+  [restriction = 'unavailable'] {
+    line-color: @unavailable;
+  }
 }


### PR DESCRIPTION
This fix ensures that blocks do not appear as available on the
reservations page after they have been surveyed.

Connects #1247