### PR TITLE
Fix 500 error when emailing event registrants

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -148,7 +148,7 @@ def event_email(request, event_slug):
         for rsvp in rsvps.select_related('user'):
             rsvp.user.email_user(form.cleaned_data['subject'],
                                  form.cleaned_data['body'],
-                                 [event.contact_email])
+                                 event.contact_email)
         message_sent = True
 
     return {


### PR DESCRIPTION
The `from_email` argument should not be a list.

To test, send an email to event registrants and inspect the console output:

Right:
![image](https://cloud.githubusercontent.com/assets/43062/7590847/769f3c9a-f898-11e4-8362-9fb9809b5108.png)

Wrong:
![image](https://cloud.githubusercontent.com/assets/43062/7590829/602bb196-f898-11e4-8fc7-2a2ad081a0bf.png)

Connects #1519