### PR TITLE
Fix ios scrolling issues

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
@@ -1,4 +1,4 @@
-<div>
+<div id="tree-header-{{ tree_number }}">
     <h4 class="sticky-title color--primary">
         <a class="hidden pull-right" data-toggle="collapse" data-target="#tree-form-{{ tree_number }}">
             <i class="icon-down-open-big"></i>
@@ -11,7 +11,7 @@
         </span>
     </h4>
 </div>
-<form class="tree-form collapse in" data-class="tree-form" autocomplete="off" id="tree-form-{{ tree_number }}">
+<form class="tree-form collapse{% if tree_number == 1 %} in{% endif %}" data-class="tree-form" autocomplete="off" id="tree-form-{{ tree_number }}">
     <!-- We need a clickable submit button in order to trigger browser error validation popups -->
     <input type="submit" data-class="fake-submit" class="hidden">
 

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -329,10 +329,10 @@ function checkFormValidity($forms) {
             $elemToFocus.closest(dom.treeForms).collapse('show');
 
             $forms.one('shown.bs.collapse', function() {
-                triggerValidationMesasages($elemToFocus, $forms, $disabledElems);
+                triggerValidationMessages($elemToFocus, $forms, $disabledElems);
             });
         } else {
-            triggerValidationMesasages($elemToFocus, $forms, $disabledElems);
+            triggerValidationMessages($elemToFocus, $forms, $disabledElems);
         }
     } else {
         $disabledElems.attr('disabled', false);
@@ -341,7 +341,7 @@ function checkFormValidity($forms) {
     return valid;
 }
 
-function triggerValidationMesasages($elemToFocus, $forms, $disabledElems) {
+function triggerValidationMessages($elemToFocus, $forms, $disabledElems) {
     $elemToFocus.focus();
 
     // "submit" the form.  This will trigger the builtin browser validation messages.

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -65,6 +65,7 @@ var dom = {
         btnGroupNext: '#btn-group-next',
         btnNext: '#btn-next',
 
+        mainHeader: '.main-header',
         actionBar: '.action-bar-survey',
         surveyPage: '#survey',
         treeFormTemplate: '#tree-form-template',
@@ -382,30 +383,35 @@ $(dom.addTree).click(function (){
     if (checkFormValidity($lastTreeForm)) {
         var treeNumber = $treeForms.length + 1;
 
-        $(dom.treeFormcontainer).append(formTemplate({tree_number: treeNumber}));
+        // Scroll to the first field for easier data entry
+        var $lastHeader = $("#tree-header-" + (treeNumber - 1));
+        $('html, body').stop().animate({
+            scrollTop: getScrollToTopPosition($lastHeader)
+        }, 400).promise().done(function() {
+            $treeForms.collapse('hide');
+            $(dom.treeFormcontainer).append(formTemplate({tree_number: treeNumber}));
+            var $newForm = $(dom.treeFormcontainer).find(dom.treeForms).last();
+            setupSpeciesAutocomplete($newForm);
 
-        var $newForm = $(dom.treeFormcontainer).find(dom.treeForms).last();
-        setupSpeciesAutocomplete($newForm);
+            setTimeout(function() {
+                $newForm.collapse('show');
+                $(dom.collapseButton).removeClass('hidden');
 
-        $treeForms.collapse('hide');
-        $newForm.collapse('show');
+                // Hide delete tree button on all but last form
+                var $deleteButtons = $(dom.treeFormcontainer).find(dom.deleteTree);
+                $deleteButtons.addClass('hidden');
+                $deleteButtons.last().removeClass('hidden');
 
-        $(dom.treeFormcontainer).one('hidden.bs.collapse', function(e) {
-            // Scroll to the first field for easier data entry
-            var $firstField = $newForm.find('input[name="distance_to_tree"]');
-            $firstField.focus();
+                stickyTitles.update();
+            }, 100);
         });
-
-        $(dom.collapseButton).removeClass('hidden');
-
-        // Hide delete tree button on all but last form
-        var $deleteButtons = $(dom.treeFormcontainer).find(dom.deleteTree);
-        $deleteButtons.addClass('hidden');
-        $deleteButtons.last().removeClass('hidden');
-
-        stickyTitles.update();
     }
 });
+
+function getScrollToTopPosition($el) {
+    var scrollPosition = $el.offset().top - $(dom.mainHeader).height();
+    return scrollPosition;
+}
 
 $(dom.noFurtherTrees).on('click', function(e) {
     // Adding active class will reveal submit button,

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -66,6 +66,7 @@ var dom = {
         btnNext: '#btn-next',
 
         mainHeader: '.main-header',
+        mapSidebar: '.map-sidebar',
         actionBar: '.action-bar-survey',
         surveyPage: '#survey',
         treeFormTemplate: '#tree-form-template',
@@ -346,7 +347,11 @@ function triggerValidationMessages($elemToFocus, $forms, $disabledElems) {
     // Scroll so element and its label are visible
     var $fieldset = $elemToFocus.closest(dom.fieldset),
         scrollPos = getScrollToTopPosition($fieldset);
-    $('body').scrollTop(scrollPos);
+    if (isMobile()) {
+        $('body').scrollTop(scrollPos);
+    } else {
+        $(dom.mapSidebar).scrollTop(scrollPos);
+    }
 
     // "submit" the form.  This will trigger the builtin browser validation messages.
     // Our submit handler will prevent this from actually submitting
@@ -354,6 +359,10 @@ function triggerValidationMessages($elemToFocus, $forms, $disabledElems) {
 
     // Reenable things now that we're done validating
     $disabledElems.attr('disabled', false);
+}
+
+function isMobile() {
+    return $(window).width() < 768;  // Bootstrap $screen-sm
 }
 
 // We need to submit the form to see the error bubbles, but we don't want to
@@ -388,8 +397,9 @@ $(dom.addTree).click(function (){
         var treeNumber = $treeForms.length + 1;
 
         // Scroll to the first field for easier data entry
-        var $lastHeader = $("#tree-header-" + (treeNumber - 1));
-        $('html, body').stop().animate({
+        var $lastHeader = $("#tree-header-" + (treeNumber - 1)),
+            $scrollContainer = isMobile() ? $('html,body') : $(dom.mapSidebar);
+        $scrollContainer.stop().animate({
             scrollTop: getScrollToTopPosition($lastHeader)
         }, 400).promise().done(function() {
             $treeForms.collapse('hide');
@@ -413,8 +423,13 @@ $(dom.addTree).click(function (){
 });
 
 function getScrollToTopPosition($el) {
-    var scrollPosition = $el.offset().top - $(dom.mainHeader).height();
-    return scrollPosition;
+    if (isMobile()) {
+        var scrollPosition = $el.offset().top - $(dom.mainHeader).height();
+        return scrollPosition;
+    } else {
+        var scrollPosition = $el.offset().top - $(dom.surveyPage).offset().top;
+        return scrollPosition;
+    }
 }
 
 $(dom.noFurtherTrees).on('click', function(e) {

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -73,6 +73,7 @@ var dom = {
         distanceToEnd: '#distance_to_end',
         treeForms: '[data-class="tree-form"]',
         collapseButton: '[data-toggle="collapse"]',
+        fieldset: 'fieldset',
 
         addTree: '#another-tree',
         noFurtherTrees: '#no-further-trees',
@@ -342,7 +343,10 @@ function checkFormValidity($forms) {
 }
 
 function triggerValidationMessages($elemToFocus, $forms, $disabledElems) {
-    $elemToFocus.focus();
+    // Scroll so element and its label are visible
+    var $fieldset = $elemToFocus.closest(dom.fieldset),
+        scrollPos = getScrollToTopPosition($fieldset);
+    $('body').scrollTop(scrollPos);
 
     // "submit" the form.  This will trigger the builtin browser validation messages.
     // Our submit handler will prevent this from actually submitting


### PR DESCRIPTION
To test, make sure the following sequences work as described:

When adding a tree:
* header of final tree scrolls to top of visible area
* section of final tree collapses
* new tree is added, and expands
* first input is visible, but not focused

When submitting a form with errors:
* Input with the error is visible
* On platforms other than iOS, input is focused and error message is shown

Thanks to @jfrankl and @maurizi 