### PR TITLE
Fix "My Progress" map tiles not appearing the first time

### DIFF
--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -93,13 +93,26 @@ function createAndGetControls(options) {
     return {map: map, multiControl: multiControl};
 }
 
+// Return a promise which is resolved when map is done zooming.
 function fitBounds(map, bounds) {
+    if (!bounds) {
+        return $.Deferred().resolve().promise();
+    }
+
     // GeoDjango bounds are [xmin, ymin, xmax, ymax]
     // Leaflet wants [ [ymin, xmin], [ymax, xmax] ]
     var b = [[bounds[1], bounds[0]], [bounds[3], bounds[2]]],
-        zooming = (map.getZoom() !== map.getBoundsZoom(b));
+        zooming = (map.getZoom() !== map.getBoundsZoom(b)),
+        defer = $.Deferred();
+
+    if (zooming) {
+        map.on('zoomend', defer.resolve);
+    } else {
+        defer.resolve();
+    }
+
     map.fitBounds(b);
-    return zooming;
+    return defer.promise();
 }
 
 function isRetinaDevice() {
@@ -174,7 +187,7 @@ function addTileLayer(map, options) {
             minZoom: zoom.MIN,
             maxZoom: zoom.MAX
         });
-    _addLayer(map, layer, options.waitForZoom);
+    map.addLayer(layer);
     return layer;
 }
 
@@ -188,26 +201,8 @@ function addGridLayer(map, options) {
             crosshairs: options.crosshairs || false,
             pointerCursor: !options.crosshairs
         });
-    _addLayer(map, layer, options.waitForZoom);
+    map.addLayer(layer);
     return layer;
-}
-
-function _addLayer(map, layer, waitForZoom) {
-    if (waitForZoom) {
-        _addAfterZoom(map, layer);
-    } else {
-        map.addLayer(layer);
-    }
-}
-
-function _addAfterZoom(map, layer) {
-    // Add layer to map after zoom animation completes.
-    // (Otherwise spurious tile requests will be issued at the old zoom level.)
-    function addLayer() {
-        map.addLayer(layer);
-        map.off('zoomend', addLayer);
-    }
-    map.on('zoomend', addLayer);
 }
 
 function getDomMapAttribute(dataAttName, domId) {

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -125,13 +125,12 @@ function loadLayers($mode) {
 }
 
 function addLayers(bounds, tileUrl) {
-    var zooming = false;
-    if (bounds) {
-        zooming = mapModule.fitBounds(progressMap, bounds);
-    }
-    tileLayer = mapModule.addTileLayer(progressMap, {
-        url: tileUrl,
-        waitForZoom: zooming
+    // Add layer to map after zoom animation completes.
+    // (Otherwise spurious tile requests will be issued at the old zoom level.)
+    mapModule.fitBounds(progressMap, bounds).then(function() {
+        tileLayer = mapModule.addTileLayer(progressMap, {
+            url: tileUrl
+        });
     });
 }
 


### PR DESCRIPTION
This fixes a race condition where the map `zoomend` event would not fire the
first time a user selects "My Progress" on the Progress map page.

I solved this by replacing the zooming event handlers with a promise.

Connects #1581