### PR TITLE
Remove mouseover effect on progress circles on a group's page

### DIFF
--- a/src/nyc_trees/apps/users/templates/groups/detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/detail.html
@@ -85,7 +85,7 @@
     </section>
     <section class="contributions">
         <h4 class="section-heading">Contributions</h4>
-        <div class="progress-circles block nopadding--top clearfix">
+        <div class="progress-circles circles-nohover block nopadding--top clearfix">
             {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" url=progress_page_url %}
             {% include "home/partials/circle.html" with label="Events " n=counts.event color="primary" modal="#users-modal" %}
             {% include "home/partials/circle.html" with label="Attendees" n=counts.attendees color="primary" modal="#users-modal" %}

--- a/src/nyc_trees/sass/partials/_home.scss
+++ b/src/nyc_trees/sass/partials/_home.scss
@@ -125,15 +125,15 @@ $hero-box-side-padding: 3rem;
 
 .progress-circle {
   display: block;
-  cursor: pointer;
   border: 4px solid;
   border-radius: 50%;
   height: 0;
   padding-bottom: 92%;
   width: 100%;
   @include transition(.2s ease-in-out color);
-  &:hover {
+  .progress-circles:not(.circles-nohover) &:hover {
     color: darken($brand-primary, 20%) !important;
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
Mouseover effect does not show on group page. Adding ```.circles-nohover``` to ```.progress-circles``` will remove this effect from any group of progress circles.

Fixes #1735.