### PR TITLE
Add includes_training field to event feed

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -205,6 +205,12 @@ def events_list_feed(request):
     events = Event.objects.order_by('-begins_at').filter(is_private=False,
                                                          group__is_active=True)
 
+    includes_training = request.GET.get('includes_training', '').lower()
+    if includes_training == 'true':
+        events = events.filter(includes_training=True)
+    elif includes_training == 'false':
+        events = events.filter(includes_training=False)
+
     return [{
         'id': e.id,
         'name': e.title,
@@ -212,6 +218,7 @@ def events_list_feed(request):
         'start_time': e.begins_at.time(),
         'end_time': e.ends_at.time(),
         'description': e.description,
+        'includes_training': e.includes_training,
         'snippet': e.description[:169],
         'email': e.contact_email,
         'locations': [{


### PR DESCRIPTION
This change adds the `includes_training` field to the event feed and
also adds the ablilty to filter the feed by adding querystring arguments.

To show training events:

    /event/feed/?includes_training=True

To show mapping events:

    /event/feed/?includes_training=False

To show all events (omit querystring):

    /event/feed/

You can only filter by the includes_training field for now.

Connects #1457