### PR TITLE
Fix anonymous user exception on training page

### DIFF
--- a/src/nyc_trees/apps/home/training/types.py
+++ b/src/nyc_trees/apps/home/training/types.py
@@ -188,7 +188,7 @@ class QuizTrainingStep(ViewTrainingStep):
         @wraps(view_fn)
         def wrapper(request, *args, **kwargs):
             training_results = (TrainingResult.objects
-                                .filter(user=request.user,
+                                .filter(user=request.user.id,
                                         module_name=self.quiz.slug,
                                         score__gte=self.quiz.passing_score))
             if not training_results.exists():


### PR DESCRIPTION
I was able to reproduce this in development.

before:
![screenshot from 2015-05-08 12 15 14](https://cloud.githubusercontent.com/assets/1699455/7540591/e5be9856-f57c-11e4-8813-0091e78d501d.png)
after:
![screenshot from 2015-05-08 12 16 09](https://cloud.githubusercontent.com/assets/1699455/7540595/e93f1708-f57c-11e4-8482-2eed9e40a483.png)

------------------------------------------
connects to #1589 on github

As discussed in person, this is the result of some code assuming an
anonymous user is a logged in user. This commit forces realization
of the user and returns None for the id. The solutions was inspired by
this stackoverflow page:
http://stackoverflow.com/questions/17623234/django-simplelazyobject

This is in response to a bug that turned up on production. Fortunately
the only time this bug would turn up is with a case in which a 404
appropriate. This fix makes sure that a 404 is returned.

