### PR TITLE
Increase number of Gunicorn workers

### DIFF
--- a/deployment/ansible/roles/nyc-trees.app/templates/gunicorn-nyc-trees.py.j2
+++ b/deployment/ansible/roles/nyc-trees.app/templates/gunicorn-nyc-trees.py.j2
@@ -15,5 +15,5 @@ loglevel = 'info'
 preload_app = True
 reload = False
 timeout = 60
-workers = 2
+workers = 3
 {% endif %}


### PR DESCRIPTION
The formula for number of Gunicorn workers is:

```
  (2 x $num_cores) + 1
```

The application servers are currently m3.mediums, which have 1 core. We were at 2 workers per application server, but following the formula above leaves us with (2 x 1) + 1 = 3.

See also: http://gunicorn-docs.readthedocs.org/en/latest/design.html#how-many-workers