### PR TITLE
Always create event map PDF when editing an event

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -59,20 +59,11 @@ def _process_event_form(form, request, event=None):
         # Lat/lng were not submitted or could not be converted to floats.
         pass
 
-    if event:
-        event_location = event.location
-
     is_valid = form.is_valid()
 
     if is_valid:
-        needs_pdf_map = (
-            event is None or
-            not event_location.equals_exact(form.data['location']))
-
         event = form.save()
-
-        if needs_pdf_map:
-            create_event_map_pdf(request, event)
+        create_event_map_pdf(request, event)
 
     return is_valid
 


### PR DESCRIPTION
Occasionally, I will run into an issue on my local dev instance where
the event map PDF fails to generate, which prevents me from RSVPing to
events. One way to trigger this issue is by manually deleting your static
folder.

Although not likely to be an issue on production, I don't think it's a
bad idea to have a workaround in place for regenerating event map PDFs.