### PR TITLE
Fix anonymous user exception on training page

### DIFF
--- a/src/nyc_trees/apps/home/training/types.py
+++ b/src/nyc_trees/apps/home/training/types.py
@@ -188,7 +188,7 @@ class QuizTrainingStep(ViewTrainingStep):
         @wraps(view_fn)
         def wrapper(request, *args, **kwargs):
             training_results = (TrainingResult.objects
-                                .filter(user=request.user,
+                                .filter(user=request.user.id,
                                         module_name=self.quiz.slug,
                                         score__gte=self.quiz.passing_score))
             if not training_results.exists():


### PR DESCRIPTION
connects to #1589 on github

As discussed in person, this is the result of some code assuming an
anonymous user is a logged in user. This commit forces realization
of the user and returns None for the id. The solutions was inspired by
this stackoverflow page:
http://stackoverflow.com/questions/17623234/django-simplelazyobject

This is in response to a bug that turned up on production. Fortunately
the only time this bug would turn up is with a case in which a 404
appropriate. This fix makes sure that a 404 is returned.