### PR TITLE
Allow group admins to survey their own events without needing an RSVP

### DIFF
--- a/src/nyc_trees/apps/event/helpers.py
+++ b/src/nyc_trees/apps/event/helpers.py
@@ -2,17 +2,21 @@ from apps.event.models import EventRegistration
 
 
 def user_is_rsvped_for_event(user, event):
-    # The filter uses user.id so that the user argument can be either
-    # a real User or the anonymous user (not logged in). The anonymous
-    # user is a SimpleLazyObject, which you cannot use in a filter.
-    return EventRegistration.objects\
-                            .filter(user=user.id, event=event)\
-                            .count() > 0
+    if not user.is_authenticated():
+        return False
+    # Group admins are implicitly RSVPd to their own events.
+    if event.group.admin == user:
+        return True
+    return EventRegistration.objects.filter(user=user, event=event).exists()
 
 
 def user_is_checked_in_to_event(user, event):
     """Return True if user is checked-in to event"""
-    return (user.is_authenticated() and
-            EventRegistration.objects.filter(user=user,
-                                             event=event,
-                                             did_attend=True).exists())
+    if not user.is_authenticated():
+        return False
+    # Group admins are implicitly RSVPd to their own events.
+    if event.group.admin == user:
+        return True
+    return EventRegistration.objects.filter(user=user,
+                                            event=event,
+                                            did_attend=True).exists()

--- a/src/nyc_trees/apps/event/models.py
+++ b/src/nyc_trees/apps/event/models.py
@@ -222,8 +222,8 @@ class EventRegistration(NycModel, models.Model):
         # Then get those events which are starting soon or have yet to end, or
         # any attended events from today, which can be mapped until midnight
         registrations = EventRegistration.objects \
-            .filter(user=user,
-                    event__begins_at__gte=beginning_of_day_utc) \
+            .filter(user=user) \
+            .filter(event__begins_at__gte=beginning_of_day_utc) \
             .filter(Q(did_attend=True, event__ends_at__lte=end_of_day_utc) |
                     Q(event__begins_at__lte=now_utc + STARTING_SOON_WINDOW,
                       event__ends_at__gt=now_utc)) \
@@ -231,6 +231,30 @@ class EventRegistration(NycModel, models.Model):
 
         attended = [r.event for r in registrations if r.did_attend]
         non_attended = [r.event for r in registrations if not r.did_attend]
+
+        # Group admins don't need to RSVP to be able to survey events.
+        # These filters are derived from the query directly above.
+        # The reason for copying this code rather than using queryset
+        # composition is that the filters are different enough
+        # (did_attend=True is irrelevant here) and the value of making this
+        # DRY does not seem worth the effort at this point.
+        admin_events = Event.objects \
+            .filter(group__admin=user) \
+            .filter(begins_at__gte=beginning_of_day_utc) \
+            .filter(Q(ends_at__lte=end_of_day_utc) |
+                    Q(begins_at__lte=now_utc + STARTING_SOON_WINDOW,
+                      ends_at__gt=now_utc))
+        non_attended = non_attended + list(admin_events)
+
+        # Filter non-attended events from attended events.
+        # The purpose of this is to fix an edge case where a group admin
+        # has both RSVPd and checked-into their own event. Without this,
+        # clicking the Treecorder link in the nav would display 2 links
+        # (the checkin page and the survey page). Since we filter out
+        # non-attended events, only the check-in page should appear for
+        # group admins.
+        attended = list(set(attended) - set(non_attended))
+
         return attended, non_attended
 
     @classmethod
@@ -239,13 +263,26 @@ class EventRegistration(NycModel, models.Model):
         Return the EventRegistration for the next event starting soon, or None
         """
         now_utc = now()
+        events_now = Event.objects \
+            .filter(begins_at__lte=now_utc + STARTING_SOON_WINDOW,
+                    ends_at__gt=now_utc) \
+            .order_by('begins_at')
 
         registrations = EventRegistration.objects \
-            .filter(user=user,
-                    event__begins_at__lte=now_utc + STARTING_SOON_WINDOW,
-                    event__ends_at__gt=now_utc) \
-            .prefetch_related('event') \
-            .order_by('event__begins_at')
+            .filter(user=user) \
+            .filter(event_id__in=events_now.values_list('id', flat=True)) \
+            .order_by('event__begins_at') \
+            .prefetch_related('event')
+
+        # Since this method returns EventRegistrations instead of Events,
+        # we have to union the above result with a list of artificial
+        # EventRegistration objects.
+        admin_events = events_now.filter(group__admin=user)
+        admin_rsvps = [EventRegistration(user=user,
+                                         event=event,
+                                         did_attend=True)
+                       for event in admin_events]
+        registrations = admin_rsvps + list(registrations)
 
         return registrations[0] if registrations else None
 

--- a/src/nyc_trees/apps/event/templates/event/event_detail.html
+++ b/src/nyc_trees/apps/event/templates/event/event_detail.html
@@ -20,7 +20,11 @@
                         is starting soon.
                     {% endif %}
                 </div>
-                {% if event_registration %}
+                {% if request.user == event.group.admin %}
+                    <div id="event-button" class="event-alert-button col-md-2 col-xs-4">
+                        {% include "event/partials/event_alert_button.html" with did_attend_event=True %}
+                    </div>
+                {% elif event_registration %}
                     <div id="event-button" class="event-alert-button col-md-2 col-xs-4">
                         {% include "event/partials/event_alert_button.html" with did_attend_event=event_registration.did_attend %}
                     </div>

--- a/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
@@ -23,7 +23,10 @@ The following variables must be in scope:
             <a href="{{ event_edit_url }}"
                class="btn btn-secondary"><i class="icon-cog"></i>Edit</a>
         {% endif %}
-        {% if is_rsvped %}
+        {% if is_admin %}
+           <a id="rsvp"
+               class="btn btn-secondary btn-rsvp active">Attending</a>
+        {% elif is_rsvped %}
             <a id="rsvp"
                href="#"
                data-verb="DELETE"


### PR DESCRIPTION
This change allows group admins to survey their own events without
taking up an RSVP slot. Clicking the Treecorder link in the nav while
an event is in progress should take the group admin to the event
check-in page.

To test:
1. Login as a group admin with an event in progress (don't RSVP)
2. Click the Treecorder link
3. You should be taken to the "survey for event" page

Connects #1692