### PR TITLE
Update treecorder instructional text

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -11,10 +11,18 @@
 
     <div class="action-bar-survey">
         <div id="select-starting-point">
-            <p>Drag the map to choose a block edge.<br/>Then choose a starting point.</p>
+            <p>
+                Drag the map and zoom in to choose a block edge.
+                Double check that you're on the right street! Then
+                choose a starting point.
+            </p>
         </div>
         <div id="select-side" class="hidden">
-            <p>What side of the street are you on?</p>
+            <p>
+                Face the direction you will be walking to move down
+                the block and map trees. Which side of the street are
+                you on?
+            </p>
             <div class="btn-group btn-group-justified" role="group">
                 <a id="btn-left" class="btn btn-switch">Left</a>
                 <a id="btn-right" class="btn btn-switch">Right</a>

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -21,7 +21,7 @@
     left: 0;
     right: 0;
     @media (max-width: $screen-sm - 1) {
-        bottom: 15rem;
+        bottom: 20rem;
     }
     @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
         top: 4.5rem;
@@ -37,7 +37,7 @@
         left: 0;
         bottom: 0;
         width: 100%;
-        height: 15rem;
+        height: 20rem;
         padding: 0 $grid-gutter-width/2;
         z-index: 1;
         background-color: #fff;


### PR DESCRIPTION
We are updating the text in an attempt to avoid some common problems that Parks is seeing in the field.

The increase in the amount of text in the "which side of the street" question required shrinking the size of the map.

Before

![screen shot 2015-06-22 at 1 03 39 pm](https://cloud.githubusercontent.com/assets/17363/8291617/7d1fee5e-18df-11e5-9eca-e6b402d21cf4.png)

After

![screen shot 2015-06-22 at 1 00 28 pm](https://cloud.githubusercontent.com/assets/17363/8291621/82bb96ec-18df-11e5-9c12-d46c5a4b096d.png)

Connects to #1763 