### PR TITLE
When showing blockface popup, auto-pan map to avoid sidebar

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/partials/legend.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/legend.html
@@ -13,7 +13,7 @@
                 {% block legend_text %}
                 {% endblock %}
                 </div>
-                <h5>Legend</h5>
+                <h5 class="js-legend-title">Legend</h5>
                 {% for entry in legend_entries %}
                     <div class="entry {% if entry.mode != legend_mode %}hidden{% endif%}" data-mode="{{ entry.mode }}">
                         <div class="swatch {{ entry.css_class }}"></div>

--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -44,6 +44,9 @@ var $ = require('jquery'),
         blockActionPopupContainer: '#reservations-blockface-popup-container',
         blockActionBarClose: '#close-blockface-action',
 
+        legendTitle: '.js-legend-title',
+        mapSidebar: '.map-sidebar',
+
         popupTemplate: '#reservations-blockface-popup-template',
         popupBlockfaceId: '[' + attrs.blockfaceId + ']',
         popupBlockfaceStatus: '[' + attrs.blockfaceStatus + ']',
@@ -101,7 +104,7 @@ var selectedLayer = new SelectableBlockfaceLayer(reservationMap, grid, {
     }
 });
 
-// Zoom the map to fit a blockface ID pased in the URL hash, if it is an
+// Zoom the map to fit a blockface ID passed in the URL hash, if it is an
 // already reserved block
 var blockfaceId = mapUtil.getBlockfaceIdFromUrl();
 
@@ -164,13 +167,24 @@ function showPopup(blockfaceId, latlng, status, action) {
     $popup.find(dom.popupAction).attr(attrs.blockfaceAction, action).html(action);
 
     // We add the blockface popup in 2 places, as a leaflet popup and as an
-    // action bar item
-    // CSS media queries will hide one or the other depending on screen size
-    L.popup({className: 'reservation-leaflet-popup'})
-        .setLatLng(latlng)
-        .setContent($popup[0])
-        .openOn(reservationMap);
+    // action bar item.
+    // CSS media queries will hide one or the other depending on screen size.
 
+    // But we don't want invisible popups to auto-pan the map in "mobile" view,
+    // so only add the popup if we are in "desktop" view -- determined by
+    // whether the legend is visible.
+    if ($(dom.legendTitle).length > 0) {
+        // Find right edge of sidebar so we can make the popup avoid it
+        var $sidebar = $(dom.mapSidebar),
+            sidebarRight = $sidebar.offset().left + $sidebar.outerWidth();
+        L.popup({
+            className: 'reservation-leaflet-popup',
+            autoPanPaddingTopLeft: [sidebarRight + 8, 8]
+        })
+            .setLatLng(latlng)
+            .setContent($popup[0])
+            .openOn(reservationMap);
+    }
     $(dom.blockActionBar).addClass('active');
     $(dom.blockActionPopupContainer).html($popup.clone());
     $(dom.cartActionBar).removeClass('active');

--- a/src/nyc_trees/js/src/reserveBlockfacePage.js
+++ b/src/nyc_trees/js/src/reserveBlockfacePage.js
@@ -135,14 +135,18 @@ var cartLayer = new BlockfaceLayer(reservationMap, {
     onEachFeature: function(feature, layer) {
         layer.on('click', function(e) {
             showPopup(feature.properties.id, e.latlng, 'In Cart', actions.remove);
-            blockfaceLayers[feature.properties.id] = layer;
-            selectedLayer.addData(feature);
+            selectFeature(feature, layer);
         });
     }
 });
 
 function selectReservedBlockface(feature, layer, latlng) {
     showPopup(feature.properties.id, latlng, 'Expires ' + feature.properties.expires_at, actions.remove);
+    selectFeature(feature, layer);
+}
+
+function selectFeature(feature, layer) {
+    selectedLayer.clearLayers();
     blockfaceLayers[feature.properties.id] = layer;
     selectedLayer.addData(feature);
 }
@@ -173,7 +177,7 @@ function showPopup(blockfaceId, latlng, status, action) {
     // But we don't want invisible popups to auto-pan the map in "mobile" view,
     // so only add the popup if we are in "desktop" view -- determined by
     // whether the legend is visible.
-    if ($(dom.legendTitle).length > 0) {
+    if ($(dom.legendTitle + ':visible').length > 0) {
         // Find right edge of sidebar so we can make the popup avoid it
         var $sidebar = $(dom.mapSidebar),
             sidebarRight = $sidebar.offset().left + $sidebar.outerWidth();


### PR DESCRIPTION
Also fixes a problem where auto-panning was happening in "mobile" view when you selected a blockface even though no popup was shown.

Connects #1349 
