### PR TITLE
Add conditional for no reservations on dashboard

### DIFF
--- a/src/nyc_trees/apps/users/templates/users/partials/profile/reservations.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/reservations.html
@@ -23,6 +23,8 @@
 
 {% if reservations.count > 0 %}
     {% include "core/partials/polling_download_section.html" with poll_url=reservations.map_poll_url %}
+{% else %}
+    Ready to map on your own as an independent volun<b>treer</b>? <a href="{{ reservations_url }}">Reserve available block edges</a> for mapping!
 {% endif %}
 
 {% endblock section_content %}


### PR DESCRIPTION
Fixes #1523. Now help text is displayed under reservations when there are no active reservations.

![image](https://cloud.githubusercontent.com/assets/1809908/7464220/f356c6aa-f28e-11e4-903c-b12c1b3f9191.png)
