### PR TITLE
Send RSVP email even if PDF doesn't exist

### DIFF
--- a/src/nyc_trees/apps/core/tasks.py
+++ b/src/nyc_trees/apps/core/tasks.py
@@ -13,5 +13,7 @@ from django.core.files.storage import default_storage
 def wait_for_default_storage_file(self, filename):
     if default_storage.exists(filename):
         return filename
-    else:
+    elif self.request.retries < self.max_retries:
         self.retry()
+    else:
+        return None


### PR DESCRIPTION
If the PDF can't be found on the disk after the maximum number of
retries, return None, instead of raising an exception. This ensures that
the RSVP email notification still sends even without the PDF attachment.

How to test:
1. Change an event's map pdf filename to a non-existent file (or delete the pdf inside your VM).
2. RSVP for that event.
3. In celery output you should see it try to find the PDF a few times, then give up, and send the RSVP email anyway.

Refs #1655 
