### PR TITLE
Show ambassador status on event admin check-in page

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/admin_checkin.html
+++ b/src/nyc_trees/apps/event/templates/event/admin_checkin.html
@@ -59,6 +59,10 @@
                 <br />{{ user.get_full_name }}
                 {% endif %}
 
+                {% if user.is_ambassador %}
+                <br /><strong class="color--primary">Ambassador</strong>
+                {% endif %}
+
                 <hr />
             </div>
         </div>

--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -356,7 +356,8 @@ def printable_event_map(request, event_slug):
 
 def event_admin_check_in_page(request, event_slug):
     event = get_object_or_404(Event, group=request.group, slug=event_slug)
-    rsvps = EventRegistration.objects.filter(event=event)
+    rsvps = EventRegistration.objects.filter(event=event) \
+        .order_by('-user__is_ambassador', 'user')
     users = [(row.user, row.did_attend) for row in rsvps]
     return {
         'group': request.group,


### PR DESCRIPTION
This also sorts the users on the event admin check-in page so that
ambassadors are at the top of the list.

Connects #1530