### PR TITLE
Make Django loaddata management command references consistent

### DIFF
--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -3,8 +3,6 @@
 set -e
 set -x
 
-DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
-
 # Export settings required to run psql non-interactively
 export PGHOST=$(cat /etc/nyc-trees.d/env/NYC_TREES_DB_HOST)
 export PGDATABASE=$(cat /etc/nyc-trees.d/env/NYC_TREES_DB_NAME)
@@ -23,7 +21,7 @@ envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata /opt/app/apps/survey/fix
 envdir /etc/nyc-trees.d/env /opt/app/manage.py assign_block_regions
 
 # Load species data
-envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata $DIR/../../src/nyc_trees/apps/survey/fixtures/species.json
+envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata /opt/app/apps/survey/fixtures/species.json
 
 # Setup soft launch flag if it does not already exist
 if ! envdir /etc/nyc-trees.d/env /opt/app/manage.py flag -l | grep full_access; then


### PR DESCRIPTION
This changeset makes all of the `loaddata` management command calls consistent.

Successful command output:

```
ubuntu@ip-10-0-3-192:~$ DJANGO_SITE_DOMAIN="treescount.foo.com" /opt/nyc-trees/scripts/aws/setupdb.sh

...

+ envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata /opt/app/apps/survey/fixtures/borough.json
Installed 5 object(s) from 1 fixture(s)
+ envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata /opt/app/apps/survey/fixtures/neighborhoodtabulationarea.json
Installed 195 object(s) from 1 fixture(s)
+ envdir /etc/nyc-trees.d/env /opt/app/manage.py assign_block_regions
+ envdir /etc/nyc-trees.d/env /opt/app/manage.py loaddata /opt/app/apps/survey/fixtures/species.json
Installed 132 object(s) from 1 fixture(s)

...

```