### PR TITLE
Increase max slug length to match connected fields.

### DIFF
--- a/src/nyc_trees/apps/core/migrations/0030_auto_20150506_1635.py
+++ b/src/nyc_trees/apps/core/migrations/0030_auto_20150506_1635.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0029_auto_20150505_1212'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='group',
+            name='slug',
+            field=models.SlugField(help_text='Short name for group, used in URLs', unique=True, max_length=255, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -240,7 +240,7 @@ class Group(NycModel, models.Model):
         help_text='Name of group, for display')
     # blank=True is valid for 'slug', because we'll automatically create slugs
     slug = models.SlugField(
-        unique=True, blank=True,
+        unique=True, blank=True, max_length=255,
         help_text='Short name for group, used in URLs')
     description = models.TextField(
         default='', blank=True,

--- a/src/nyc_trees/apps/event/migrations/0014_auto_20150506_1634.py
+++ b/src/nyc_trees/apps/event/migrations/0014_auto_20150506_1634.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('event', '0013_auto_20150505_1155'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='event',
+            name='slug',
+            field=models.SlugField(help_text='Short name used in URLs', max_length=255, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/event/models.py
+++ b/src/nyc_trees/apps/event/models.py
@@ -39,7 +39,7 @@ class Event(NycModel, models.Model):
 
     # blank=True is valid for 'slug', because we'll automatically create slugs
     slug = models.SlugField(
-        blank=True,
+        blank=True, max_length=255,
         help_text='Short name used in URLs')
 
     description = models.TextField(


### PR DESCRIPTION
Creating an event or group with a name greater than 50 characters would
fail, because the automatically generated slugs were longer than the
default max_length.

Connects to #1524