### PR TITLE
Use state plane projection for trees layout, for improved accuracy

### DIFF
--- a/src/nyc_trees/apps/census_admin/trees.sql
+++ b/src/nyc_trees/apps/census_admin/trees.sql
@@ -3,8 +3,8 @@ WITH trees_for_this_survey AS(
   SELECT
     id,
     survey_id,
-    .3408*(CASE WHEN curb_location='OnCurb' THEN 2.5 ELSE 12 END) curb_offset,
-    .3408*distance_to_tree dist
+    1.000*(CASE WHEN curb_location='OnCurb' THEN 2.5 ELSE 12 END) curb_offset,
+    1.000*distance_to_tree dist
   FROM survey_tree
   ORDER BY id
 ),
@@ -34,7 +34,7 @@ layed AS (
              CASE WHEN is_mapped_in_blockface_polyline_direction
              THEN st_geometryn(geom,1)
              ELSE ST_Reverse(st_geometryn(geom,1)) END,
-             _ST_BestSRID(geom::geometry)),
+             102718), -- state plane, for improved accuracy, feet units
          left_side, dist, length, width) as tbeds
   FROM aggs
 ),

--- a/src/nyc_trees/apps/survey/survey_detail.sql
+++ b/src/nyc_trees/apps/survey/survey_detail.sql
@@ -3,8 +3,8 @@ WITH trees_for_this_survey AS(
   SELECT
     id,
     survey_id,
-    .3408*(CASE WHEN curb_location='OnCurb' THEN 2.5 ELSE 12 END) curb_offset,
-    .3408*distance_to_tree dist
+    1.000*(CASE WHEN curb_location='OnCurb' THEN 2.5 ELSE 12 END) curb_offset,
+    1.000*distance_to_tree dist
   FROM survey_tree
   WHERE survey_id = %s
   ORDER BY id
@@ -33,7 +33,7 @@ layed AS (
              CASE WHEN is_mapped_in_blockface_polyline_direction
              THEN st_geometryn(geom,1)
              ELSE ST_Reverse(st_geometryn(geom,1)) END,
-             _ST_BestSRID(geom::geometry)),
+             102718), -- state plane, for improved accuracy, feet units
          left_side, dist, length, width) as tbeds
   FROM aggs
 )


### PR DESCRIPTION
The state plane projection more closely matches real-world measurements from surveyors.
Here are the results comparing utm18n (coming out of _st_bestsrid) and state plane:
```
 tree_id | survey_id | block_id | dist_requested | dist_utm18n | dist_stateplane 
---------+-----------+----------+----------------+-------------+-----------------
     528 |       165 |   343906 |         172.50 |      192.95 |          172.52
     529 |       165 |   343906 |          35.30 |       39.48 |           35.30
     530 |       165 |   343906 |          32.10 |       35.90 |           32.10
     531 |       165 |   343906 |          31.50 |       35.23 |           31.50
     532 |       165 |   343906 |          31.90 |       35.68 |           31.90
     533 |       165 |   343906 |          29.50 |       32.99 |           29.50
     534 |       165 |   343906 |          17.00 |       19.01 |           17.00
     535 |       165 |   343906 |          25.00 |       27.96 |           25.00
     536 |       165 |   343906 |          58.20 |       65.09 |           58.20
     537 |       165 |   343906 |          15.30 |       17.11 |           15.30
     538 |       165 |   343906 |          22.10 |       24.72 |           22.10
     539 |       165 |   343906 |          90.50 |      101.22 |           90.50
     540 |       165 |   343906 |          36.40 |       40.71 |           36.40
     541 |       165 |   343906 |          77.40 |       86.57 |           77.40
     542 |       165 |   343906 |          87.70 |       98.09 |           87.70
     543 |       165 |   343906 |          30.70 |       34.34 |           30.70
     544 |       165 |   343906 |         116.50 |       34.19 |          116.50
(17 rows)
```