### PR TITLE
Allow requesting group independent mapper status when logged out

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/trusted_mapper_request_sent.html
+++ b/src/nyc_trees/apps/home/templates/home/trusted_mapper_request_sent.html
@@ -11,7 +11,7 @@
 </p>
 <p>
     Once approved by a group admin, you will receive an email confirmation
-    to allow you to map block edges in this group territory.
+    to allow you to map block edges in this group's Census Zone.
 </p>
 
 {% endblock main %}

--- a/src/nyc_trees/apps/users/routes/group.py
+++ b/src/nyc_trees/apps/users/routes/group.py
@@ -51,7 +51,8 @@ request_mapper_status = do(
     login_required,
     group_request,
     json_api_call,
-    route(POST=v.request_mapper_status))
+    route(GET=v.redirect_to_group_detail,
+          POST=v.request_mapper_status))
 
 group_unmapped_territory_geojson = route(
     POST=census_admin_do(json_api_call,


### PR DESCRIPTION
If you click 'request independent mapper status" for a group when logged out, after logging in you will be redirected to the group detail page where you can click the button again.

Connects #1666