### PR TITLE
Show private events in user event lists

### DIFF
--- a/src/nyc_trees/apps/event/event_list.py
+++ b/src/nyc_trees/apps/event/event_list.py
@@ -125,9 +125,11 @@ class EventList(object):
         right_now = now()
         filtersets = {
             EventList.trainingFilters: OrderedDict([
-                (_ALL, None),
-                (_TRAINING, lambda qs: qs.filter(includes_training=True)),
-                (_MAPPING, lambda qs: qs.filter(includes_training=False)),
+                (_ALL, lambda qs: qs.filter(is_private=False)),
+                (_TRAINING, lambda qs: qs.filter(
+                    is_private=False, includes_training=True)),
+                (_MAPPING, lambda qs: qs.filter(
+                    is_private=False, includes_training=False)),
             ]),
             EventList.chronoFilters: OrderedDict([
                 (_CURRENT, lambda qs: (qs
@@ -327,8 +329,7 @@ def immediate_events(request):
     user = request.user
     seven_days = relativedelta(days=7)
     nowish = (Event.objects
-              .filter(is_private=False,
-                      group__is_active=True,
+              .filter(group__is_active=True,
                       ends_at__gt=now(),
                       ends_at__lte=now() + seven_days)
               .order_by('begins_at'))
@@ -348,6 +349,5 @@ def immediate_events(request):
 
 @EventList
 def all_events(request):
-    return Event.objects.filter(is_private=False,
-                                group__is_active=True,
+    return Event.objects.filter(group__is_active=True,
                                 ends_at__gt=now()).order_by('begins_at')

--- a/src/nyc_trees/apps/event/event_list.py
+++ b/src/nyc_trees/apps/event/event_list.py
@@ -145,6 +145,7 @@ class EventList(object):
                     .filter(EventList.Filters.get_rsvp_q(request.user)))),
                 (_RECOMMENDED, lambda qs: (
                     qs
+                    .filter(is_private=False)
                     .exclude(EventList.Filters.get_rsvp_q(request.user))
                     .filter(
                         EventList.Filters.get_recommended_q(request.user)))),


### PR DESCRIPTION
"Your Events This Week" on the Events page wasn't showing a user's private events.
* Removed the `is_private=False` filter from `EventList.immediate_events`
* That routine is used nowhere else, so the change is safe

The dashboard wasn't showing a user's private events.
* Removed the `is_private=False` filter from `EventList.all_events`
* That routine is also used with the `EventList.trainingFilters`
  so they need an `is_private=False` filter
* I believe that no other lists are affected by this change, and I think I tested them all,
  but with the multiple levels of indirect linkages it's hard to tell

Connects #1754