### PR TITLE
Set a higher zoom level when zooming to a location

### DIFF
--- a/src/nyc_trees/js/src/lib/mapUtil.js
+++ b/src/nyc_trees/js/src/lib/mapUtil.js
@@ -5,6 +5,7 @@ var $ = require('jquery'),
 
 var _ZOOM = {
     NEIGHBORHOOD: 16,
+    LOCATION: 18,
     MIN: 8,
     MAX: 19
 };

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -66,9 +66,9 @@ function createAndGetControls(options) {
     } else if (options.bounds) {
         map.fitBounds(options.bounds, {maxZoom: zoom.NEIGHBORHOOD});
     } else if (mapLocation) {
-        map.setView(mapLocation, zoom.NEIGHBORHOOD);
+        map.setView(mapLocation, zoom.LOCATION);
     } else if (options.location && options.location.lat !== 0) {
-        map.setView(options.location, zoom.NEIGHBORHOOD);
+        map.setView(options.location, zoom.LOCATION);
     } else {
         map.fitBounds(config.bounds);
     }
@@ -168,7 +168,7 @@ function initGeolocation($controlsContainer, map) {
 
     function showPosition(position) {
         var center = L.latLng(position.coords.latitude, position.coords.longitude);
-        map.setView(center, zoom.NEIGHBORHOOD);
+        map.setView(center, zoom.LOCATION);
     }
 
     function showError() {

--- a/src/nyc_trees/js/src/searchController.js
+++ b/src/nyc_trees/js/src/searchController.js
@@ -119,7 +119,7 @@ function create($controlsContainer, map) {
 
         zoomToCandidate = function(candidate) {
             var point = L.latLng(candidate.y, candidate.x);
-            setCenterAndZoomLL(map, zoom.NEIGHBORHOOD, point);
+            setCenterAndZoomLL(map, zoom.LOCATION, point);
             dismiss();
         },
 


### PR DESCRIPTION
This commit introduces a new zoom level "preset" to be used when zooming to the geolocation of the device, or to the location of a mapping event. This is a usability improvement suggested by Parks based on feedback from mapping events.

Geolocation zoom before

![screen shot 2015-06-22 at 10 11 21 am](https://cloud.githubusercontent.com/assets/17363/8287886/7fb0e3ac-18c7-11e5-8abb-fd0064b042d7.png)

After

![screen shot 2015-06-22 at 10 13 27 am](https://cloud.githubusercontent.com/assets/17363/8287889/85dc8d76-18c7-11e5-855e-6854822c9a9e.png)

Connects to #1749