### PR TITLE
Add pages for resending activation emails on a failed password reset.

### DIFF
--- a/src/nyc_trees/apps/login/routes.py
+++ b/src/nyc_trees/apps/login/routes.py
@@ -27,6 +27,9 @@ activation_complete = do(
 
 register = NycRegistrationView.as_view()
 
+password_reset_impossible = route(
+    GET=render_template('login/password_reset_impossible.html')())
+
 #####################################
 # LOGIN ROUTES
 #####################################
@@ -38,6 +41,11 @@ forgot_username = do(
 forgot_username_sent = do(
     render_template('login/forgot_username_complete.html'),
     v.forgot_username_sent)
+
+# We use a slightly different template when coming from a failed password reset
+password_reset_resend_activation = do(
+    render_template('login/password_reset_activation_email.html'),
+    route(GET=v.send_activation_email_page, POST=v.send_activation_email))
 
 send_activation_email = do(
     render_template('login/send_activation_email.html'),

--- a/src/nyc_trees/apps/login/templates/login/password_reset_activation_email.html
+++ b/src/nyc_trees/apps/login/templates/login/password_reset_activation_email.html
@@ -1,0 +1,8 @@
+{% extends "login/send_activation_email.html" %}
+
+{% block message %}
+<p>
+    Your account has not yet been activated, which prevents us from sending a password reset email.
+    Enter the Email address you used to register with TreesCount! and click the “Send” button below to send another account activation email.
+</p>
+{% endblock message %}

--- a/src/nyc_trees/apps/login/templates/login/password_reset_impossible.html
+++ b/src/nyc_trees/apps/login/templates/login/password_reset_impossible.html
@@ -1,0 +1,19 @@
+{% extends "../templates/registration/registration_base.html" %}
+{% load i18n %}
+{% load utils %}
+
+{% block registration_title %}Password Reset{% endblock %}
+
+{% block registration_content %}
+<div class="content login-signup">
+  <div class="well login-signup-panel">
+    <p>
+        Your account has not yet been activated, which prevents us from sending a password reset email. Please email the TreesCount! 2015 Team at {{ "treescount.help@parks.nyc.gov"|urlize }} about activating your account.
+    </p>
+  </div>
+</div>
+{% endblock %}
+
+{% block page_js %}
+<script type="text/javascript" src="{{ "js/registrationBase.js"|static_url }}"></script>
+{% endblock page_js %}

--- a/src/nyc_trees/apps/login/templates/login/send_activation_email.html
+++ b/src/nyc_trees/apps/login/templates/login/send_activation_email.html
@@ -10,10 +10,12 @@
     <form method="POST" id="send-activation-email-form">
       <fieldset>
         {% csrf_token %}
+        {% block message %}
         <p>
             Need us to send you an account activation email? Enter the Email address you used to register
             with TreesCount! and click the “Send” button below.
         </p>
+        {% endblock message %}
         {% include "core/partials/non_field_errors.html" %}
         <p>
           <div class="fieldWrapper">

--- a/src/nyc_trees/apps/login/urls/accounts.py
+++ b/src/nyc_trees/apps/login/urls/accounts.py
@@ -21,6 +21,9 @@ urlpatterns = patterns(
     # password reset URLs are mapped to the customized view.
     url(r'^password_reset/$', r.password_reset, name='password_reset_alt'),
 
+    url(r'^password-reset-failure/$', r.password_reset_impossible,
+        name='password_reset_impossible'),
+
     # Shadows django-registration-redux endpoint.
     # Ref: https://github.com/macropin/django-registration/blob/master/registration/backends/default/urls.py # NOQA
     url(r'^activate/complete/$', r.activation_complete,

--- a/src/nyc_trees/apps/login/urls/login.py
+++ b/src/nyc_trees/apps/login/urls/login.py
@@ -19,6 +19,10 @@ urlpatterns = patterns(
         r.forgot_username_sent,
         name='forgot_username_sent'),
 
+    url(r'^password-reset-activation-email/$',
+        r.password_reset_resend_activation,
+        name='password_reset_resend_activation'),
+
     url(r'^send-activation-email/$',
         r.send_activation_email,
         name='send_activation_email'),


### PR DESCRIPTION
Connects to #1783 

When attempting a password reset for a user that registered less than 7 days ago:
![inactive_resend](https://cloud.githubusercontent.com/assets/4432106/9016118/6147a132-379c-11e5-954b-8b16a77a4674.png)

When attempting a password reset for a user that registered more than 7 days ago:
![inactive_fail](https://cloud.githubusercontent.com/assets/4432106/9016124/70bd95f4-379c-11e5-9be8-a465f54097e0.png)

Blocked waiting for confirmation of the text.