### PR TITLE
Fix tile generation several maps.

### DIFF
--- a/src/tiler/sql/group_territory.sql
+++ b/src/tiler/sql/group_territory.sql
@@ -1,5 +1,5 @@
 (SELECT
-  block.geom, 'reserved' as survey_type
+  block.geom, 'reserved' as survey_type, 'none' AS restriction
   FROM survey_blockface AS block
   INNER JOIN survey_territory AS turf
     ON block.id = turf.blockface_id

--- a/src/tiler/sql/group_territory_admin.sql
+++ b/src/tiler/sql/group_territory_admin.sql
@@ -15,7 +15,8 @@
         WHEN turf.group_id = <%= group_id %> THEN 'surveyed-by-me'
         ELSE 'surveyed-by-others'
       END
-  END AS survey_type
+  END AS survey_type,
+  'none' AS restriction
 
   FROM survey_blockface AS block
   LEFT OUTER JOIN survey_territory AS turf

--- a/src/tiler/sql/group_territory_survey.sql
+++ b/src/tiler/sql/group_territory_survey.sql
@@ -7,7 +7,8 @@
   CASE
     WHEN (block.is_available AND reservation.id IS NULL) THEN 'available'
     ELSE 'unavailable'
-  END AS survey_type
+  END AS survey_type,
+  'none' AS restriction
   FROM survey_blockface AS block
   INNER JOIN survey_territory AS turf
     ON block.id = turf.blockface_id

--- a/src/tiler/sql/user_reservations_print.sql
+++ b/src/tiler/sql/user_reservations_print.sql
@@ -1,5 +1,5 @@
 (SELECT
-  block.geom, 'reserved' as survey_type
+  block.geom, 'reserved' as survey_type, 'none' AS restriction
   FROM survey_blockface AS block
   INNER JOIN survey_blockfacereservation AS reservation
     ON (block.id = reservation.blockface_id


### PR DESCRIPTION
Styling based on the restriction column was added in 3b1bebf6, but
windshaft bombs out if a property referenced in CartoCSS is not in the
SQL query.

Adding the constant ``'none' as restriction`` to these queries will fix
the issue.

Connects to #1572