### PR TITLE
Fix survey centering on iOS

### DIFF
--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -38,7 +38,7 @@
         bottom: 0;
         width: 100%;
         height: 15rem;
-        padding: $grid-gutter-width/3 $grid-gutter-width/2;
+        padding: 0 $grid-gutter-width/2;
         z-index: 1;
         background-color: #fff;
         display: table;
@@ -347,12 +347,12 @@
         margin-top: 20px;
         font-size: $font-size-base;
     }
-    
+
     &.active {
         border-top: none;
        .distance-end-form, #submit-survey {
             display: block;
-        } 
+        }
         p {
             display: none;
         }


### PR DESCRIPTION
Remove unneeded padding from actionbar on survey/treecorder. This will fix vertical centering on older iPhones. Fixes #1662.

![image](https://cloud.githubusercontent.com/assets/1809908/7655644/e0ada4ee-faf2-11e4-8cce-0616026c663d.png)
