### PR TITLE
Allow logging in via either username or email address

### DIFF
--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -161,7 +161,15 @@ class User(NycModel, AbstractUser):
 
     def clean(self):
         if ((User.objects.exclude(pk=self.pk)
-             .filter(email__iexact=self.email).exists())):
+             .filter(email__iexact=self.username).exists())):
+            raise ValidationError({'username': [
+                'That username is already in use. '
+                'Please supply a different username.']
+            })
+
+        if ((User.objects.exclude(pk=self.pk)
+             .filter(Q(email__iexact=self.email) |
+                     Q(username__iexact=self.email)).exists())):
             raise ValidationError({'email': [
                 'This email address is already in use. '
                 'Please supply a different email address.']

--- a/src/nyc_trees/apps/login/forms.py
+++ b/src/nyc_trees/apps/login/forms.py
@@ -72,9 +72,25 @@ class NycRegistrationForm(RegistrationFormUniqueEmail):
     )
 
     def clean_username(self):
-        if self.cleaned_data['username'].lower() in User.reserved_usernames:
+        username = self.cleaned_data['username']
+
+        if username.lower() in User.reserved_usernames:
             raise ValidationError('This username is not available.')
+
+        if User.objects.filter(email__iexact=username).exists():
+            raise ValidationError('That username is already in use. '
+                                  'Please supply a different username.')
+
         return super(NycRegistrationForm, self).clean_username()
+
+    def clean_email(self):
+        email = self.cleaned_data['email']
+
+        if User.objects.filter(username__iexact=email).exists():
+            raise ValidationError('That email address is already in use. '
+                                  'Please supply a different email address.')
+
+        return super(NycRegistrationForm, self).clean_email()
 
 
 class UsernameOrEmailPasswordResetForm(forms.Form):

--- a/src/nyc_trees/apps/login/forms.py
+++ b/src/nyc_trees/apps/login/forms.py
@@ -24,10 +24,12 @@ from django.template.loader import render_to_string
 
 
 class NycAuthenticationForm(AuthenticationForm):
+    username = forms.CharField(max_length=254,
+                               label="Username or Email Address")
 
     error_messages = {
-        'invalid_login': 'Please enter a correct username and password. '
-                         'Note that password is case-sensitive',
+        'invalid_login': 'Please enter a correct username or email address '
+                         'and password. Note that password is case-sensitive',
         'inactive': 'Please click the account activation link you received by '
                     'email before trying to log in.'
     }

--- a/src/nyc_trees/apps/login/urls/login.py
+++ b/src/nyc_trees/apps/login/urls/login.py
@@ -8,7 +8,7 @@ from django.conf.urls import patterns, url
 from apps.login import routes as r
 
 
-# Everything is mounted on login/
+# Everything is mounted on accounts/
 urlpatterns = patterns(
     '',
     url(r'^forgot-username/$',

--- a/src/nyc_trees/libs/auth_backend.py
+++ b/src/nyc_trees/libs/auth_backend.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.contrib.auth.backends import ModelBackend
+
+from apps.core.models import User
+
+
+class EmailOrUsernameAuthentication(ModelBackend):
+    def authenticate(self, username=None, password=None):
+        user = None
+        try:
+            user = User.objects.get(email__iexact=username)
+        except User.DoesNotExist:
+            try:
+                user = User.objects.get(username__iexact=username)
+            except User.DoesNotExist:
+                pass
+
+        if user is None:
+            # From the Django ModelBackend:
+            # Run the default password hasher once to reduce the timing
+            # difference between an existing and a non-existing user (#20760).
+            User().set_password(password)
+            return None
+
+        if user.check_password(password):
+            return user
+        else:
+            return None

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -264,6 +264,9 @@ ROOT_URLCONF = '%s.urls' % SITE_NAME
 
 AUTH_USER_MODEL = 'core.User'
 
+AUTHENTICATION_BACKENDS = [
+    'libs.auth_backend.EmailOrUsernameAuthentication'
+]
 
 # APP CONFIGURATION
 DJANGO_APPS = (


### PR DESCRIPTION
This allows email login for both normal login and the Django Admin site,
but I only updated the labels and error messages for the normal login page.

Connects to #1777