### PR TITLE
Show error validation messages on iOS and old Android browsers

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
@@ -7,6 +7,7 @@
 {% endif %}
 <div class="field">
 
+    <div class="errorlist hidden" data-name="{{ field }}">This field is required.</div>
     <div class="btn-group btn-group-toggles">
         {% for value, label in choices %}
             {# NOTE: For the styling to work correctly, the label must come directly after the radio #}

--- a/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/radios.html
@@ -7,7 +7,7 @@
 {% endif %}
 <div class="field">
 
-    <div class="errorlist hidden" data-name="{{ field }}">This field is required.</div>
+    <div class="errorlist" style="display: none;" data-name="{{ field }}">This field is required.</div>
     <div class="btn-group btn-group-toggles">
         {% for value, label in choices %}
             {# NOTE: For the styling to work correctly, the label must come directly after the radio #}

--- a/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
@@ -16,7 +16,7 @@
         <legend>Measurements</legend>
         <div class="field">
             <label for="distance_to_tree-{{ tree_number }}">Distance to Tree <small>(decimal feet)</small></label>
-            <div class="errorlist hidden" data-name="distance_to_tree">Please enter a number between 0 and 100,000.</div>
+            <div class="errorlist" style="display: none;" data-name="distance_to_tree">Please enter a number between 0 and 100,000.</div>
             <input class="form-control" name="distance_to_tree" id="distance_to_tree-{{ tree_number }}" required type="number" min="0" max="100000" step="any" placeholder="ft">
         </div>
     </fieldset>
@@ -44,7 +44,7 @@
             <legend>Stump Size</legend>
             <div class="stump_diameter field">
                 <label for="stump_diameter-{{ tree_number }}">Stump Diameter <small>(inches)</small></label>
-                <div class="errorlist hidden" data-name="stump_diameter">Please enter a number between 0 and 2,000.</div>
+                <div class="errorlist" style="display: none;" data-name="stump_diameter">Please enter a number between 0 and 2,000.</div>
                 <input class="form-control" name="stump_diameter" id="stump_diameter-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
             </div>
         </fieldset>
@@ -55,7 +55,7 @@
             <legend>Tree Trunk</legend>
             <div class="field">
                 <label for="alive-circumference-{{ tree_number }}">Circumference <small>(inches)</small></label>
-                <div class="errorlist hidden" data-name="circumference">Please enter a number between 0 and 2,000.</div>
+                <div class="errorlist" style="display: none;" data-name="circumference">Please enter a number between 0 and 2,000.</div>
                 <input class="form-control" name="circumference" id="alive-circumference-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
             </div>
         </fieldset>
@@ -65,7 +65,7 @@
             <legend>Tree Species</legend>
             <div class="field">
                 <label for="species_id-{{ tree_number }}">Species Name</label>
-                <div class="errorlist hidden" data-name="species_id">This field is required.</div>
+                <div class="errorlist" style="display: none;" data-name="species_id">This field is required.</div>
                 <select name="species_id" id="species_id-{{ tree_number }}" required>
                   {# A blank option so first species is not preselected #}
                   <option value="">&nbsp;</option>
@@ -99,7 +99,7 @@
             <legend>Tree Problems</legend>
             <div class="field">
                 <div>
-                    <div class="errorlist hidden" data-name="problems">Please select one or more fields.</div>
+                    <div class="errorlist" style="display: none;" data-name="problems">Please select one or more fields.</div>
                     <input id="no-problems-{{ tree_number }}" required type="checkbox" name="problems" value="None" />
                     <label class="btn btn-block" for="no-problems-{{ tree_number }}">
                         No Problems

--- a/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
@@ -12,13 +12,11 @@
     </h4>
 </div>
 <form class="tree-form collapse{% if tree_number == 1 %} in{% endif %}" data-class="tree-form" autocomplete="off" id="tree-form-{{ tree_number }}">
-    <!-- We need a clickable submit button in order to trigger browser error validation popups -->
-    <input type="submit" data-class="fake-submit" class="hidden">
-
     <fieldset>
         <legend>Measurements</legend>
         <div class="field">
             <label for="distance_to_tree-{{ tree_number }}">Distance to Tree <small>(decimal feet)</small></label>
+            <div class="errorlist hidden" data-name="distance_to_tree">Please enter a number between 0 and 100,000.</div>
             <input class="form-control" name="distance_to_tree" id="distance_to_tree-{{ tree_number }}" required type="number" min="0" max="100000" step="any" placeholder="ft">
         </div>
     </fieldset>
@@ -46,6 +44,7 @@
             <legend>Stump Size</legend>
             <div class="stump_diameter field">
                 <label for="stump_diameter-{{ tree_number }}">Stump Diameter <small>(inches)</small></label>
+                <div class="errorlist hidden" data-name="stump_diameter">Please enter a number between 0 and 2,000.</div>
                 <input class="form-control" name="stump_diameter" id="stump_diameter-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
             </div>
         </fieldset>
@@ -56,13 +55,17 @@
             <legend>Tree Trunk</legend>
             <div class="field">
                 <label for="alive-circumference-{{ tree_number }}">Circumference <small>(inches)</small></label>
+                <div class="errorlist hidden" data-name="circumference">Please enter a number between 0 and 2,000.</div>
                 <input class="form-control" name="circumference" id="alive-circumference-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
             </div>
         </fieldset>
+    </div>
+    <div data-status="Alive" class="hidden">
         <fieldset>
             <legend>Tree Species</legend>
             <div class="field">
                 <label for="species_id-{{ tree_number }}">Species Name</label>
+                <div class="errorlist hidden" data-name="species_id">This field is required.</div>
                 <select name="species_id" id="species_id-{{ tree_number }}" required>
                   {# A blank option so first species is not preselected #}
                   <option value="">&nbsp;</option>
@@ -96,6 +99,7 @@
             <legend>Tree Problems</legend>
             <div class="field">
                 <div>
+                    <div class="errorlist hidden" data-name="problems">Please select one or more fields.</div>
                     <input id="no-problems-{{ tree_number }}" required type="checkbox" name="problems" value="None" />
                     <label class="btn btn-block" for="no-problems-{{ tree_number }}">
                         No Problems

--- a/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
@@ -18,8 +18,8 @@
     <fieldset>
         <legend>Measurements</legend>
         <div class="field">
-            <label for="distance_to_tree">Distance to Tree <small>(decimal feet)</small></label>
-            <input class="form-control" name="distance_to_tree" id="distance_to_tree" required type="number" min="0" max="100000" step="any" placeholder="ft">
+            <label for="distance_to_tree-{{ tree_number }}">Distance to Tree <small>(decimal feet)</small></label>
+            <input class="form-control" name="distance_to_tree" id="distance_to_tree-{{ tree_number }}" required type="number" min="0" max="100000" step="any" placeholder="ft">
         </div>
     </fieldset>
 
@@ -45,19 +45,19 @@
         <fieldset>
             <legend>Stump Size</legend>
             <div class="stump_diameter field">
-                <label>Stump Diameter <small>(inches)</small></label>
-                <input class="form-control" name="stump_diameter" id="stump_diameter" required type="number" min="1" max="2000" step="1" placeholder="in">
+                <label for="stump_diameter-{{ tree_number }}">Stump Diameter <small>(inches)</small></label>
+                <input class="form-control" name="stump_diameter" id="stump_diameter-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
             </div>
         </fieldset>
     </div>
 
-        <!-- Circumference is repeated here for convenience, to avoid having to special-case showing/hiding it. -->
+    <!-- Circumference is repeated here for convenience, to avoid having to special-case showing/hiding it. -->
     <div data-status="Dead" class="hidden">
         <fieldset>
             <legend>Tree Trunk</legend>
             <div class="field">
-                <label>Circumference <small>(inches)</small></label>
-                <input class="form-control" name="circumference" required type="number" min="1" max="2000" step="1" placeholder="in">
+                <label for="dead-circumference-{{ tree_number }}">Circumference <small>(inches)</small></label>
+                <input class="form-control" name="circumference" id="dead-circumference-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
             </div>
         </fieldset>
     </div>
@@ -66,15 +66,15 @@
         <fieldset>
             <legend>Tree Trunk</legend>
             <div class="field">
-                <label for="circumference">Circumference <small>(inches)</small></label>
-                <input class="form-control" name="circumference" id="circumference" required type="number" min="1" max="2000" step="1" placeholder="in">
+                <label for="alive-circumference-{{ tree_number }}">Circumference <small>(inches)</small></label>
+                <input class="form-control" name="circumference" id="alive-circumference-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
             </div>
         </fieldset>
         <fieldset>
             <legend>Tree Species</legend>
             <div class="field">
-                <label for="species_id">Species Name</label>
-                <select name="species_id" id="species_id" required>
+                <label for="species_id-{{ tree_number }}">Species Name</label>
+                <select name="species_id" id="species_id-{{ tree_number }}" required>
                   {# A blank option so first species is not preselected #}
                   <option value="">&nbsp;</option>
                   {% for species in choices.species %}

--- a/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/tree_form.html
@@ -51,18 +51,7 @@
         </fieldset>
     </div>
 
-    <!-- Circumference is repeated here for convenience, to avoid having to special-case showing/hiding it. -->
-    <div data-status="Dead" class="hidden">
-        <fieldset>
-            <legend>Tree Trunk</legend>
-            <div class="field">
-                <label for="dead-circumference-{{ tree_number }}">Circumference <small>(inches)</small></label>
-                <input class="form-control" name="circumference" id="dead-circumference-{{ tree_number }}" required type="number" min="1" max="2000" step="1" placeholder="in">
-            </div>
-        </fieldset>
-    </div>
-
-    <div data-status="Alive" class="hidden">
+    <div data-status="Alive Dead" class="hidden">
         <fieldset>
             <legend>Tree Trunk</legend>
             <div class="field">

--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -49,12 +49,10 @@
 
             <div id="no-further-trees-group">
                 <form autocomplete="off" class="distance-end-form">
-                    <!-- We need a clickable submit button in order to trigger browser error validation popups -->
-                    <input type="submit" data-class="fake-submit" class="hidden">
-
                     <div class="field">
                         <label for="distance_to_end">Distance to End <small>(decimal feet)</small></label>
-                        <input id="distance_to_end" class="form-control" required type="number" min="0" max="100000" step="any" placeholder="ft">
+                        <div class="errorlist hidden" data-name="distance_to_end">Please enter a number between 0 and 100,000.</div>
+                        <input id="distance_to_end" name="distance_to_end" class="form-control" required type="number" min="0" max="100000" step="any" placeholder="ft">
                     </div>
                 </form>
                 <div class="tree-form-block">

--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -51,7 +51,7 @@
                 <form autocomplete="off" class="distance-end-form">
                     <div class="field">
                         <label for="distance_to_end">Distance to End <small>(decimal feet)</small></label>
-                        <div class="errorlist hidden" data-name="distance_to_end">Please enter a number between 0 and 100,000.</div>
+                        <div class="errorlist" style="display: none;" data-name="distance_to_end">Please enter a number between 0 and 100,000.</div>
                         <input id="distance_to_end" name="distance_to_end" class="form-control" required type="number" min="0" max="100000" step="any" placeholder="ft">
                     </div>
                 </form>

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -301,9 +301,9 @@ function checkFormValidity($forms) {
         var $el = $(el),
             $error = getErrorlistForElement($el);
 
-        $error.addClass('hidden');
+        $error.hide();
         if ($el.is(':visible') && !el.validity.valid) {
-            $error.removeClass('hidden');
+            $error.show();
 
             // We keep a handle to the first invalid element so we can scroll to it.
             if (valid) {
@@ -348,7 +348,7 @@ function scrollToInvalidElement($elemToFocus, $forms, $disabledElems) {
     // If we couldn't find a fieldset (likely distance to end), just scroll to the element
     var scrollPos = getScrollToTopPosition($fieldset.length > 0 ? $fieldset : $elemToFocus);
     if (isMobile()) {
-        $('body').scrollTop(scrollPos);
+        $('html,body').scrollTop(scrollPos);
     } else {
         $(dom.mapSidebar).scrollTop(scrollPos);
     }
@@ -359,8 +359,24 @@ function scrollToInvalidElement($elemToFocus, $forms, $disabledElems) {
 
 // Clear error bubbles when values change
 $(dom.surveyPage).on('blur change keyup paste', function(e) {
-    if (e.target.validity.valid) {
-        getErrorlistForElement($(e.target)).addClass('hidden');
+    var $error = getErrorlistForElement($(e.target)),
+        currentScroll, $scrollableElem;
+
+    // We carefully scroll the page up with the same animation time as the
+    // $error.slideDown(), so that the actual input element remains in the same
+    // place on the page
+    if ($error.is(':visible') && e.target.validity.valid) {
+        $error.slideUp(300);
+
+        if (isMobile()) {
+            $scrollableElem = $('html,body');
+            currentScroll = $(document).scrollTop();
+        } else {
+            $scrollableElem = $(dom.mapSidebar);
+            currentScroll = $scrollableElem.scrollTop();
+        }
+        var newScrollPos = currentScroll - $error.outerHeight(true);
+        $scrollableElem.animate({ scrollTop: newScrollPos }, 300);
     }
 });
 

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -265,7 +265,8 @@ function getSectionToggleHandler(fieldName) {
         var currentStatus = $form.find('input[name="' + fieldName + '"]:checked').val() || "";
 
         $sections.addClass('hidden');
-        $sections.filter('[data-' + fieldName + '="' + currentStatus + '"]').removeClass('hidden');
+        // Note that we use '~=` which selects from a whitespace deliminated list
+        $sections.filter('[data-' + fieldName + '~="' + currentStatus + '"]').removeClass('hidden');
     };
 }
 

--- a/src/nyc_trees/sass/partials/_form-errors.scss
+++ b/src/nyc_trees/sass/partials/_form-errors.scss
@@ -1,36 +1,39 @@
 .errorlist {
-	color: darken($brand-warning, 20%);
-	padding: .25rem 1rem .25rem 3rem;
-	background: rgba($brand-warning, 0.3);
-	border: 1px solid $brand-warning;
-	border-radius: $border-radius-base;
-	position: relative;
-	margin: 0 0 .25rem;
-	list-style-type: circle;
+    color: darken($brand-warning, 20%);
+    padding: .25rem 1rem .25rem 3rem;
+    background: rgba($brand-warning, 0.3);
+    border: 1px solid $brand-warning;
+    border-radius: $border-radius-base;
+    position: relative;
+    margin: 0 0 .25rem;
+    list-style-type: circle;
 
-	&:after {
-		content: '';
-		border: 5px solid transparent;
-		border-top-color: $brand-warning;
-		position: absolute;
-		bottom: -10px;
-	}
+    &:after {
+        content: '';
+        border: 5px solid transparent;
+        border-top-color: $brand-warning;
+        position: absolute;
+        bottom: -10px;
+    }
+}
+.tree-form .errorlist {
+    margin-bottom: 0.5rem;
 }
 
 .non-field-errors {
-	color: darken($brand-warning, 20%);
-	padding: 1rem;
-	background: rgba($brand-warning, 0.3);
-	border: 1px solid $brand-warning;
-	border-radius: $border-radius-base;
-	position: relative;
-	margin: 0 0 .25rem;
+    color: darken($brand-warning, 20%);
+    padding: 1rem;
+    background: rgba($brand-warning, 0.3);
+    border: 1px solid $brand-warning;
+    border-radius: $border-radius-base;
+    position: relative;
+    margin: 0 0 .25rem;
 
-	.form-error {
-		margin: 0;
+    .form-error {
+        margin: 0;
 
-		+ .form-error {
-			margin-top: 10px;
-		}
-	}
+        + .form-error {
+            margin-top: 10px;
+        }
+    }
 }


### PR DESCRIPTION
Switches from using builtin browser validation messages to custom messages.

We need to show custom error messages on iOS and older Android browsers, as they will not do so for us.  Since we are doing so for some browsers, I have opted to switch to custom error messages on all browsers.

We still rely on html5 for the actual validation checking, which does work on all mobile browsers.

Connects to #1664