### PR TITLE
Add swapfiles to both services and app VMs

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/meta/main.yml
+++ b/deployment/ansible/roles/nyc-trees.app/meta/main.yml
@@ -8,3 +8,4 @@ dependencies:
   - { role: "azavea.sauce-connect", when: sauce_labs_api_key_is_defined }
   - { role: "nyc-trees.monitoring", collectd_prefix: "collectd.app.", when: "['test'] | is_not_in(group_names)" }
   - { role: "nyc-trees.celery" }
+  - { role: "azavea.swapfile", when: "['development', 'test'] | some_are_in(group_names)" }

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -17,3 +17,4 @@
     - { role: "nyc-trees.logstash", when: "['test'] | is_not_in(group_names)" }
     - { role: "nyc-trees.tasseo", when: "['test'] | is_not_in(group_names)" }
     - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }
+    - { role: "azavea.swapfile", when: "['development', 'test'] | some_are_in(group_names)" }


### PR DESCRIPTION
We have been seeing out-of-memory issues on the redis server when handling
DB requests, and on the app server when building the production bundle
with `npm run build`.

Adding a swapfile should fix both issues.

Fixes #1555