### PR TITLE
Load openlayers from SSL-compatible CDN

### DIFF
--- a/src/nyc_trees/apps/survey/admin.py
+++ b/src/nyc_trees/apps/survey/admin.py
@@ -24,6 +24,10 @@ class SurveyAdmin(admin.ModelAdmin):
 class BlockfaceAdmin(admin.ModelAdmin):
     search_fields = ('id',)
     list_filter = ('is_available',)
+    exclude = ('geom',)
+
+    def has_add_permission(self, request):
+        return False
 
 
 class BlockfaceReservationAdmin(admin.ModelAdmin):


### PR DESCRIPTION
connects to #1696 on github

@dboyer @kdeloach in #1696, you suggested removing this widget because it's broken. This PR should fix it. I'm still open to removing it though.