### PR TITLE
Show user location on Treecorder map

### DIFF
--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -167,6 +167,7 @@ statePrompter.lock();
 selectedLayer.clicksEnabled = false;
 blockfaceMap.addLayer(selectedLayer);
 blockfaceMap.addLayer(endPointLayers);
+mapModule.startTrackingUserPosition(blockfaceMap);
 
 grid.on('mapMove', function(e) {
     var data = e.data;
@@ -403,6 +404,7 @@ $(dom.btnNext).click(function(e) {
     blockfaceMap.keyboard.disable();
     blockfaceMap.removeLayer(grid);
     mapModule.hideCrosshairs();
+    mapModule.stopTrackingUserPosition(blockfaceMap);
 });
 
 $(dom.addTree).click(function (){


### PR DESCRIPTION
For testing, points near Azavea are shown in southern Manhattan.

To test:
* Use a mobile device (ideally a tablet, wide enough to show both the map and the input form)
* Reserve some blocks at the southern tip of Manhattan
* Open Treecorder. You should see a green dot somewhere around there.
* Walk around. The dot should move.
* Start entering data. The dot should disappear.

Connects #1764