### PR TITLE
Fix "request mapper status" link on reservations instructions page

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/reservations_instructions.html
+++ b/src/nyc_trees/apps/survey/templates/survey/reservations_instructions.html
@@ -59,9 +59,9 @@
         </div>
     </a>
 
-    <form method="POST" action="{% url "request_individual_mapper_status" username=user.username %}">
+    <form id="request_status" method="POST" action="{% url "request_individual_mapper_status" username=user.username %}">
         {% csrf_token %}
-        <a href="javascript:;" onclick="form.submit()" class="training block item{% if not step3_complete %} inactive{% endif %}">
+        <a href="javascript:;" {% if step3_complete %}onclick="request_status.submit()"{% endif %} class="training block item{% if not step3_complete %} inactive{% endif %}">
             <div class="row">
                 <div class="col-xs-8">
                     <h5>Request independent mapper status</h5>

--- a/src/nyc_trees/apps/users/views/user.py
+++ b/src/nyc_trees/apps/users/views/user.py
@@ -104,12 +104,16 @@ def update_user(request, username):
 
 def request_individual_mapper_status(request, username):
     user = request.user
-    if not user.eligible_to_become_individual_mapper:
-        return HttpResponseForbidden()
-    if not user.individual_mapper:
+    if user.individual_mapper:
+        # Nothing to do.
+        pass
+    elif not user.individual_mapper \
+            and user.eligible_to_become_individual_mapper():
         user.individual_mapper = True
         user.requested_individual_mapping_at = timezone.now()
         user.clean_and_save()
+    else:
+        return HttpResponseForbidden()
     return redirect('individual_mapper_instructions')
 
 


### PR DESCRIPTION
This fixes the "Request independent mapper status" link (step 4) on the
reservations instructions page.

This also fixes a bug where you could bypass training by submitting a
POST to the request mapper status endpoint.

Connects #1694