### PR TITLE
Update sticky titles after collapse/expand animation completes

### DIFF
--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -418,13 +418,14 @@ $(dom.treeFormcontainer).on('show.bs.collapse', function(e) {
         $toggle = $(dom.collapseButton).filter('[data-target="#' + formId + '"]').children('i');
 
     $toggle.removeClass('icon-right-open-big').addClass('icon-down-open-big');
-    stickyTitles.update();
 });
 $(dom.treeFormcontainer).on('hide.bs.collapse', function(e) {
     var formId = $(e.target).attr('id'),
         $toggle = $(dom.collapseButton).filter('[data-target="#' + formId + '"]').children('i');
 
     $toggle.removeClass('icon-down-open-big').addClass('icon-right-open-big');
+});
+$(dom.treeFormcontainer).on('shown.bs.collapse, hidden.bs.collapse', function() {
     stickyTitles.update();
 });
 


### PR DESCRIPTION
This fixes the issue with collapsing a section when its sticky title was at the bottom of the section.