### PR TITLE
Fix sorting in tree shapefile query

### DIFF
--- a/src/nyc_trees/apps/census_admin/trees.sql
+++ b/src/nyc_trees/apps/census_admin/trees.sql
@@ -6,11 +6,13 @@ WITH trees_for_this_survey AS(
     1.000*(CASE WHEN curb_location='OnCurb' THEN 2.5 ELSE 12 END) curb_offset,
     1.000*distance_to_tree dist
   FROM survey_tree
-  ORDER BY id
 ),
 aggregated_trees AS (
-  SELECT survey_id, array_agg(curb_offset) width,
-         array_agg(0) length, array_agg(dist) dist, array_agg(id) tree_ids
+  SELECT survey_id,
+         array_agg(curb_offset ORDER BY id) width,
+         array_agg(0) length,
+         array_agg(dist ORDER BY id) dist,
+         array_agg(id ORDER BY id) tree_ids
   FROM trees_for_this_survey
   GROUP BY survey_id
 ),


### PR DESCRIPTION
Sorting each aggregate by the tree id ensures all the arrays are in the same order, the order in which the trees were entered.

Test by comparing the ``trees.shp`` files generated by ``dump_db`` in a desktop GIS, before and after the fix.

Before

![screen shot 2015-05-21 at 9 22 57 am](https://cloud.githubusercontent.com/assets/17363/7753969/af8abec4-ff9d-11e4-990d-af167b5d868f.png)

After

![screen shot 2015-05-21 at 9 23 26 am](https://cloud.githubusercontent.com/assets/17363/7753972/b58afca8-ff9d-11e4-84ee-3bb57955e68c.png)


Connects to #1711
