### PR TITLE
Add watchman health check for send_reminder_emails cron job

### DIFF
--- a/src/nyc_trees/apps/survey/checks.py
+++ b/src/nyc_trees/apps/survey/checks.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from datetime import timedelta
+
+from django.utils.timezone import now
+
+from apps.core.models import TaskRun
+from apps.survey.management.commands.send_reminder_emails import COMMAND_NAME
+
+
+def cron_jobs():
+    return {
+        'cron_jobs': [
+            send_reminder_emails()
+        ]
+    }
+
+
+def send_reminder_emails():
+    task = TaskRun.objects.filter(name=COMMAND_NAME) \
+                          .order_by('-date_started').first()
+
+    if task:
+        last_ran_at = task.date_started
+        ok = now().date() - task.date_started <= timedelta(days=1)
+    else:
+        last_ran_at = 'never'
+        ok = True
+
+    return {
+        'name': 'send_reminder_emails',
+        'last_ran_at': last_ran_at,
+        'ok': ok,
+    }

--- a/src/nyc_trees/apps/survey/management/commands/send_reminder_emails.py
+++ b/src/nyc_trees/apps/survey/management/commands/send_reminder_emails.py
@@ -23,7 +23,7 @@ from apps.core.models import TaskRun
 from apps.survey.models import BlockfaceReservation
 from apps.mail.views import send_reservation_reminder
 
-_COMMAND_NAME = 'apps.survey.management.commands.send_reminder_emails'
+COMMAND_NAME = 'apps.survey.management.commands.send_reminder_emails'
 _ALREADY_SENT_MESSAGE = ('WARNING: reservation emails sent already today. '
                          'Doing nothing!')
 
@@ -35,8 +35,9 @@ _DONE = -1
 
 
 class Command(BaseCommand):
+
     def _log(self, msg):
-        self.stdout.write("%s: %s" % (_COMMAND_NAME, msg))
+        self.stdout.write("%s: %s" % (COMMAND_NAME, msg))
 
     def handle(self, *args, **options):
         right_now = now()
@@ -48,7 +49,7 @@ class Command(BaseCommand):
 
             _, unlocked = (TaskRun
                            .objects
-                           .get_or_create(name=_COMMAND_NAME,
+                           .get_or_create(name=COMMAND_NAME,
                                           date_started=today))
 
         if not unlocked:

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -300,6 +300,7 @@ REGISTRATION_AUTO_LOGIN = True
 WATCHMAN_CHECKS = (
     'watchman.checks.caches',
     'watchman.checks.databases',
+    'apps.survey.checks.cron_jobs',
 )
 
 # END THIRD-PARTY CONFIGURATION


### PR DESCRIPTION
This adds a new section to the watchman health check to report the
status of cron jobs.

For the send_reminder_emails cron job we report OK if the job has run
at least once in the past 48 hours.

Connects #906