### PR TITLE
Fix exception when sending bulk event email

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -151,7 +151,7 @@ def event_email_page(request, event_slug):
 def event_email(request, event_slug):
     event = get_object_or_404(Event, slug=event_slug, group=request.group)
     form = EmailForm(request.POST)
-    extra_recipients = set([request.user, request.group.admin])
+    extra_recipients = set(filter(None, [request.user, request.group.admin]))
     rsvps = EventRegistration.objects.filter(event=event, opt_in_emails=True) \
                                      .select_related('user') \
                                      .exclude(user__in=extra_recipients)


### PR DESCRIPTION
This fixes the case where sending event emails for groups with no group
admin would throw an exception.

To test:
1. Find an event for a group with no group admin (or set the group
admin to null)
2. Send a bulk event email
3. Email should send successfully

Connects #1739