### PR TITLE
Turn off zoom fixes on the progress map when reloading any layer

### DIFF
--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -112,6 +112,9 @@ function loadLayers($mode) {
         geojsonUrl = $mode.data('geojson-url'),
         bounds = $mode.data('bounds');
 
+    progressMap.off('zoomend', fixZoomLayerSwitch);
+    progressMap.off('zoomend', changeLegendEntries);
+
     // Replace layers
     $.each([tileLayer, geojsonLayer, neighborhoodTileLayer, boroughTileLayer], function(_, layer) {
         if (layer) {
@@ -157,9 +160,6 @@ function addLayers(bounds, tileUrl, neighborhoodTileUrl, boroughTileUrl) {
     // Add layer to map after zoom animation completes.
     // (Otherwise spurious tile requests will be issued at the old zoom level.)
     mapModule.fitBounds(progressMap, bounds).then(function() {
-        progressMap.off('zoomend', fixZoomLayerSwitch);
-        progressMap.off('zoomend', changeLegendEntries);
-
         if (neighborhoodTileUrl || boroughTileUrl) {
             tileLayer = mapModule.addTileLayer(progressMap, {
                 url: tileUrl,


### PR DESCRIPTION
We need to put events on zoomend for the all progress view, but it
interferes with the selection on the user and group views.

We had been explicitly turning the zoomend handler off, but it was only
affecting user progress, not group progress.  Moving the `.off(...)` calls
should make it turn off for both.

Connects to #1697