### PR TITLE
Use stamen toner labels on top of a label-less basemap for most maps.

### DIFF
--- a/src/nyc_trees/js/src/event_list_page.js
+++ b/src/nyc_trees/js/src/event_list_page.js
@@ -23,6 +23,9 @@ $(dom.mapToggle).one('shown.bs.tab', function() {
             mapModule.create({
                 geolocation: true,
                 search: true,
+                // There is no raster tile layer, so labels embedded in the
+                // basemap will work just fine
+                withLabels: true
             });
             return;
         }

--- a/src/nyc_trees/js/src/progressPage.js
+++ b/src/nyc_trees/js/src/progressPage.js
@@ -11,7 +11,9 @@ require('./lib/mapHelp');
 var progressMap = mapModule.create({
         geolocation: true,
         legend: true,
-        search: true
+        search: true,
+        // Using a separate layer for labels interferes with the neighborhood and borough layers
+        withLabels: true
     }),
     tileLayer = null,
     neighborhoodTileLayer=null,


### PR DESCRIPTION
This is intended to prevent the blockface tile layer from obscuring the
street names, to help in identifying the correct blockface while mapping.

I kept the progress map as it was, because I was running into issues
with labels interfering with the labels on the aggregate neighborhood
and borough layers.

I also excluded the event list map and the survey detail map, because
they do not have a blockface layer, so there is no need for a separate
label layer.

Thanks to @jwalgran for the initial implementation!

Connects to #1759 

To test, please check that labels are visible and above the blockface layer on the following maps: reservations, treecorder, census zone administration, reservations PDF, and event PDF.