### PR TITLE
Allow mapping at events all day

### DIFF
--- a/src/nyc_trees/apps/core/templates/base.html
+++ b/src/nyc_trees/apps/core/templates/base.html
@@ -40,6 +40,9 @@
     {# This block exists for placing elements that need to be children of the body, like bootstrap modals #}
     {% block extra_content %}
     {% endblock extra_content %}
+    {% if treecorder_urls|length > 1 %}
+      {% include "home/partials/treecorder_modal.html" %}
+    {% endif %}
 
     {% block footer %}
         <footer>

--- a/src/nyc_trees/apps/core/templates/core/partials/nav.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/nav.html
@@ -17,7 +17,15 @@
     {% endif %}
     <ul class="nav-side-list">
         {% flag full_access %}
-            <li{% if active_page == "treecorder" %} class="active"{% endif %}><a href="{% url 'treecorder' %}">Treecorder</a></li>
+            <li{% if active_page == "treecorder" %} class="active"{% endif %}>
+                {% if treecorder_urls|length_is:"1" %}
+                    {% with link=treecorder_urls.items|first %}
+                    <a href="{{ link.1 }}">Treecorder</a>
+                    {% endwith %}
+                {% else %}
+                    <a href="javascript:" data-toggle="modal" data-target="#treecorder-survey-modal">Treecorder</a>
+                {% endif %}
+            </li>
             <li{% if active_page == "dashboard" %} class="active"{% endif %}>
                 <a href="{% url 'home_page' %}">{% if user.is_authenticated %}Dashboard{% else %}Homepage{% endif %}</a>
             </li>

--- a/src/nyc_trees/apps/event/models.py
+++ b/src/nyc_trees/apps/event/models.py
@@ -4,15 +4,17 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import shortuuid
+from pytz import timezone, utc
 
 from datetime import timedelta
-from django.utils import timezone
+from django.utils.timezone import now
 
 from django.conf import settings
 from django.contrib.gis.db import models
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.core.validators import RegexValidator
+from django.db.models import Q
 from django.utils.text import slugify
 
 from apps.core.models import User, Group
@@ -122,9 +124,9 @@ class Event(NycModel, models.Model):
     def starting_soon(self, target_dt=None):
         """
         Return True if `target_dt` is within the event starting period.
-        Argument `target_dt` defaults to `timezone.now` if omitted.
+        Argument `target_dt` defaults to `now` if omitted.
         """
-        target_dt = target_dt or timezone.now()
+        target_dt = target_dt or now()
         return target_dt >= self.begins_at - STARTING_SOON_WINDOW \
             and target_dt < self.ends_at
 
@@ -132,12 +134,18 @@ class Event(NycModel, models.Model):
         """
         Return True if event is in-progress in the context of `target_dt`.
         """
-        target_dt = target_dt or timezone.now()
+        target_dt = target_dt or now()
         return target_dt >= self.begins_at and target_dt < self.ends_at
+
+    def is_mapping_allowed(self):
+        now_utc = now()
+        end_of_event_day = end_of_day_in_utc(self.ends_at)
+
+        return self.begins_at <= now_utc <= end_of_event_day
 
     @property
     def has_started(self):
-        return self.begins_at <= timezone.now()
+        return self.begins_at <= now()
 
     def get_admin_checkin_url(self):
         return reverse('event_admin_check_in_page',
@@ -161,11 +169,11 @@ class Event(NycModel, models.Model):
         return url_if_cooked(self.map_pdf_filename)
 
     def is_past(self):
-        return self.ends_at < timezone.now()
+        return self.ends_at < now()
 
     @property
     def can_send_email(self):
-        return (self.ends_at + EMAIL_WINDOW) >= timezone.now()
+        return (self.ends_at + EMAIL_WINDOW) >= now()
 
     class Meta:
         unique_together = (("group", "slug"), ("group", "title"))
@@ -199,16 +207,60 @@ class EventRegistration(NycModel, models.Model):
         Return a tuple of (attended events, non-attended events) for upcoming
         and in-progress events for which the user has RSVPd.
         """
-        now = timezone.now()
+        now_utc = now()
+
+        end_of_day_utc = end_of_day_in_utc(now_utc)
+        beginning_of_day_utc = start_of_day_in_utc(now_utc)
+
+        # First filter to the events starting today
+        # Then get those events which are starting soon or have yet to end, or
+        # any attended events from today, which can be mapped until midnight
         registrations = EventRegistration.objects \
             .filter(user=user,
-                    event__begins_at__lte=now + STARTING_SOON_WINDOW,
-                    event__ends_at__gt=now) \
+                    event__begins_at__gte=beginning_of_day_utc) \
+            .filter(Q(did_attend=True, event__ends_at__lte=end_of_day_utc) |
+                    Q(event__begins_at__lte=now_utc + STARTING_SOON_WINDOW,
+                      event__ends_at__gt=now_utc)) \
             .prefetch_related('event')
+
         attended = [r.event for r in registrations if r.did_attend]
         non_attended = [r.event for r in registrations if not r.did_attend]
         return attended, non_attended
 
+    @classmethod
+    def next_event_starting_soon(cls, user):
+        """
+        Return the EventRegistration for the next event starting soon, or None
+        """
+        now_utc = now()
+
+        registrations = EventRegistration.objects \
+            .filter(user=user,
+                    event__begins_at__lte=now_utc + STARTING_SOON_WINDOW,
+                    event__ends_at__gt=now_utc) \
+            .prefetch_related('event') \
+            .order_by('event__begins_at')
+
+        return registrations[0] if registrations else None
+
     def __unicode__(self):
         return "'%s' registration for '%s'" % (self.user.username,
                                                self.event.title)
+
+
+def end_of_day_in_utc(dt_utc):
+    est_tz = timezone('US/Eastern')
+    now_est = dt_utc.astimezone(est_tz)
+
+    end_of_day_est = now_est.replace(hour=23, minute=59, second=59)
+
+    return end_of_day_est.astimezone(utc)
+
+
+def start_of_day_in_utc(dt_utc):
+    est_tz = timezone('US/Eastern')
+    now_est = dt_utc.astimezone(est_tz)
+
+    start_of_day_est = now_est.replace(hour=0, minute=0, second=0)
+
+    return start_of_day_est.astimezone(utc)

--- a/src/nyc_trees/apps/home/templates/home/partials/treecorder_modal.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/treecorder_modal.html
@@ -1,0 +1,17 @@
+<div class="modal fade" id="treecorder-survey-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Where do you want to map?</h4>
+      </div>
+      <div class="modal-body">
+          <p>Please choose where you will be mapping trees. You can map at an event or map your reserved block edges.</p>
+          <ul>
+          {% for label, url in treecorder_urls.iteritems %}
+            <li><a href="{{ url }}">{{ label }}</a></li>
+          {% endfor %}
+          </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/nyc_trees/apps/home/templates/home/partials/treecorder_modal.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/treecorder_modal.html
@@ -1,4 +1,4 @@
-<div class="modal fade" id="treecorder-survey-modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade navbar-modal" id="treecorder-survey-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/src/nyc_trees/apps/home/views.py
+++ b/src/nyc_trees/apps/home/views.py
@@ -28,14 +28,10 @@ def home_page(request):
         context['counts_all'] = _global_counts()
         context['counts_week'] = _global_counts(past_week=True)
 
-        registered_events = EventRegistration.my_events_now(request.user)
-        attended_events, non_attended_events = registered_events
-        if attended_events:
-            context['event'] = attended_events[0]
-            context['did_attend_event'] = True
-        elif non_attended_events:
-            context['event'] = non_attended_events[0]
-            context['did_attend_event'] = False
+        event_reg = EventRegistration.next_event_starting_soon(request.user)
+        if event_reg:
+            context['event'] = event_reg.event
+            context['did_attend_event'] = event_reg.did_attend
     else:
         context = {
             'user': request.user,

--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -83,6 +83,10 @@ def get_context_for_territory_admin_layer(group_id):
                                   {'group': group_id})
 
 
+def get_group_territory_modification_time(request):
+    return _get_max_modification_time([Group])
+
+
 def _get_context_for_layer(layer_name, models, params=None):
     tiler_url_format = \
         "%(tiler_url)s/%(cache_buster)s/%(db)s/%(type)s/{z}/{x}/{y}"
@@ -107,11 +111,17 @@ def _get_context_for_layer(layer_name, models, params=None):
     return context
 
 
-def _get_cache_buster(models, params):
+def _get_cache_buster(models, params=None):
+    max_datetime = _get_max_modification_time(models, params)
+
+    max_timestamp = timegm(max_datetime.utctimetuple())
+    return max_timestamp
+
+
+def _get_max_modification_time(models, params=None):
     datetimes = [_get_last_updated_datetime(Model, params) for Model in models]
 
-    max_timestamp = timegm(max(*datetimes).utctimetuple())
-    return max_timestamp
+    return max(datetimes)
 
 
 def _get_last_updated_datetime(Model, params):

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -130,9 +130,6 @@ blockface = route(GET=do(json_api_call, v.blockface))
 
 blockface_near_point = route(GET=do(json_api_call, v.blockface_near_point))
 
-redirect_to_treecorder = route(GET=do(login_required,
-                                      v.redirect_to_treecorder))
-
 #####################################
 # ADMIN ROUTES
 #####################################

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -6,6 +6,7 @@ from __future__ import division
 from django.core.urlresolvers import reverse
 
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.http import last_modified
 
 from django_tinsel.decorators import route, render_template, json_api_call
 from django_tinsel.utils import decorate as do
@@ -13,6 +14,7 @@ from django_tinsel.utils import decorate as do
 from apps.core.decorators import (individual_mapper_do, group_request,
                                   census_admin_do, update_with)
 from apps.survey import views as v
+from apps.survey.layer_context import get_group_territory_modification_time
 
 #####################################
 # PROGRESS PAGE ROUTES
@@ -26,7 +28,9 @@ progress_page_blockface_popup = route(
         render_template('survey/partials/progress_page_blockface_popup.html'),
         v.progress_page_blockface_popup))
 
-group_borders_geojson = route(GET=json_api_call(v.group_borders_geojson))
+group_borders_geojson = do(
+    last_modified(get_group_territory_modification_time),
+    route(GET=json_api_call(v.group_borders_geojson)))
 
 group_popup = route(GET=do(group_request,
                            render_template('survey/partials/group_popup.html'),

--- a/src/nyc_trees/apps/survey/urls/survey.py
+++ b/src/nyc_trees/apps/survey/urls/survey.py
@@ -8,7 +8,7 @@ from django.conf.urls import patterns, url
 from apps.survey.routes import (survey, survey_from_event,
                                 flag_survey, survey_detail,
                                 confirm_survey, confirm_survey_from_event,
-                                release_blockface, redirect_to_treecorder)
+                                release_blockface)
 
 
 # These URLs have the prefix 'survey/'
@@ -20,8 +20,6 @@ urlpatterns = patterns(
     url(r'^(?P<group_slug>[\w-]+)/event/(?P<event_slug>[\w-]+)'
         r'/confirm/(?P<survey_id>\d+)/$',
         confirm_survey_from_event, name='confirm_survey_from_event'),
-
-    url(r'^treecorder/$', redirect_to_treecorder, name='treecorder'),
 
     # main endpoint (independent / from event)
     url(r'^$', survey, name='survey'),

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -23,7 +23,7 @@ from django.utils.timezone import now
 from apps.core.models import Group
 from apps.core.helpers import user_is_group_admin, user_is_individual_mapper
 
-from apps.event.models import Event, EventRegistration
+from apps.event.models import Event
 from apps.event.helpers import (user_is_checked_in_to_event,
                                 user_is_rsvped_for_event)
 
@@ -464,35 +464,6 @@ def _validate_event_and_group(request, event_slug):
     if not user_is_checked_in_to_event(request.user, event):
         raise PermissionDenied('User not checked-in to this event')
     return event
-
-
-def redirect_to_treecorder(request):
-    user = request.user
-
-    # We assume you can't have RSVPed to events without completing training
-    attended_events, unattended_events = EventRegistration.my_events_now(user)
-
-    if attended_events:
-        event = attended_events[0]
-        return redirect('survey_from_event',
-                        group_slug=event.group.slug, event_slug=event.slug)
-    elif unattended_events:
-        event = unattended_events[0]
-        return redirect('event_user_check_in_page',
-                        group_slug=event.group.slug, event_slug=event.slug)
-
-    # Need to check indivdual mapper status first, to allow census admins to
-    # "skip" a users online training via the admin site easily
-    if user.individual_mapper:
-        if user.blockfacereservation_set.current().exists():
-            return redirect('survey')
-        else:
-            return redirect('reservations')
-
-    if not user.training_complete:
-        return redirect('training_instructions')
-
-    return redirect('reservations_instructions')
 
 
 def start_survey(request):

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -491,7 +491,7 @@ def start_survey_from_event(request, event_slug):
         return redirect('event_user_check_in_page',
                         group_slug=event.group.slug, event_slug=event.slug)
 
-    if not event.in_progress():
+    if not event.is_mapping_allowed():
         return HttpResponseForbidden('Event not currently in-progress')
 
     return {

--- a/src/nyc_trees/nyc_trees/context_processors.py
+++ b/src/nyc_trees/nyc_trees/context_processors.py
@@ -7,6 +7,59 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from apps.users.views.user import USER_SETTINGS_PRIVACY_TAB_ID
+from apps.event.models import EventRegistration
+
+
+def treecorder_urls(request):
+    user = request.user
+    # At the time this function was written, the generated context was
+    # only used in the base.html template, and our AJAX requests all
+    # render partials, not full templates inheriting from base. Given
+    # those constraints, we can skip generating this context, which
+    # saves some database query time.
+    if request.is_ajax():
+        return {}
+
+    if not request.user.is_authenticated():
+        return {
+            # The key of the URLs dict is not used when there is only one entry
+            'treecorder_urls': {
+                '': reverse('auth_login') + '?next=' + request.get_full_path()
+            }
+        }
+
+    urls = {}
+
+    attended_events, unattended_events = EventRegistration.my_events_now(user)
+
+    for event in unattended_events:
+        label = 'Check into event %s for %s' % (event.title, event.group.name)
+        urls[label] = reverse('event_user_check_in_page', kwargs={
+            'group_slug': event.group.slug, 'event_slug': event.slug})
+
+    for event in attended_events:
+        label = 'Map at event %s for %s' % (event.title, event.group.name)
+        urls[label] = reverse('survey_from_event', kwargs={
+            'group_slug': event.group.slug, 'event_slug': event.slug})
+
+    if user.individual_mapper:
+        if user.blockfacereservation_set.current().exists():
+            urls['Map your reserved block edges'] = reverse('survey')
+
+    # If there are no events and no reserved blocks, we should link to a either
+    # the reservations page or the apprpriate instructions page
+    if not urls:
+        # The key of the URLs dict is not used when there is only one entry
+        if user.individual_mapper:
+            urls[''] = reverse('reservations')
+        elif not user.training_complete:
+            urls[''] = reverse('training_instructions')
+        else:
+            urls[''] = reverse('reservation_instructions')
+
+    return {
+        'treecorder_urls': urls
+    }
 
 
 def user_settings_privacy_url(request):

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -221,6 +221,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.request',
     'nyc_trees.context_processors.user_settings_privacy_url',
     'nyc_trees.context_processors.config',
+    'nyc_trees.context_processors.treecorder_urls',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders

--- a/src/nyc_trees/sass/partials/_header.scss
+++ b/src/nyc_trees/sass/partials/_header.scss
@@ -223,3 +223,10 @@
     cursor: pointer;
   }
 }
+
+// Modals opened from the navbar should have a higher z-index than the
+// overlay-menu, to prevent closing the nav until the modal opened from
+// the nav has been closed
+.navbar-modal {
+  z-index: $zindex-overlaymenu + 1 !important;
+}


### PR DESCRIPTION
- Refactors treecorder link to show a modal when there is ambiguity about how to survey
- Allows mapping events until midnight the day of the event, if the user was checked in to that event

Connects to #150 
