### PR TITLE
Remove loading blockfaces from setupdb.sh

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -16,9 +16,6 @@ psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
 # Run migrations
 envdir /etc/nyc-trees.d/env /opt/app/manage.py migrate
-# Load block face data
-
-ls /opt/app/apps/survey/fixtures/blockface_*.json | xargs -n1 envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata
 
 # Load species data
 envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata $DIR/../../src/nyc_trees/apps/survey/fixtures/species.json


### PR DESCRIPTION
For a few reasons

- The database for every stack already contains these blocks, and they
  will not be changing over the course of census. We will only be
  getting additions.

- The block rows have a mutable ``is_available`` column used for
  tracking the status of the row, and we do not want to overwrite it.

- It slows down the deploy process.

Connects to #1591 