### PR TITLE
Hide geom field in blockface admin

### DIFF
--- a/src/nyc_trees/apps/survey/admin.py
+++ b/src/nyc_trees/apps/survey/admin.py
@@ -24,6 +24,10 @@ class SurveyAdmin(admin.ModelAdmin):
 class BlockfaceAdmin(admin.ModelAdmin):
     search_fields = ('id',)
     list_filter = ('is_available',)
+    exclude = ('geom',)
+
+    def has_add_permission(self, request):
+        return False
 
 
 class BlockfaceReservationAdmin(admin.ModelAdmin):


### PR DESCRIPTION
connects to #1696 on github

we never want the user to be able to edit it, and it also is not working
as currently implemented.