### PR TITLE
Add a custom 500 error page template

### DIFF
--- a/src/nyc_trees/apps/core/templates/500.html
+++ b/src/nyc_trees/apps/core/templates/500.html
@@ -1,0 +1,9 @@
+{% extends "registration/registration_base.html" %}
+{% load i18n %}
+
+{% block registration_title %}Looks like something went wrong!{% endblock %}
+
+{% block registration_content %}
+  <h4>There was a problem loading the requested page</h4>
+  <p>We track these errors automatically, but if the problem continues, feel free to <a href="mailto:TreesCount.Help@parks.nyc.gov">contact us</a>.</p>
+{% endblock %}


### PR DESCRIPTION
This changeset adds a custom 500 error page template to override the default.