### PR TITLE
Fix event map PDF generation triggered by logged out users

### DIFF
--- a/src/nyc_trees/libs/pdf_maps.py
+++ b/src/nyc_trees/libs/pdf_maps.py
@@ -50,6 +50,13 @@ def create_pdf(request, url, filename):
     host = request.get_host()
     if hasattr(request, 'session'):  # prevent test failure
         session_id = request.session.session_key
+
+        # `execv` inside `subprocess.check_output` wants all strings as
+        # arguments, but users who aren't logged in return a `None`
+        # session ID. Here we convert `None` to an empty string.
+        if session_id is None:
+            session_id = ''
+
         create_and_save_pdf.delay(session_id, host, url, filename)
 
 


### PR DESCRIPTION
Shelling out to PhantomJS happens within a function that takes session ID as an argument. That session ID is then passed to PhantomJS via command line arguments.

For reservation PDFs, the session ID is needed to tailor the map for the user who reserved. For event PDFs, no session ID is needed, but it still goes through the same function as reservation PDFs. In cases where the user who triggered an event PDF regeneration is logged out, the session ID is `None`, which `execv` (inside `subprocess.check_output`) doesn't like. It expects all arguments to be Python strings.