### PR TITLE
Prevent decreasing max attendance below RSVP count

### DIFF
--- a/src/nyc_trees/apps/event/models.py
+++ b/src/nyc_trees/apps/event/models.py
@@ -114,6 +114,12 @@ class Event(NycModel, models.Model):
                 "Please choose a location in New York City"
             ]})
 
+        rsvp_count = self.eventregistration_set.count()
+        if self.max_attendees < rsvp_count:
+            raise ValidationError({'max_attendees': [
+                "Max attendees cannot be set to a value less than the number "
+                "of people currently registered (%d)" % rsvp_count]})
+
     def training_summary(self):
         return 'Training' if self.includes_training else 'Mapping'
 


### PR DESCRIPTION
If 12 people RSVP to an event, it should not be possible to decrease the value of max_attendees to 10.

Connects to #1676