### PR TITLE
Restrict access from banned users

### DIFF
--- a/src/nyc_trees/nyc_trees/middleware.py
+++ b/src/nyc_trees/nyc_trees/middleware.py
@@ -7,6 +7,7 @@ import re
 import waffle
 
 from django.conf import settings
+from django.contrib.auth import logout
 from django.shortcuts import redirect
 
 
@@ -25,3 +26,13 @@ class SoftLaunchMiddleware(object):
 
         if not allowed:
             return redirect(self.redirect_url)
+
+
+# Author: Tony Abou-Assaleh
+# Source: http://stackoverflow.com/a/7871831
+class BannedUserMiddleware(object):
+    def process_request(self, request):
+        if not request.user.is_authenticated():
+            return
+        if request.user.is_banned:
+           logout(request)

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -251,6 +251,7 @@ MIDDLEWARE_CLASSES = (
     'django_statsd.middleware.GraphiteMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'nyc_trees.middleware.SoftLaunchMiddleware',
+    'nyc_trees.middleware.BannedUserMiddleware',
 )
 # END MIDDLEWARE CONFIGURATION
 


### PR DESCRIPTION
Check if user is banned before processing any views. If they *are*
banned, immediately logout user.

How to test:
  1. Login as any user
  2. Set `is_banned` to True for that user
  3. Refresh the page
  4. You be logged out now, and unable to login until the ban is lifted

Connects #1530