### PR TITLE
Disable autoescape in base text email template

### DIFF
--- a/src/nyc_trees/apps/mail/templates/mail/base_email.txt
+++ b/src/nyc_trees/apps/mail/templates/mail/base_email.txt
@@ -1,4 +1,6 @@
+{% autoescape off %}
 {% block content %}
 {% endblock content %}
 
 Please contact us at Treescount.Help@parks.nyc.gov for technical assistance or any questions related to the TreesCount! 2015 website.
+{% endautoescape %}


### PR DESCRIPTION
The content of a plain text email never needs to be escaped. The Django docs explain that autoescape settings are passed from parent to child templates.

https://docs.djangoproject.com/en/1.7/topics/templates/#for-template-blocks

Connects to #1565