### PR TITLE
Clarify event e-mail message when no RSVPs have opted in

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/email_rsvps.html
+++ b/src/nyc_trees/apps/event/templates/event/email_rsvps.html
@@ -16,7 +16,7 @@
                     {% include "core/partials/email_form.html" %}
                 {% else %}
                     {# There is no one to email! #}
-                    <p>There are no volun<b>treers</b> RSVPed for your event. Please try again when there is at least 1 volun<b>treer</b> RSVPed.</p>
+                    <p>None of your event's RSVPs have opted in to event e-mail notifications.</p>
                 {% endif %}
             {% endif %}
             </section>


### PR DESCRIPTION
An event may have at least 1 RSVP, but those RSVPs may not have opted in to event e-mail notifications.

Connects #1678