### PR TITLE
Remove zoom buttons on mobile

### DIFF
--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -208,6 +208,14 @@
 }
 
 @media (max-width: $screen-sm - 1) {
+  .leaflet-control-zoom-out, .leaflet-control-zoom-in {
+    display: none !important;
+  }
+  .geolocate-button {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom: none;
+  }
   .pageheading-description-detail {
     .tab-status-map-tab & {
       display: none;


### PR DESCRIPTION
Fixes #1522. The zoom buttons on mobile are not needed because users pinch to zoom. Nobody in user testing clicked on the zoom buttons to zoom. By having fewer buttons, we can better emphasize the geolocate and search buttons.

![image](https://cloud.githubusercontent.com/assets/1809908/7437038/9e8fdd38-f021-11e4-81a2-6f8dc0746b20.png)
