### PR TITLE
Add data migration causing all event map PDFs to be regenerated

### DIFF
--- a/src/nyc_trees/apps/event/migrations/0015_auto_20150730_1735.py
+++ b/src/nyc_trees/apps/event/migrations/0015_auto_20150730_1735.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def clear_event_pdfs(apps, schema_editor):
+    Event = apps.get_model("event", "Event")
+    for event in Event.objects.all():
+        event.map_pdf_filename = ''
+        event.save()
+
+def no_op(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('event', '0014_auto_20150506_1634'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_event_pdfs, reverse_code=no_op),
+    ]


### PR DESCRIPTION
Note we did this before this is copied from `src\nyc_trees\apps\event\migrations\0012_auto_20150424_1705.py`

Connects #1787