### PR TITLE
Allow census admins to map any available block, regardless of group.

### DIFF
--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.utils.timezone import make_aware, utc
 
+from apps.core.helpers import user_is_census_admin
 from apps.survey.models import (Group, Blockface, Survey, BlockfaceReservation,
                                 Borough, Territory, NeighborhoodTabulationArea)
 from apps.users.models import TrustedMapper
@@ -46,9 +47,15 @@ def get_context_for_group_progress_layer():
 
 @login_required
 def get_context_for_reservable_layer(request):
-    models = [Group, Blockface, Territory, BlockfaceReservation, TrustedMapper]
-    return _get_context_for_layer("user_reservable", models,
-                                  {'user': request.user.pk})
+    if user_is_census_admin(request.user):
+        models = [Blockface, BlockfaceReservation]
+        return _get_context_for_layer("admin_reservable", models,
+                                      {'user': request.user.pk})
+    else:
+        models = [
+            Group, Blockface, Territory, BlockfaceReservation, TrustedMapper]
+        return _get_context_for_layer("user_reservable", models,
+                                      {'user': request.user.pk})
 
 
 @login_required

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -21,7 +21,8 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils.timezone import now
 
 from apps.core.models import Group
-from apps.core.helpers import user_is_group_admin, user_is_individual_mapper
+from apps.core.helpers import (user_is_group_admin, user_is_individual_mapper,
+                               user_is_census_admin)
 
 from apps.event.models import Event
 from apps.event.helpers import (user_is_checked_in_to_event,
@@ -359,7 +360,7 @@ def confirm_blockface_reservations(request):
 
         if ((blockface.is_available and
              blockface.id not in already_reserved_blockface_ids and
-             (territory is None or
+             (territory is None or user_is_census_admin(request.user) or
               territory.group_id in user_trusted_group_ids or
               territory.group_id in user_admin_group_ids))):
             new_reservations.append(BlockfaceReservation(

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -35,6 +35,7 @@ var Windshaft = require('windshaft'),
         user_progress: 'id',
         group_progress: 'id',
         user_reservable: 'id,group_id,group_slug,survey_type,restriction',
+        admin_reservable: 'id,survey_type,restriction',
         user_reservations: 'id,survey_type,geojson'
     },
 

--- a/src/tiler/sql/admin_reservable.sql
+++ b/src/tiler/sql/admin_reservable.sql
@@ -1,0 +1,25 @@
+(SELECT
+  block.geom,
+  block.id,
+  CASE
+    -- Not even census admins can reserve an unavailable or already reserved blockface.
+    WHEN (block.is_available AND reservation.id IS NULL) THEN 'available'
+    -- If a blockface is currently reserved, we should make it look
+    -- 'available'.  We use a GeoJSON layer in the UI for the user's
+    -- reserved blockfaces, and when a blockface is deselected we want to
+    -- be able to reselect it
+    WHEN (block.is_available
+          AND reservation.user_id IS NOT DISTINCT FROM <%= user_id %>) THEN 'available'
+    ELSE 'unavailable'
+  END AS survey_type,
+  CASE
+    WHEN NOT block.is_available THEN 'unavailable'
+    WHEN reservation.id IS NOT NULL AND reservation.user_id <> <%= user_id %> THEN 'reserved'
+    ELSE 'none'
+  END AS restriction
+  FROM survey_blockface AS block
+  LEFT OUTER JOIN survey_blockfacereservation AS reservation
+    ON (block.id = reservation.blockface_id
+        AND reservation.canceled_at IS NULL
+        AND reservation.expires_at > now() at time zone 'utc')
+) AS query


### PR DESCRIPTION
Adds a separate reservable layer for census admins, which shows allows
them to map any available unreserved block, regardless of trusted mapper
status for blocks in group territory.

Connects to #199