### PR TITLE
If submit succeeds, don't reenable the submit button

### DIFF
--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -613,8 +613,6 @@ function submitSurveyWithTrees() {
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
             toastr.warning('Double-check your survey and try resubmitting it.', 'Something went wrong...');
-        })
-        .always(function() {
             // Re-enable the submit button
             $(dom.submitSurvey).on('click', submitSurveyWithTrees);
         });


### PR DESCRIPTION
Without this change I saw multiple posts when clicking "Submit" multiple times.
With this change I only saw one submit.

I also verified that you can't submit the same data twice by using the browser back button.

Connects #1765