### PR TITLE
Call client.quit after tiler redis health check

### DIFF
--- a/src/tiler/healthCheck.js
+++ b/src/tiler/healthCheck.js
@@ -37,6 +37,7 @@ function checkRedis(host, port, timeout, cb) {
     var gotResponse = false;
 
     client.on('connect', function() {
+        client.quit();
         gotResponse = true;
         cb({cache: {ok: true}});
     });
@@ -44,6 +45,7 @@ function checkRedis(host, port, timeout, cb) {
     client.on('error', function() {
         // no arguments are passed when the error event is triggered
         // TODO: Find out how to return more useful failure information
+        client.quit();
         gotResponse = true;
         cb({
             cache: {
@@ -57,6 +59,7 @@ function checkRedis(host, port, timeout, cb) {
 
     setTimeout(function() {
         if (!gotResponse) {
+            client.quit();
             cb({cache: {error: 'Timeout'}});
         }
     }, timeout);


### PR DESCRIPTION
Without explicitly quitting the client the health check slowly consumes all the available connections and starts causing failures.

Running the ``develop`` branch

```
vagrant@tiler:~$ telnet 33.33.33.30 6379
Trying 33.33.33.30...
Connected to 33.33.33.30.
Escape character is '^]'.
CLIENT LIST
$1727
addr=33.33.33.30:39040 fd=5 name= age=1728 idle=87 flags=b db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=blpop
addr=33.33.33.3:52399 fd=6 name= age=1344 idle=1344 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=exec
addr=33.33.33.3:52400 fd=8 name= age=1344 idle=1 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=publish
addr=33.33.33.3:52401 fd=9 name= age=1344 idle=0 flags=b db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=brpop
addr=33.33.33.3:52402 fd=10 name= age=1343 idle=54 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=unwatch
addr=33.33.33.3:52403 fd=11 name= age=1343 idle=1343 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52404 fd=12 name= age=1343 idle=1343 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52405 fd=14 name= age=1343 idle=1 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.3:52406 fd=15 name= age=1343 idle=1343 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.20:49684 fd=27 name= age=112 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client
addr=33.33.33.3:52426 fd=7 name= age=42 idle=42 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=ping
addr=33.33.33.20:49715 fd=13 name= age=22 idle=22 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=ping
```

After 5 requests to ``http://33.33.33.20/health-check`` there are 5 more clients

```
CLIENT LIST
$2419
addr=33.33.33.30:39040 fd=5 name= age=1759 idle=5 flags=b db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=blpop
addr=33.33.33.3:52399 fd=6 name= age=1375 idle=1375 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=exec
addr=33.33.33.3:52400 fd=8 name= age=1375 idle=2 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=publish
addr=33.33.33.3:52401 fd=9 name= age=1375 idle=1 flags=b db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=brpop
addr=33.33.33.3:52402 fd=10 name= age=1374 idle=85 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=unwatch
addr=33.33.33.3:52403 fd=11 name= age=1374 idle=1374 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52404 fd=12 name= age=1374 idle=1374 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52405 fd=14 name= age=1374 idle=2 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.3:52406 fd=15 name= age=1374 idle=1374 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.20:49684 fd=27 name= age=143 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client
addr=33.33.33.20:49715 fd=13 name= age=53 idle=5 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=rpush
addr=33.33.33.20:49718 fd=7 name= age=8 idle=8 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=info
addr=33.33.33.3:52427 fd=16 name= age=8 idle=8 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=ping
addr=33.33.33.20:49721 fd=17 name= age=7 idle=7 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=info
addr=33.33.33.20:49724 fd=18 name= age=6 idle=6 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=info
addr=33.33.33.20:49727 fd=19 name= age=6 idle=6 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=info
addr=33.33.33.20:49730 fd=20 name= age=5 idle=5 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=info
```

Restart the tiler on this branch.

```
CLIENT LIST
$1726
addr=33.33.33.30:39040 fd=5 name= age=1835 idle=5 flags=b db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=blpop
addr=33.33.33.3:52399 fd=6 name= age=1451 idle=1451 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=exec
addr=33.33.33.3:52400 fd=8 name= age=1451 idle=1 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=publish
addr=33.33.33.3:52401 fd=9 name= age=1451 idle=1 flags=b db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=brpop
addr=33.33.33.3:52402 fd=10 name= age=1450 idle=61 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=unwatch
addr=33.33.33.3:52403 fd=11 name= age=1450 idle=1450 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52404 fd=12 name= age=1450 idle=1450 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52405 fd=14 name= age=1450 idle=1 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.3:52406 fd=15 name= age=1450 idle=1450 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.20:49684 fd=27 name= age=219 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client
addr=33.33.33.3:52428 fd=7 name= age=18 idle=18 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=ping
addr=33.33.33.20:49731 fd=13 name= age=14 idle=5 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=rpush
```

After 5 requests to ``http://33.33.33.20/health-check`` there are the same number of clients

```
CLIENT LIST
$1726
addr=33.33.33.30:39040 fd=5 name= age=1852 idle=6 flags=b db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=blpop
addr=33.33.33.3:52399 fd=6 name= age=1468 idle=1468 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=exec
addr=33.33.33.3:52400 fd=8 name= age=1468 idle=0 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=publish
addr=33.33.33.3:52401 fd=9 name= age=1468 idle=0 flags=b db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=brpop
addr=33.33.33.3:52402 fd=10 name= age=1467 idle=78 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=unwatch
addr=33.33.33.3:52403 fd=11 name= age=1467 idle=1467 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52404 fd=12 name= age=1467 idle=1467 flags=N db=2 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=sadd
addr=33.33.33.3:52405 fd=14 name= age=1467 idle=0 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.3:52406 fd=15 name= age=1467 idle=1467 flags=N db=2 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
addr=33.33.33.20:49684 fd=27 name= age=236 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client
addr=33.33.33.3:52428 fd=7 name= age=35 idle=35 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=ping
addr=33.33.33.20:49731 fd=13 name= age=31 idle=6 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=rpush
```

Connects to #1704 