### PR TITLE
Update layoutBoxes to 67a5f279 version

### DIFF
--- a/src/nyc_trees/apps/survey/migrations/0028_update_layoutboxes_20150529_1328.py
+++ b/src/nyc_trees/apps/survey/migrations/0028_update_layoutboxes_20150529_1328.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+
+from django.db import migrations
+
+_LAYOUTBOXES_FILE = os.path.join(os.path.dirname(__file__), 'layoutBoxes.sql')
+
+
+with open(_LAYOUTBOXES_FILE, 'r') as f:
+    _CREATE_LAYOUTBOXES = f.read()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0027_recreate_group_territory_20150526_1129'),
+    ]
+
+    operations = [
+        # The reverse is a no-op, but Django makes us provide valid SQL
+        migrations.RunSQL(sql=_CREATE_LAYOUTBOXES, reverse_sql="SELECT 1;")
+    ]

--- a/src/nyc_trees/apps/survey/migrations/layoutBoxes.sql
+++ b/src/nyc_trees/apps/survey/migrations/layoutBoxes.sql
@@ -1,3 +1,64 @@
+--
+-- This file is part of Treekit.
+--
+-- Copyright (C) 2015 Sandro Santilli <strk@keybit.net>
+--
+-- Treekit is free software: you can redistribute it and/or modify
+-- it under the terms of the Affero GNU General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- Treekit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the Affero GNU General Public License
+-- along with Treekit.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+
+-- {
+--
+-- Given two points and an offset return an offsetted segment
+--
+-- Positive offset will generate line on the left,
+-- negative on the right. Direction will be the same of input.
+--
+-- Author: Sandro Santilli <strk@keybit.net>
+--
+-- }{
+CREATE OR REPLACE FUNCTION _tk_OffsetSegment(p0 geometry, p1 geometry, off float8)
+RETURNS geometry  AS
+$$
+DECLARE
+  theta FLOAT8;
+  x0 FLOAT8;
+  y0 FLOAT8;
+  x1 FLOAT8;
+  y1 FLOAT8;
+  g GEOMETRY;
+BEGIN
+  x0 := ST_X(p0);
+  y0 := ST_Y(p0);
+  x1 := ST_X(p1);
+  y1 := ST_Y(p1);
+  theta := atan2(y1 - y0, x1 - x0);
+  x0 := x0 - sin(theta) * off;
+  y0 := y0 + cos(theta) * off;
+  x1 := x1 - sin(theta) * off;
+  y1 := y1 + cos(theta) * off;
+
+  g := ST_MakeLine(
+    ST_MakePoint(x0, y0),
+    ST_MakePoint(x1, y1)
+  );
+
+  return ST_SetSRID(g, ST_SRID(p0));
+END;
+$$
+LANGUAGE 'plpgsql' IMMUTABLE STRICT;
+
 -- {
 --
 -- Given a linestring and an ordered array of box data, return an array of
@@ -21,7 +82,6 @@ DECLARE
   roadrec RECORD;
   tree RECORD;
   curdst FLOAT8; -- current distance from road's start point, in meters
-  f2m FLOAT8; -- foot 2 meter factor
   p0 GEOMETRY;
   p1 GEOMETRY;
   distfrac FLOAT8; -- fraction of distance along the line
@@ -44,7 +104,7 @@ BEGIN
            off[i] as off
     INTO tree;
 
-    --RAISE DEBUG 'Box % dist:% len:% width:%', i, tree.dist, tree.len, tree.width;
+    --RAISE DEBUG 'Box % dist:% len:% width:% offset:%', i, tree.dist, tree.len, tree.width, tree.off;
 
     curdst := curdst + tree.dist;
     distfrac := curdst/roadrec.len;
@@ -52,48 +112,35 @@ BEGIN
     p0 := ST_Line_Interpolate_Point(roadrec.geom, distfrac);
     IF tree.len = 0 THEN
       -- This is an arbitrarily small number used
-      -- to obtain another point but on the same segment
-      IF curdst >= roadrec.len THEN
-        distfrac := distfrac - 0.0000001;
+      -- to obtain another point possibly on the same segment
+      IF distfrac >= 1 - 1e-7 THEN
+        distfrac := distfrac - 1e-7;
+        tree.off := -tree.off;
       ELSE
-        distfrac := distfrac + 0.0000001;
+        distfrac := distfrac + 1e-7;
       END IF;
     ELSE
+      IF curdst >= roadrec.len THEN
+        RAISE WARNING 'Tree bed cannot start at the end of road';
+        CONTINUE;
+      END IF;
       curdst := curdst + tree.len;
       distfrac := curdst/roadrec.len;
       distfrac := greatest(least(distfrac,1),0); -- warn if clamped ?
     END IF;
     p1 := ST_Line_Interpolate_Point(roadrec.geom, distfrac);
     l0 := ST_MakeLine(p0, p1);
-    IF tree.len = 0 AND ST_Equals(p0, ST_EndPoint(roadrec.geom)) THEN
-      l0 := ST_Reverse(l0);
-    END IF;
-    BEGIN
-      IF tree.off IS NOT NULL THEN
-        l0 := ST_OffsetCurve(l0, tree.off*roadrec.side);
-        IF tree.off*roadrec.side < 0 THEN
-          l0 := ST_Reverse(l0);
-        END IF;
-      END IF;
-      l1 := ST_OffsetCurve(l0, tree.width*roadrec.side);
-    EXCEPTION
-      WHEN OTHERS THEN
-        RAISE WARNING 'Running OffsetCurve on line % returned %', ret, SQLERRM;
-        CONTINUE;
-    END;
 
-    IF roadrec.side = 1 THEN
-      l1 := ST_Reverse(l1);
+    IF tree.off IS NOT NULL THEN
+      l0 := _tk_OffsetSegment(ST_PointN(l0,1), ST_PointN(l0,2), tree.off*roadrec.side);
     END IF;
+
+    l1 := _tk_OffsetSegment(ST_PointN(l0,1), ST_PointN(l0,2), tree.width*roadrec.side);
 
     IF tree.len = 0 THEN
-      IF ST_Equals(p0, ST_EndPoint(roadrec.geom)) AND roadrec.side = 1 THEN
-        ret := ST_PointN(l1, 1);
-      ELSE
-        ret := ST_PointN(l1, 2);
-      END IF;
+      ret := ST_PointN(l1, 1);
     ELSE
-      ret := ST_MakeLine(l0, l1);
+      ret := ST_MakeLine(l0, ST_Reverse(l1));
       ret := ST_MakeLine(ret, ST_StartPoint(l0)); -- add closing point
       ret := ST_MakePolygon(ret); -- turn into a polygon
     END IF;

--- a/src/nyc_trees/apps/survey/migrations/layoutBoxes.sql
+++ b/src/nyc_trees/apps/survey/migrations/layoutBoxes.sql
@@ -116,6 +116,7 @@ BEGIN
       IF distfrac >= 1 - 1e-7 THEN
         distfrac := distfrac - 1e-7;
         tree.off := -tree.off;
+        tree.width := -tree.width;
       ELSE
         distfrac := distfrac + 1e-7;
       END IF;


### PR DESCRIPTION
Pulled in from https://github.com/treekit/treekit

The most important part of this update is https://github.com/treekit/treekit/commit/1ef16d75d4a4b54b90deedc1601b2c110d0c2058 which fixes a problem where null geometries were created for trees on short blocks.

Connects to #1728