### PR TITLE
Update progress color ramp

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/partials/progress_legend.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/progress_legend.html
@@ -39,9 +39,9 @@ Progress
         </tr>
     </table>
     <div class="mapped-labels">
-        <div class="col-xs-4 text-left">0</div>
+        <div class="col-xs-4 text-left" style="padding-left: 0">0</div>
         <div class="col-xs-4 text-center">50</div>
-        <div class="col-xs-4 text-right">100%</div>
+        <div class="col-xs-4 text-right" style="padding-right: 0">100%</div>
     </div>
 </div>
 {% endblock legend_entries %}

--- a/src/nyc_trees/sass/partials/_legend.scss
+++ b/src/nyc_trees/sass/partials/_legend.scss
@@ -41,13 +41,13 @@
     background-color: #FFEB3B;
   }
   .mapped-percentage-color-ramp {
+    border: 1px solid #ddd;
     opacity: 0.75; // Account for the layer being translucent on top of a grey basemap
     width: 100%;
     .mapped-percentage {
       width: 10%;
       height: 0;
       padding-top: 10%;
-      border: 1px solid #ddd;
     }
   }
 

--- a/src/nyc_trees/sass/partials/_legend.scss
+++ b/src/nyc_trees/sass/partials/_legend.scss
@@ -41,6 +41,7 @@
     background-color: #FFEB3B;
   }
   .mapped-percentage-color-ramp {
+    opacity: 0.75; // Account for the layer being translucent on top of a grey basemap
     width: 100%;
     .mapped-percentage {
       width: 10%;
@@ -56,14 +57,41 @@
   }
 
   // If you change these colors, you should also change src/tiler/style/progres.mss
-  .mapped-0  { background-color: #fff; }
-  .mapped-10 { background-color: #f7fcfd; }
-  .mapped-20 { background-color: #e5f5f9; }
-  .mapped-30 { background-color: #ccece6; }
-  .mapped-40 { background-color: #99d8c9; }
-  .mapped-50 { background-color: #66c2a4; }
-  .mapped-60 { background-color: #41ae76; }
-  .mapped-70 { background-color: #238b45; }
-  .mapped-80 { background-color: #006d2c; }
-  .mapped-90 { background-color: #00441b; }
+
+/*
+
+  Generated with http://www.zonums.com/online/color_ramp/
+
+  Input:
+  ------
+  0,88,36
+  3
+  122,193,67
+  3
+  246,249,244
+
+  Output:
+  -------
+  0,88,36       #005824
+  30,114,43     #1E722B
+  61,140,51     #3D8C33
+  91,166,59     #5BA63B
+  122,193,67    #7AC143
+  153,207,111   #99CF6F
+  184,221,155   #B8DD9B
+  215,235,199   #D7EBC7
+  246,249,244   #F6F9F4
+
+*/
+
+  .mapped-0  { background-color: #FFFFFF; }
+  .mapped-10 { background-color: #F6F9F4; }
+  .mapped-20 { background-color: #D7EBC7; }
+  .mapped-30 { background-color: #B8DD9B; }
+  .mapped-40 { background-color: #99CF6F; }
+  .mapped-50 { background-color: #7AC143; }
+  .mapped-60 { background-color: #5BA63B; }
+  .mapped-70 { background-color: #3D8C33; }
+  .mapped-80 { background-color: #1E722B; }
+  .mapped-90 { background-color: #005824; }
 }

--- a/src/tiler/style/progress.mss
+++ b/src/tiler/style/progress.mss
@@ -34,15 +34,15 @@
   line-width: 1;
   polygon-opacity: 0.50;
   polygon-fill: #fff;
-  [percent >= 10] { polygon-fill: #f7fcfd }
-  [percent >= 20] { polygon-fill: #e5f5f9 }
-  [percent >= 30] { polygon-fill: #ccece6 }
-  [percent >= 40] { polygon-fill: #99d8c9 }
-  [percent >= 50] { polygon-fill: #66c2a4 }
-  [percent >= 60] { polygon-fill: #41ae76 }
-  [percent >= 70] { polygon-fill: #238b45 }
-  [percent >= 80] { polygon-fill: #006d2c }
-  [percent >= 90] { polygon-fill: #00441b }
+  [percent >= 10] { polygon-fill: #F6F9F4 }
+  [percent >= 20] { polygon-fill: #D7EBC7 }
+  [percent >= 30] { polygon-fill: #B8DD9B }
+  [percent >= 40] { polygon-fill: #99CF6F }
+  [percent >= 50] { polygon-fill: #7AC143 }
+  [percent >= 60] { polygon-fill: #5BA63B }
+  [percent >= 70] { polygon-fill: #3D8C33 }
+  [percent >= 80] { polygon-fill: #1E722B }
+  [percent >= 90] { polygon-fill: #005824 }
 }
 
 /*


### PR DESCRIPTION
Parks requested a ramp that ran through the green used throughout the site.

I also tweaked the appearance of the legend a bit. Pushing the labels out to the edges more strongly associates them with the colors that represent those values. Not drawing borders between the color cells just looks nicer to me.

To take this screenshot I adjusted the color breaks in the tiler to demonstrate more variation.

![screen shot 2015-05-14 at 10 55 49 am](https://cloud.githubusercontent.com/assets/17363/7638421/6874195a-fa29-11e4-892d-4bb4df9d9fbc.png)

Connects to #1635