### PR TITLE
Fix initial map zoom levels, and show mapped/unmapped blocks on event map PDF

### DIFF
--- a/src/nyc_trees/apps/event/views.py
+++ b/src/nyc_trees/apps/event/views.py
@@ -31,7 +31,7 @@ from apps.core.tasks import wait_for_default_storage_file
 from apps.mail.tasks import notify_rsvp, notify_after_event_checkin
 from apps.mail.libs import send_to
 
-from apps.survey.layer_context import get_context_for_territory_layer
+from apps.survey.layer_context import get_context_for_printable_event_map
 from libs.pdf_maps import create_event_map_pdf
 
 
@@ -373,7 +373,7 @@ def printable_event_map(request, event_slug):
     context = {
         'event': event,
         'location': [event.location.y, event.location.x],
-        'layer': get_context_for_territory_layer(request.group.id),
+        'layer': get_context_for_printable_event_map(request.group.id),
     }
     return context
 

--- a/src/nyc_trees/apps/survey/layer_context.py
+++ b/src/nyc_trees/apps/survey/layer_context.py
@@ -45,6 +45,12 @@ def get_context_for_group_progress_layer():
     return _get_context_for_layer("group_progress", models)
 
 
+def get_context_for_printable_event_map(group_id):
+    models = [Blockface, Survey, Territory]
+    return _get_context_for_layer("event_pdf", models,
+                                  {'group': group_id})
+
+
 @login_required
 def get_context_for_reservable_layer(request):
     if user_is_census_admin(request.user):

--- a/src/nyc_trees/apps/survey/templates/survey/survey_detail.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey_detail.html
@@ -26,7 +26,7 @@
         data-blockface-id="{{ blockface_id }}"
         data-survey-url="{{ survey_url }}"
         {% if bounds %}data-bounds="{{ bounds }}"
-        {% elif location %}data-location="{{ location }}"
+        {% elif location %}data-location="{{ location }}" data-zoom="LOCATION"
         {% endif %}>
     </div>
 </div>

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -59,7 +59,8 @@ function createAndGetControls(options) {
         multiControl = L.control.zoom({position: 'bottomleft'}).addTo(map),
         $multiControlContainer = $(multiControl.getContainer()),
         bounds = getDomMapAttribute('bounds', options.domId),
-        mapLocation = getDomMapAttribute('location', options.domId);
+        mapLocation = getDomMapAttribute('location', options.domId),
+        zoomSpec = getDomMapAttribute('zoom', options.domId);
 
     map.addControl(L.control.attribution({prefix: false}));
 
@@ -68,9 +69,10 @@ function createAndGetControls(options) {
     } else if (options.bounds) {
         map.fitBounds(options.bounds, {maxZoom: zoom.NEIGHBORHOOD});
     } else if (mapLocation) {
-        map.setView(mapLocation, zoom.LOCATION);
+        var z = (zoomSpec === 'LOCATION' ? zoom.LOCATION : zoom.NEIGHBORHOOD);
+        map.setView(mapLocation, z);
     } else if (options.location && options.location.lat !== 0) {
-        map.setView(options.location, zoom.LOCATION);
+        map.setView(options.location, zoom.NEIGHBORHOOD);
     } else {
         map.fitBounds(config.bounds);
     }

--- a/src/tiler/server.js
+++ b/src/tiler/server.js
@@ -134,6 +134,8 @@ function req2style(req) {
     if (type === 'progress' || type === 'user_progress' || type === 'group_progress' ||
             type === 'borough_progress' || type === 'nta_progress') {
         return styles.progress();
+    } else if (type === 'event_pdf') {
+        return styles.event_pdf();
     } else {
         return styles.default();
     }

--- a/src/tiler/sql/event_pdf.sql
+++ b/src/tiler/sql/event_pdf.sql
@@ -1,0 +1,18 @@
+-- The 'DISTINCT ON' and 'ORDER BY' clause are needed so that we only use
+-- the latest survey for a blockface
+(SELECT
+  DISTINCT ON (block.id)
+  block.geom, block.id,
+  CASE
+    WHEN survey.user_id IS NOT NULL THEN 'T'
+    ELSE 'F'
+  END AS is_mapped
+  FROM survey_blockface AS block
+  JOIN survey_territory AS turf
+    ON block.id = turf.blockface_id
+  LEFT OUTER JOIN survey_survey AS survey
+    ON (block.id = survey.blockface_id
+        AND COALESCE(survey.quit_reason, '') = '')
+  WHERE turf.group_id = <%= group_id %>
+  ORDER BY block.id, survey.created_at DESC NULLS LAST
+) AS query

--- a/src/tiler/style/event_pdf.mss
+++ b/src/tiler/style/event_pdf.mss
@@ -1,0 +1,14 @@
+#survey_blockface {
+  line-join: round;
+  line-cap: round;
+  line-opacity: 1;
+
+  [is_mapped = 'F'] {
+    line-width: 4;
+    line-color: #82471a;
+  }
+  [is_mapped = 'T'] {
+    line-width: 2;
+    line-color: #8BC34A;
+  }
+}


### PR DESCRIPTION
Here's a shot from the event map PDF. 
![image](https://cloud.githubusercontent.com/assets/2162993/8985663/7c7ad1aa-36a6-11e5-8fff-0f3e6c60487d.png)

In B/W :
![image](https://cloud.githubusercontent.com/assets/2162993/8985703/9c9559d8-36a6-11e5-84f0-125befa26037.png)

Connects #1780 
Connects #1779