### PR TITLE
Disable trusted mapper button if user has been approved

### DIFF
--- a/src/nyc_trees/apps/core/helpers.py
+++ b/src/nyc_trees/apps/core/helpers.py
@@ -29,9 +29,15 @@ def user_is_individual_mapper(user):
 
 def user_is_trusted_mapper(user, group):
     return user.is_authenticated() and \
-        TrustedMapper.objects.filter(group=group,
-                                     user=user,
-                                     is_approved=True).exists()
+        (user_is_group_admin(user, group) or
+         TrustedMapper.objects.filter(group=group,
+                                      user=user,
+                                      is_approved=True).exists())
+
+
+def user_mapper_status_pending(user, group):
+    return user.is_authenticated() and \
+        TrustedMapper.objects.filter(user=user, group=group).exists()
 
 
 def user_is_eligible_to_become_trusted_mapper(user, group):

--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -101,12 +101,25 @@
         <form method="POST" action="{% url 'request_mapper_status' group_slug=group.slug %}">
             {% csrf_token %}
             <h4 class="section-heading">Independent Mapping</h4>
+            {% if user_is_trusted_mapper %}
+            <p>
+                You are an approved independent mapper for this group, so you
+                can reserve and map blocks in its Census Zone. Remember to
+                contact your local loaning hub to check out individual tools.
+            </p>
+            {% elif mapper_status_pending %}
+            <p>
+                You have requested independent mapper status for this group.
+                Your request is pending.
+            </p>
+            {% else %}
             <p>
                 Volun<b>treers</b> are able to map trees on their own, outside of scheduled events!
                 Click the button below to request independent mapping status within this group&rsquo;s Census Zone.
                 Remember to contact your local loaning hub to check out individual tools and start mapping on your own.
             </p>
             <button class="btn btn-primary btn-mobile--max">Request Independent Mapper Status</button>
+            {% endif %}
         </form>
     </section>
     {% endif %}

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -21,6 +21,7 @@ from libs.sql import get_group_tree_count
 
 from apps.core.helpers import (user_is_group_admin,
                                user_is_trusted_mapper,
+                               user_mapper_status_pending,
                                user_is_eligible_to_become_trusted_mapper)
 from apps.core.decorators import group_request
 from apps.core.models import Group
@@ -119,6 +120,8 @@ def group_detail(request):
         'group': group,
         'event_list': event_list,
         'user_is_following': user_is_following,
+        'user_is_trusted_mapper': user_is_trusted_mapper(user, group),
+        'mapper_status_pending': user_mapper_status_pending(user, group),
         'edit_url': reverse('group_edit', kwargs={'group_slug': group.slug}),
         'counts': {
             'tree_digits': trees_digits,


### PR DESCRIPTION
This disables the trusted mapper button on the group detail page if the
user has been approved as a trusted mapper. Some help text is also
displayed.

Connects #1668