### PR TITLE
Update CloudFormation templates so that resources are up-to-date

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,4 +1,4 @@
 ansible==1.8.4
 awscli==1.7.13
 boto==2.34.0
-troposphere==0.7.1
+troposphere==1.0.0

--- a/deployment/troposphere/app_hosted_zone_template.py
+++ b/deployment/troposphere/app_hosted_zone_template.py
@@ -66,6 +66,7 @@ cloudfront_failover_distribution = t.add_resource(cf.Distribution(
         Enabled=True,
         ViewerCertificate=cf.ViewerCertificate(
             IamCertificateId=Ref(app_ssl_certificate_id_param),
+            MinimumProtocolVersion='TLSv1',
             SslSupportMethod='sni-only'
         )
     )

--- a/deployment/troposphere/app_template.py
+++ b/deployment/troposphere/app_template.py
@@ -193,7 +193,7 @@ app_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
     LoadBalancerNames=[Ref(app_server_load_balancer)],
     MaxSize=4,
     MinSize=2,
-    NotificationConfiguration=asg.NotificationConfiguration(
+    NotificationConfigurations=[asg.NotificationConfigurations(
         TopicARN=Ref(notification_arn_param),
         NotificationTypes=[
             asg.EC2_INSTANCE_LAUNCH,
@@ -201,7 +201,7 @@ app_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
             asg.EC2_INSTANCE_TERMINATE,
             asg.EC2_INSTANCE_TERMINATE_ERROR
         ]
-    ),
+    )],
     VPCZoneIdentifier=Ref(private_subnets_param),
     Tags=[
         asg.Tag('Name', 'AppServer', True),

--- a/deployment/troposphere/tiler_template.py
+++ b/deployment/troposphere/tiler_template.py
@@ -182,7 +182,7 @@ tile_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
     LoadBalancerNames=[Ref(tile_server_load_balancer)],
     MaxSize=4,
     MinSize=2,
-    NotificationConfiguration=asg.NotificationConfiguration(
+    NotificationConfigurations=[asg.NotificationConfigurations(
         TopicARN=Ref(notification_arn_param),
         NotificationTypes=[
             asg.EC2_INSTANCE_LAUNCH,
@@ -190,7 +190,7 @@ tile_server_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
             asg.EC2_INSTANCE_TERMINATE,
             asg.EC2_INSTANCE_TERMINATE_ERROR
         ]
-    ),
+    )],
     VPCZoneIdentifier=Ref(private_subnets_param),
     Tags=[
         asg.Tag('Name', 'TileServer', True),


### PR DESCRIPTION
In the process of creating a new stack from an existing template, the following resources and their parameters became stale and required updates:

- CloudFront Distribution/MinimumProtocolVersion

If you specify the `IamCertificateId` property and specify SNI only for the `SslSupportMethod` property, you must use `TLSv1` for the minimum protocol version. If you don't specify a value, AWS CloudFormation specifies `SSLv3`.

- AutoScalingGroup/NotificationConfigurations

`NotificationConfiguration` is now `NotificationConfigurations` (plural) and now accepts an array of `NotificationConfigurations`.