### PR TITLE
Fix tiler health check by threading through database name

### DIFF
--- a/deployment/ansible/roles/nyc-trees.tiler/defaults/main.yml
+++ b/deployment/ansible/roles/nyc-trees.tiler/defaults/main.yml
@@ -5,6 +5,7 @@ tiler_deploy_branch: "master"
 tiler_use_profiler: "false"
 
 tiler_config:
+  - { file: "NYC_TREES_DB_NAME", content: "{{ postgresql_database }}" }
   - { file: "NYC_TREES_DB_USER", content: "{{ postgresql_username }}" }
   - { file: "NYC_TREES_DB_PASSWORD", content: "{{ postgresql_password }}" }
   - { file: "NYC_TREES_DB_HOST", content: "{{ postgresql_host }}" }

--- a/src/tiler/healthCheck.js
+++ b/src/tiler/healthCheck.js
@@ -79,7 +79,7 @@ module.exports = function createHealthCheckHandler(config, timeout) {
         pgPort = pgConf.port,
         pgUser = pgConf.user,
         pgPassword = pgConf.password,
-        pgDatabase = pgConf.user, // We require db name match username
+        pgDatabase = pgConf.dbname,
 
         redisHost = config.redis.host,
         redisPort = config.redis.port;

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -11,6 +11,7 @@ var Windshaft = require('windshaft'),
     dbPassword = process.env.NYC_TREES_DB_PASSWORD || 'nyc_trees',
     dbHost = process.env.NYC_TREES_DB_HOST || 'localhost',
     dbPort = process.env.NYC_TREES_DB_PORT || 5432,
+    dbName = process.env.NYC_TREES_DB_NAME || 'nyc_trees',
 
     redisHost = process.env.NYC_TREES_CACHE_HOST || 'localhost',
     redisPort = process.env.NYC_TREES_CACHE_PORT || 6379,
@@ -48,6 +49,7 @@ var Windshaft = require('windshaft'),
 
         grainstore: {
             datasource: {
+                dbname: dbName,
                 user: dbUser,
                 password: dbPassword,
                 host: dbHost,


### PR DESCRIPTION
In EC2, the RDS user and database name do not match. These changes pass through the backend database name so that the health check can make use of it.

Connects #1129