### PR TITLE
Add AutoScalingPolicy to application and tile servers

### DIFF
--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -252,6 +252,7 @@ t.add_resource(cw.Alarm(
     'alarmAppServerRequestCountLow',
     AlarmDescription='Application server request count low',
     AlarmActions=[Ref(app_server_scale_down_policy)],
+    InsufficientDataActions=[Ref(app_server_scale_down_policy)],
     Statistic='Sum',
     Period=60,
     Threshold='75',

--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -169,6 +169,105 @@ app_server_load_balancer = t.add_resource(elb.LoadBalancer(
     )
 ))
 
+#
+# Auto Scaling Group Resources
+#
+app_server_launch_config = t.add_resource(asg.LaunchConfiguration(
+    'lcAppServer',
+    ImageId=Ref(app_server_ami_param),
+    IamInstanceProfile=Ref(app_server_instance_profile_param),
+    InstanceType=Ref(app_server_instance_type_param),
+    KeyName=Ref(keyname_param),
+    SecurityGroups=[Ref(app_server_security_group)]
+))
+
+app_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
+    'asgAppServer',
+    AvailabilityZones=map(lambda x: 'us-east-1%s' % x,
+                          utils.EC2_AVAILABILITY_ZONES),
+    Cooldown=300,
+    DesiredCapacity=2,
+    HealthCheckGracePeriod=600,
+    HealthCheckType='ELB',
+    LaunchConfigurationName=Ref(app_server_launch_config),
+    LoadBalancerNames=[Ref(app_server_load_balancer)],
+    MaxSize=4,
+    MinSize=2,
+    NotificationConfiguration=asg.NotificationConfiguration(
+        TopicARN=Ref(notification_arn_param),
+        NotificationTypes=[
+            asg.EC2_INSTANCE_LAUNCH,
+            asg.EC2_INSTANCE_LAUNCH_ERROR,
+            asg.EC2_INSTANCE_TERMINATE,
+            asg.EC2_INSTANCE_TERMINATE_ERROR
+        ]
+    ),
+    VPCZoneIdentifier=Ref(private_subnets_param),
+    Tags=[
+        asg.Tag('Name', 'AppServer', True),
+        asg.Tag('Color', Ref(color_param), True)
+    ]
+))
+
+app_server_scale_up_policy = t.add_resource(asg.ScalingPolicy(
+    'asgAppServerScaleUpPolicy',
+    AdjustmentType='ChangeInCapacity',
+    AutoScalingGroupName=Ref(app_server_auto_scaling_group),
+    Cooldown=60,
+    ScalingAdjustment='2'
+))
+
+app_server_scale_down_policy = t.add_resource(asg.ScalingPolicy(
+    'asgAppServerScaleDownPolicy',
+    AdjustmentType='ChangeInCapacity',
+    AutoScalingGroupName=Ref(app_server_auto_scaling_group),
+    Cooldown=60,
+    ScalingAdjustment='-2'
+))
+
+#
+# CloudWatch Resources
+#
+t.add_resource(cw.Alarm(
+    'alarmAppServerRequestCountHigh',
+    AlarmDescription='Application server request count high',
+    AlarmActions=[Ref(app_server_scale_up_policy)],
+    Statistic='Sum',
+    Period=60,
+    Threshold='60',
+    EvaluationPeriods=2,
+    ComparisonOperator='GreaterThanThreshold',
+    MetricName='RequestCount',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(app_server_load_balancer)
+        )
+    ],
+))
+
+t.add_resource(cw.Alarm(
+    'alarmAppServerRequestCountLow',
+    AlarmDescription='Application server request count low',
+    AlarmActions=[Ref(app_server_scale_down_policy)],
+    Statistic='Sum',
+    Period=60,
+    Threshold='75',
+    EvaluationPeriods=10,
+    ComparisonOperator='LessThanThreshold',
+    MetricName='RequestCount',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(app_server_load_balancer)
+        )
+    ],
+))
+
 t.add_resource(cw.Alarm(
     'alarmAppServerBackend4XX',
     AlarmDescription='Application server backend 4XXs',
@@ -207,46 +306,6 @@ t.add_resource(cw.Alarm(
             Value=Ref(app_server_load_balancer)
         )
     ],
-))
-
-#
-# Auto Scaling Group Resources
-#
-app_server_launch_config = t.add_resource(asg.LaunchConfiguration(
-    'lcAppServer',
-    ImageId=Ref(app_server_ami_param),
-    IamInstanceProfile=Ref(app_server_instance_profile_param),
-    InstanceType=Ref(app_server_instance_type_param),
-    KeyName=Ref(keyname_param),
-    SecurityGroups=[Ref(app_server_security_group)]
-))
-
-app_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
-    'asgAppServer',
-    AvailabilityZones=map(lambda x: 'us-east-1%s' % x,
-                          utils.EC2_AVAILABILITY_ZONES),
-    Cooldown=300,
-    DesiredCapacity=2,
-    HealthCheckGracePeriod=600,
-    HealthCheckType='ELB',
-    LaunchConfigurationName=Ref(app_server_launch_config),
-    LoadBalancerNames=[Ref(app_server_load_balancer)],
-    MaxSize=2,
-    MinSize=2,
-    NotificationConfiguration=asg.NotificationConfiguration(
-        TopicARN=Ref(notification_arn_param),
-        NotificationTypes=[
-            asg.EC2_INSTANCE_LAUNCH,
-            asg.EC2_INSTANCE_LAUNCH_ERROR,
-            asg.EC2_INSTANCE_TERMINATE,
-            asg.EC2_INSTANCE_TERMINATE_ERROR
-        ]
-    ),
-    VPCZoneIdentifier=Ref(private_subnets_param),
-    Tags=[
-        asg.Tag('Name', 'AppServer', True),
-        asg.Tag('Color', Ref(color_param), True)
-    ]
 ))
 
 #

--- a/deployment/troposphere/tiler_template.py
+++ b/deployment/troposphere/tiler_template.py
@@ -241,6 +241,7 @@ t.add_resource(cw.Alarm(
     'alarmTileServerRequestCountLow',
     AlarmDescription='Tile server request count low',
     AlarmActions=[Ref(tile_server_scale_down_policy)],
+    InsufficientDataActions=[Ref(tile_server_scale_down_policy)],
     Statistic='Sum',
     Period=60,
     Threshold='75',

--- a/deployment/troposphere/tiler_template.py
+++ b/deployment/troposphere/tiler_template.py
@@ -158,6 +158,105 @@ tile_server_load_balancer = t.add_resource(elb.LoadBalancer(
     )
 ))
 
+#
+# Auto Scaling Group Resources
+#
+tile_server_launch_config = t.add_resource(asg.LaunchConfiguration(
+    'lcTileServer',
+    ImageId=Ref(tile_server_ami_param),
+    IamInstanceProfile=Ref(tile_server_instance_profile_param),
+    InstanceType=Ref(tile_server_instance_type_param),
+    KeyName=Ref(keyname_param),
+    SecurityGroups=[Ref(tile_server_security_group)]
+))
+
+tile_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
+    'asgTileServer',
+    AvailabilityZones=map(lambda x: 'us-east-1%s' % x,
+                          utils.EC2_AVAILABILITY_ZONES),
+    Cooldown=300,
+    DesiredCapacity=2,
+    HealthCheckGracePeriod=600,
+    HealthCheckType='ELB',
+    LaunchConfigurationName=Ref(tile_server_launch_config),
+    LoadBalancerNames=[Ref(tile_server_load_balancer)],
+    MaxSize=4,
+    MinSize=2,
+    NotificationConfiguration=asg.NotificationConfiguration(
+        TopicARN=Ref(notification_arn_param),
+        NotificationTypes=[
+            asg.EC2_INSTANCE_LAUNCH,
+            asg.EC2_INSTANCE_LAUNCH_ERROR,
+            asg.EC2_INSTANCE_TERMINATE,
+            asg.EC2_INSTANCE_TERMINATE_ERROR
+        ]
+    ),
+    VPCZoneIdentifier=Ref(private_subnets_param),
+    Tags=[
+        asg.Tag('Name', 'TileServer', True),
+        asg.Tag('Color', Ref(color_param), True)
+    ]
+))
+
+tile_server_scale_up_policy = t.add_resource(asg.ScalingPolicy(
+    'asgTileServerScaleUpPolicy',
+    AdjustmentType='ChangeInCapacity',
+    AutoScalingGroupName=Ref(tile_server_auto_scaling_group),
+    Cooldown=60,
+    ScalingAdjustment='2'
+))
+
+tile_server_scale_down_policy = t.add_resource(asg.ScalingPolicy(
+    'asgTileServerScaleDownPolicy',
+    AdjustmentType='ChangeInCapacity',
+    AutoScalingGroupName=Ref(tile_server_auto_scaling_group),
+    Cooldown=60,
+    ScalingAdjustment='-2'
+))
+
+#
+# CloudWatch Resources
+#
+t.add_resource(cw.Alarm(
+    'alarmTileServerRequestCountHigh',
+    AlarmDescription='Tile server request count high',
+    AlarmActions=[Ref(tile_server_scale_up_policy)],
+    Statistic='Sum',
+    Period=60,
+    Threshold='60',
+    EvaluationPeriods=2,
+    ComparisonOperator='GreaterThanThreshold',
+    MetricName='RequestCount',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(tile_server_load_balancer)
+        )
+    ],
+))
+
+t.add_resource(cw.Alarm(
+    'alarmTileServerRequestCountLow',
+    AlarmDescription='Tile server request count low',
+    AlarmActions=[Ref(tile_server_scale_down_policy)],
+    Statistic='Sum',
+    Period=60,
+    Threshold='75',
+    EvaluationPeriods=10,
+    ComparisonOperator='LessThanThreshold',
+    MetricName='RequestCount',
+    Namespace='AWS/ELB',
+    Dimensions=[
+        cw.MetricDimension(
+            'metricLoadBalancerName',
+            Name='LoadBalancerName',
+            Value=Ref(tile_server_load_balancer)
+        )
+    ],
+))
+
 t.add_resource(cw.Alarm(
     'alarmTileServerBackend4XX',
     AlarmDescription='Tile server backend 4XXs',
@@ -198,45 +297,6 @@ t.add_resource(cw.Alarm(
     ],
 ))
 
-#
-# Auto Scaling Group Resources
-#
-tile_server_launch_config = t.add_resource(asg.LaunchConfiguration(
-    'lcTileServer',
-    ImageId=Ref(tile_server_ami_param),
-    IamInstanceProfile=Ref(tile_server_instance_profile_param),
-    InstanceType=Ref(tile_server_instance_type_param),
-    KeyName=Ref(keyname_param),
-    SecurityGroups=[Ref(tile_server_security_group)]
-))
-
-tile_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
-    'asgTileServer',
-    AvailabilityZones=map(lambda x: 'us-east-1%s' % x,
-                          utils.EC2_AVAILABILITY_ZONES),
-    Cooldown=300,
-    DesiredCapacity=2,
-    HealthCheckGracePeriod=600,
-    HealthCheckType='ELB',
-    LaunchConfigurationName=Ref(tile_server_launch_config),
-    LoadBalancerNames=[Ref(tile_server_load_balancer)],
-    MaxSize=2,
-    MinSize=2,
-    NotificationConfiguration=asg.NotificationConfiguration(
-        TopicARN=Ref(notification_arn_param),
-        NotificationTypes=[
-            asg.EC2_INSTANCE_LAUNCH,
-            asg.EC2_INSTANCE_LAUNCH_ERROR,
-            asg.EC2_INSTANCE_TERMINATE,
-            asg.EC2_INSTANCE_TERMINATE_ERROR
-        ]
-    ),
-    VPCZoneIdentifier=Ref(private_subnets_param),
-    Tags=[
-        asg.Tag('Name', 'TileServer', True),
-        asg.Tag('Color', Ref(color_param), True)
-    ]
-))
 
 #
 # Outputs


### PR DESCRIPTION
There are several high traffic periods in the day when mapping events occur. Typically, these happen in bursts and then taper off after an hour or two. In order to protect ourselves during these surges of traffic, scale up and scale down policies have been added to the application and tile servers.

Looking at the ELB graphs for overall request count, a threshold of 60 with a period of 60 seconds and 2 consecutive evaluation periods is a good combination to trigger a scale up event. Before the following minute is over, server capacity doubles.

On the other hand, a threshold of 75 with a period of 60 seconds and 10 consecutive evaluation periods is a safe combination to trigger a scale down event. This is more conservative and protects against lulls between evaluation periods where activity drops, but then picks back up in the next minute or two.

Regardless, the desired and minimum capacity for each AutoScalingGroup remains at 2.