### PR TITLE
Fix field validation for the "Distance to End" field

### DIFF
--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -345,8 +345,9 @@ function checkFormValidity($forms) {
 
 function triggerValidationMessages($elemToFocus, $forms, $disabledElems) {
     // Scroll so element and its label are visible
-    var $fieldset = $elemToFocus.closest(dom.fieldset),
-        scrollPos = getScrollToTopPosition($fieldset);
+    var $fieldset = $elemToFocus.closest(dom.fieldset);
+    // If we couldn't find a fieldset (likely distance to end), just scroll to the element
+    var scrollPos = getScrollToTopPosition($fieldset.length > 0 ? $fieldset : $elemToFocus);
     if (isMobile()) {
         $('body').scrollTop(scrollPos);
     } else {


### PR DESCRIPTION
The validation for "Distance to End" was broken by the recent iOS fixes
that scroll the page on validation failures.  The JS was trying to scroll
to the fieldset containing the input that failed validation, but the
Disatnce to End field is not inside a fieldset.

To fix this and prevent future regressions, I have changed it so that we
fall back to scrolling to the input itself if we cannot find a fieldset.

Connects to #1701