### PR TITLE
Change URLs to accept all valid usernames

### DIFF
--- a/src/nyc_trees/apps/event/urls/group.py
+++ b/src/nyc_trees/apps/event/urls/group.py
@@ -48,7 +48,7 @@ urlpatterns = patterns(
         event_user_check_in_poll, name='event_user_check_in_poll'),
 
     url(r'^(?P<group_slug>[\w-]+)/event/'
-        r'(?P<event_slug>[\w-]+)/checkin/(?P<username>[^/]+)/$',
+        r'(?P<event_slug>[\w-]+)/checkin/(?P<username>[\w.@+-]+)/$',
         check_in_user_to_event, name='check_in_user_to_event'),
 
     url(r'^(?P<group_slug>[\w-]+)/event/'

--- a/src/nyc_trees/apps/users/urls/group.py
+++ b/src/nyc_trees/apps/users/urls/group.py
@@ -29,7 +29,7 @@ urlpatterns = patterns(
         r.start_group_map_print_job,
         name='start_group_map_print_job'),
 
-    url(r'^(?P<group_slug>[\w-]+)/individual-mapper/(?P<username>\w+)/$',
+    url(r'^(?P<group_slug>[\w-]+)/individual-mapper/(?P<username>[\w.@+-]+)/$',
         r.edit_user_mapping_priveleges,
         name='edit_user_mapping_priveleges'),
 

--- a/src/nyc_trees/apps/users/urls/user.py
+++ b/src/nyc_trees/apps/users/urls/user.py
@@ -17,21 +17,21 @@ urlpatterns = patterns(
 
     url(r'^achievements/$', r.achievements, name='achievements'),
 
-    url(r'^(?P<username>\w+)/$', r.user_detail, name='user_detail'),
+    url(r'^(?P<username>[\w.@+-]+)/$', r.user_detail, name='user_detail'),
 
-    url(r'^(?P<username>\w+)/request-individual-mapper-status/$',
+    url(r'^(?P<username>[\w.@+-]+)/request-individual-mapper-status/$',
         r.request_individual_mapper_status,
         name='request_individual_mapper_status'),
 
-    url(r'^(?P<username>\w+)/printable-survey-form/$',
+    url(r'^(?P<username>[\w.@+-]+)/printable-survey-form/$',
         r.start_form_for_reservation_job,
         name='start_form_for_reservation_job'),
 
-    url(r'^(?P<username>\w+)/printable-map/$',
+    url(r'^(?P<username>[\w.@+-]+)/printable-map/$',
         r.start_map_for_reservation_job,
         name='start_map_for_reservation_job'),
 
-    url(r'^(?P<username>\w+)/printable-tooldepots/$',
+    url(r'^(?P<username>[\w.@+-]+)/printable-tooldepots/$',
         r.start_map_for_tool_depots_job,
         name='start_map_for_tool_depots_job'),
 )


### PR DESCRIPTION
I used the same regex that Django uses when validating usernames:
https://github.com/django/django/blob/1.7.8/django/contrib/auth/models.py#L371
so I think this should cover all possible usernames

Connects to #1440
Connects to #1443