### PR TITLE
Add indexes to 'updated_at' for Survey and BlockfaceReservation

### DIFF
--- a/src/nyc_trees/apps/core/test_utils.py
+++ b/src/nyc_trees/apps/core/test_utils.py
@@ -78,7 +78,8 @@ def make_survey(user, blockface, **kwargs):
     defaults.update(kwargs)
 
     s = Survey(**defaults)
-    s.clean_and_save()
+    s.full_clean()
+    s.save()
 
     return s
 

--- a/src/nyc_trees/apps/survey/migrations/0021_auto_20150506_1406.py
+++ b/src/nyc_trees/apps/survey/migrations/0021_auto_20150506_1406.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0020_auto_20150505_1155'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='blockfacereservation',
+            name='updated_at',
+            field=models.DateTimeField(help_text='Time when row was last updated', auto_now=True, db_index=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='survey',
+            name='updated_at',
+            field=models.DateTimeField(help_text='Time when row was last updated', auto_now=True, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -56,7 +56,7 @@ class Territory(NycModel, models.Model):
         verbose_name_plural = "Territories"
 
 
-class Survey(NycModel, models.Model):
+class Survey(models.Model):
     # We do not anticipate deleting a Blockface, but we definitely
     # should not allow it to be deleted if there is a related Survey
     blockface = models.ForeignKey(
@@ -84,6 +84,15 @@ class Survey(NycModel, models.Model):
     quit_reason = models.TextField(
         blank=True,
         help_text='Description of why survey was abandoned')
+
+    # We can't use the NycModel mixin, because we want to add db indexes
+    created_at = models.DateTimeField(
+        auto_now_add=True, editable=False,
+        help_text='Time when row was created')
+    updated_at = models.DateTimeField(
+        auto_now=True, db_index=True, editable=False,
+        help_text='Time when row was last updated'
+    )
 
     def __unicode__(self):
         return 'block %s on %s by %s' % (self.blockface_id, self.created_at,
@@ -311,7 +320,7 @@ class ReservationsQuerySet(models.QuerySet):
         return self.filter(user=user).current().count()
 
 
-class BlockfaceReservation(NycModel, models.Model):
+class BlockfaceReservation(models.Model):
     user = models.ForeignKey(
         User,
         help_text='ID of user reserving blockface')
@@ -332,6 +341,15 @@ class BlockfaceReservation(NycModel, models.Model):
     reminder_sent_at = models.DateTimeField(
         null=True, blank=True,
         help_text='Time expiration reminder was emailed')
+
+    # We can't use the NycModel mixin, because we want to add db indexes
+    created_at = models.DateTimeField(
+        auto_now_add=True, editable=False,
+        help_text='Time when row was created')
+    updated_at = models.DateTimeField(
+        auto_now=True, db_index=True, editable=False,
+        help_text='Time when row was last updated'
+    )
 
     objects = ReservationsQuerySet.as_manager()
 

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -631,7 +631,8 @@ def _create_survey_and_trees(request, event=None):
             return HttpResponseForbidden(
                 'You have not reserved this block edge.')
 
-    survey.clean_and_save()
+    survey.full_clean()
+    survey.save()
 
     if survey.quit_reason == '':
         _mark_survey_blockface_availability(survey, False)
@@ -648,7 +649,8 @@ def _create_survey_and_trees(request, event=None):
 def flag_survey(request, survey_id):
     survey = get_object_or_404(Survey, id=survey_id, user=request.user)
     survey.is_flagged = True
-    survey.clean_and_save()
+    survey.full_clean()
+    survey.save()
     ctx = {'success': True}
     return ctx
 


### PR DESCRIPTION
These tables are queried to find the most recent update time when
computing tiler cache buster values, when loading that map page.

Survey is queried for the most recent 'updated_at' for every progress page
layer, and BlockfaceReservation.updated_at is queried for every other
map layer.

I am only adding indexes for these 2 table's 'updated_at' columns because
I expect that the number of rows in the other tables we use to calculate
cache busters will remain small, or already have indexes.

I attempted to measure the performance impact of these changes, but the
Postgresql query plan did not use the new indexes.  I suspect this is
because the amount of data in my development DB is rather small.

That said, I expect we will have a large number of rows in these tables
by the end of the census, perhaps numbering in the hundreds of thousands.

Connects to #275