### PR TITLE
Fix label positions on the progress map for concave polygons.

### DIFF
--- a/src/tiler/style/progress.mss
+++ b/src/tiler/style/progress.mss
@@ -60,4 +60,5 @@ node -e "var m=require('mapnik');m.register_system_fonts();console.log(m.fontFil
   text-size: 12;
   text-halo-fill:  fadeout(#fff, 30%);
   text-halo-radius: 2;
+  text-placement: interior;
 }


### PR DESCRIPTION
Some of the neighborhood polygons on the progress map have centroids that
lie outside the polygon, which leads to their percentage label being
placed inside a different neighborhood (which will then have two labels).

By adding `text-placement: interior` to the CartoCSS, we tell Mapnik to
prefer placing labels on the interior of polygons if the centroid is not
inside the poygon.

Prior to this fix:
![centroid1](https://cloud.githubusercontent.com/assets/4432106/8261849/ba253a02-169b-11e5-95ea-8493ca10f9b8.png)

After:
![fixed2](https://cloud.githubusercontent.com/assets/4432106/8261851/bf726c32-169b-11e5-8030-8d89f857dfef.png)

