### PR TITLE
Ensure that address search box is above leaflet controls.

### DIFF
--- a/src/nyc_trees/sass/partials/_map.scss
+++ b/src/nyc_trees/sass/partials/_map.scss
@@ -147,6 +147,7 @@
   font-size: $font-size-h6;
   background-color: #fff;
   padding: $grid-gutter-width/2;
+  z-index: $zindex-leaflet-controls+1;
 }
 
 .location-search-results {


### PR DESCRIPTION
Important for android browsers where the virtual keyboard resizes the
browser window, which can shrink the leaflet map enough to make the search
and leaflet controls conflict.

Connects to #1683