### PR TITLE
Fix species modal

### DIFF
--- a/src/nyc_trees/sass/partials/_globals.scss
+++ b/src/nyc_trees/sass/partials/_globals.scss
@@ -22,7 +22,6 @@
 html {
   font-size: 62.5%;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
-  overflow-x: hidden;
   height: 100%;
 }
 

--- a/src/nyc_trees/sass/partials/_home.scss
+++ b/src/nyc_trees/sass/partials/_home.scss
@@ -188,11 +188,6 @@ $hero-box-side-padding: 3rem;
   margin-top: -1rem;
 }
 
-.species-modal-content {
-    max-height: 300px;
-    overflow: auto;
-}
-
 .ticker {
   padding-top: 1rem;
   text-align: center;


### PR DESCRIPTION
Some of the modal styles were being overridden. Removing these overrides and removing the overflow property from the html element fixes the issue. Fixes #1661.

![image](https://cloud.githubusercontent.com/assets/1809908/7657087/3c57e412-fafd-11e4-9957-440b921229ed.png)
