### PR TITLE
Remove inline teammate autocomplete in favor of AJAX backed autocomplete

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/partials/teammate_item.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/teammate_item.html
@@ -1,4 +1,0 @@
-<option value={{ teammate.user_id }}>
-    {{ teammate.username }}
-    {% if teammate.full_name %} &mdash; {{ teammate.full_name }} {% endif %}
-</option>

--- a/src/nyc_trees/apps/event/templates/event/partials/teammates.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/teammates.html
@@ -1,7 +1,0 @@
-<select class="teammate" style="width: 100%;">
-    {# A blank option to allow for clearing the selection #}
-    <option value="">&nbsp;</option>
-    {% for teammate in teammates %}
-        {% include "event/partials/teammate_item.html" %}
-    {% endfor %}
-</select>

--- a/src/nyc_trees/apps/survey/helpers.py
+++ b/src/nyc_trees/apps/survey/helpers.py
@@ -3,33 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from apps.core.models import User
-from apps.users import can_show_full_name
-
 from apps.survey.models import Survey, Territory
-
-
-def teammates_for_mapping(current_user):
-    attendees = User.objects.exclude(id=current_user.id) \
-                            .filter(is_active=True) \
-                            .order_by('username')
-    return _teammates_context(attendees)
-
-
-def _teammates_context(users):
-    return [_teammate_user_context(u) for u in users]
-
-
-def _teammate_user_context(user):
-    if can_show_full_name(user):
-        full_name = ("%s %s" % (user.first_name, user.last_name)).strip()
-    else:
-        full_name = ""
-    return {
-        "user_id": user.id,
-        "username": user.username,
-        "full_name": full_name
-    }
 
 
 def group_percent_completed(group):

--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -130,6 +130,9 @@ blockface = route(GET=do(json_api_call, v.blockface))
 
 blockface_near_point = route(GET=do(json_api_call, v.blockface_near_point))
 
+teammates_for_mapping = route(GET=do(
+    login_required, json_api_call, v.teammates_for_mapping))
+
 #####################################
 # ADMIN ROUTES
 #####################################

--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -34,7 +34,7 @@
         <div id="select-teammate" class="hidden">
             <p>Is someone helping you count trees? Enter their user name. If not, click Next.</p>
             <div id="teammate-list">
-                {% include "event/partials/teammates.html" %}
+                <input class="teammate" id="teammate-select" />
             </div>
             <div id="btn-group-next" class="hidden" role="group">
                 <button id="btn-next" class="btn btn-primary btn-block">Next</button>

--- a/src/nyc_trees/apps/survey/urls/survey.py
+++ b/src/nyc_trees/apps/survey/urls/survey.py
@@ -8,7 +8,7 @@ from django.conf.urls import patterns, url
 from apps.survey.routes import (survey, survey_from_event,
                                 flag_survey, survey_detail,
                                 confirm_survey, confirm_survey_from_event,
-                                restart_blockface)
+                                restart_blockface, teammates_for_mapping)
 
 
 # These URLs have the prefix 'survey/'
@@ -34,4 +34,8 @@ urlpatterns = patterns(
 
     url(r'^restart_blockedge/(?P<survey_id>\d+)/$',
         restart_blockface, name='restart_blockface'),
+
+    # Note: changes here must be kept in sync with
+    # src/nyc_trees/js/src/surveyPage.js
+    url(r'^teammates/$', teammates_for_mapping)
 )

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -94,7 +94,7 @@ var dom = {
         btnGroupToTeammate: '#btn-group-to-teammate',
         btnToTeammate: '#btn-to-teammate',
         selectTeammate: '#select-teammate',
-        teammateSelectElement: 'select.teammate',
+        teammateSelectElement: '#teammate-select',
 
         btnNoTrees: '#no-trees',
         noTreesPopup: '#no-trees-popup',
@@ -680,7 +680,21 @@ $(dom.quitPopup).on('shown.bs.modal', function () {
 
 $(dom.teammateSelectElement).select2({
     placeholder: "Username",
-    allowClear: true
+    allowClear: true,
+    minimumInputLength: 1,
+    ajax: {
+        // Note: changes here must be kept in sync with
+        // src/nyc_trees/survey/urls/survey.py
+        url: "/survey/teammates/",
+        dataType: 'json',
+        quietMillis: 100,
+        data: function (term) {
+            return {q: term};
+        },
+        results: function(data) {
+            return {results: data};
+        }
+    }
 });
 
 $(dom.btnNoTrees).on('click', function(e) {


### PR DESCRIPTION
The select tag based autocomplete was proving to be not performant enough
with a significant number of users (over 3000).

Moving to an AJAX-based autocomplete should alleviate the performance
issues we have encountered with it.

Connects to #1726