### PR TITLE
Add a health check endpoint to the tiler

### DIFF
--- a/deployment/troposphere/tiler_template.py
+++ b/deployment/troposphere/tiler_template.py
@@ -145,7 +145,7 @@ tile_server_load_balancer = t.add_resource(elb.LoadBalancer(
         ),
     ],
     HealthCheck=elb.HealthCheck(
-        Target='HTTP:80/',
+        Target='HTTP:80/health-check/',
         HealthyThreshold='3',
         UnhealthyThreshold='2',
         Interval='30',

--- a/src/tiler/healthCheck.js
+++ b/src/tiler/healthCheck.js
@@ -1,0 +1,119 @@
+"use strict";
+
+// Loading dependencies from a dependency is not a best practice, but
+// I think it makes sense in this situation.  We want our health
+// endpoint to check connectivity to postgres and redis in a way that
+// matches real-world usage as closely as possible. Ideally this
+// health check would be part of windshaft, so I am pulling in
+// windshaft's installed versions of pg and redis.
+var pg = require('windshaft/node_modules/pg');
+var redis = require('windshaft/node_modules/redis-mpool/node_modules/redis');
+
+function checkPostgres(host, port, user, password, database, timeout, cb) {
+    var conString = ['postgres://', user, ':', password, '@', host, '/', database].join('');
+    var client = new pg.Client(conString);
+    var gotResponse = false;
+    client.connect(function(err) {
+        client.end();
+        gotResponse = true;
+        if (err) {
+            cb({database: {error: err}});
+        } else {
+            cb({database: {ok: true}});
+        }
+    });
+
+    setTimeout(function() {
+        if (!gotResponse) {
+            cb({database: {error: 'Timeout'}});
+        }
+    }, timeout);
+}
+
+function checkRedis(host, port, timeout, cb) {
+    // I am skipping over connection pooling because we are most interested in
+    // a basic connectivity check.
+    var client = redis.createClient(port, host);
+    var gotResponse = false;
+
+    client.on('connect', function() {
+        gotResponse = true;
+        cb({cache: {ok: true}});
+    });
+
+    client.on('error', function() {
+        // no arguments are passed when the error event is triggered
+        // TODO: Find out how to return more useful failure information
+        gotResponse = true;
+        cb({
+            cache: {
+                error: {
+                    message: ['Redis client raised an error event while connecting to ',
+                              host, ':', port].join('')
+                }
+            }
+        });
+    });
+
+    setTimeout(function() {
+        if (!gotResponse) {
+            cb({cache: {error: 'Timeout'}});
+        }
+    }, timeout);
+}
+
+function statusObjectFromException(ex) {
+    return {
+        error: {
+            message: 'Exception in health check.',
+            exception: ex && ex.toString ? ex.toString() : ex
+        }
+    };
+}
+
+module.exports = function createHealthCheckHandler(config, timeout) {
+    // config should be the same config object passed to Windshaft.Server()
+    var pgConf = config.grainstore.datasource,
+
+        pgHost = pgConf.host,
+        pgPort = pgConf.port,
+        pgUser = pgConf.user,
+        pgPassword = pgConf.password,
+        pgDatabase = pgConf.user, // We require db name match username
+
+        redisHost = config.redis.host,
+        redisPort = config.redis.port;
+
+    return function(req, res) {
+        var status = {};
+
+        try {
+            checkPostgres(pgHost, pgPort, pgUser, pgPassword, pgDatabase, timeout,
+                function(result) {
+                    status.database = result.database;
+                    if (status.cache) {
+                        res.json(status);
+                    }
+                });
+        } catch(e) {
+            status.database = statusObjectFromException(e);
+            if (status.cache) {
+                res.json(status);
+            }
+        }
+
+        try {
+            checkRedis(redisHost, redisPort, timeout, function(result) {
+                status.cache = result.cache;
+                if (status.database) {
+                    res.json(status);
+                }
+            });
+        } catch(e) {
+            status.cache = statusObjectFromException(e);
+            if (status.database) {
+                res.json(status);
+            }
+        }
+   };
+};

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -3,6 +3,7 @@
 var Windshaft = require('windshaft'),
     fs = require('fs'),
     _ = require('lodash'),
+    healthCheck = require('./healthCheck'),
     files = require('./files'),
     port = process.env.PORT || 4000,
 
@@ -20,6 +21,8 @@ var Windshaft = require('windshaft'),
     // See http://wiki.openstreetmap.org/wiki/Meta_tiles for a discussion of metatiles.
     // 4 is the default set in https://github.com/CartoDB/Windshaft/blob/42218bc480bedaa6b5e1b7d60478ea8afdce2d87/lib/windshaft/renderers/mapnik/factory.js#L26
     mapnikMetatileCount = process.env.NYC_TREES_METATILE_COUNT || 4,
+
+    tilerHealthTimeout = process.env.NYC_TREES_TILER_HEALTH_TIMEOUT || 1000,
 
     queries = files('./sql'),
     styles = files('./style'),
@@ -133,5 +136,7 @@ function req2sql(req) {
     }
 }
 
-Windshaft.Server(config).listen(port);
+var server = Windshaft.Server(config);
+server.get('/health-check', healthCheck(config, tilerHealthTimeout));
+server.listen(port);
 console.log("Now serving tiles");


### PR DESCRIPTION
We want to be able to detect connectivity issues between the tiler and the two services it depends on, the Postgres database and the Redis cache. This commit adds a ``/health-check`` endpoint that attempts to connected to both services and returns the status of those connections in a JSON response.

Test by stopping the Postgres and Redis services and verifying that ``/health-check`` returns an appropriate message.  You can also hack the code or set ``NYC_TREES_TILER_HEALTH_TIMEOUT=1`` to test the timeout functionality. 

Connects to #1129 