### PR TITLE
Count quit surveys as completed for aggregate counts.

### DIFF
--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -226,7 +226,7 @@ class User(NycModel, AbstractUser):
     def surveys(self):
         """Return surveys user has participated in"""
         from apps.survey.models import Survey
-        return Survey.objects.complete().filter(
+        return Survey.objects.filter(
             Q(user=self) | Q(teammate=self))
 
     @property

--- a/src/nyc_trees/apps/home/views.py
+++ b/src/nyc_trees/apps/home/views.py
@@ -54,7 +54,7 @@ def _global_counts(past_week=False):
     if past_week:
         blocks_mapped = get_block_count_past_week()
     else:
-        blocks_mapped = Survey.objects.complete().distinct('blockface').count()
+        blocks_mapped = Survey.objects.distinct('blockface').count()
     if blocks_mapped > 0:
         fraction_mapped = float(blocks_mapped) / float(blocks_total)
         blocks_percent = "{:.1%}".format(fraction_mapped)

--- a/src/nyc_trees/apps/survey/helpers.py
+++ b/src/nyc_trees/apps/survey/helpers.py
@@ -15,7 +15,6 @@ def group_percent_completed(group):
 
     if group_blocks_count > 0:
         completed_blocks = Survey.objects \
-            .complete() \
             .filter(blockface_id__in=group_blocks) \
             .filter(blockface__is_available=False) \
             .distinct('blockface')

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -90,11 +90,6 @@ class Territory(NycModel, models.Model):
         verbose_name_plural = "Territories"
 
 
-class SurveyQuerySet(models.QuerySet):
-    def complete(self):
-        return self.filter(quit_reason='')
-
-
 class Survey(models.Model):
     # We do not anticipate deleting a Blockface, but we definitely
     # should not allow it to be deleted if there is a related Survey
@@ -132,8 +127,6 @@ class Survey(models.Model):
         auto_now=True, db_index=True, editable=False,
         help_text='Time when row was last updated'
     )
-
-    objects = SurveyQuerySet.as_manager()
 
     def __unicode__(self):
         return 'block %s on %s by %s' % (self.blockface_id, self.created_at,

--- a/src/nyc_trees/apps/survey/templates/survey/partials/progress_page_blockface_popup.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/progress_page_blockface_popup.html
@@ -7,6 +7,8 @@
             reserved by you.
         {% elif survey_type == "unavailable" %}
             reserved
+        {% elif survey_type == "unmappable" %}
+            could not be mapped.
         {% elif survey_type == "surveyed-by-me" %}
             mapped by you.
         {% elif survey_type == "surveyed-by-others" %}

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -65,15 +65,21 @@ def progress_page(request):
         'legend_entries': [
             {'mode': 'all', 'css_class': 'mapped', 'label': 'Mapped'},
             {'mode': 'all', 'css_class': 'not-mapped', 'label': 'Not mapped'},
+            {'mode': 'all', 'css_class': 'unmappable',
+             'label': 'Could not be mapped'},
 
             {'mode': 'my', 'css_class': 'mapped', 'label': 'Mapped by you'},
             {'mode': 'my', 'css_class': 'not-mapped',
              'label': 'Not mapped by you'},
+            {'mode': 'my', 'css_class': 'unmappable',
+             'label': 'Could not be mapped'},
 
             {'mode': 'group', 'css_class': 'mapped',
              'label': 'Mapped by this group'},
             {'mode': 'group', 'css_class': 'not-mapped',
              'label': 'Not mapped'},
+            {'mode': 'group', 'css_class': 'unmappable',
+             'label': 'Could not be mapped'},
         ],
         'percentage_ramps': range(0, 100, 10),
         'legend_mode': 'all-percent',
@@ -151,6 +157,9 @@ def _get_survey_type(blockface, user, group):
         latest_survey = Survey.objects \
             .filter(blockface=blockface) \
             .latest('created_at')
+
+        if latest_survey.quit_reason:
+            return 'unmappable'
 
         if user.is_authenticated() and user.pk in {
            latest_survey.user_id, latest_survey.teammate_id}:

--- a/src/nyc_trees/libs/sql.py
+++ b/src/nyc_trees/libs/sql.py
@@ -10,7 +10,6 @@ _survey_sql = """
     WITH most_recent_survey AS (
         SELECT DISTINCT ON (survey.blockface_id) survey.*
         FROM survey_survey AS survey
-        WHERE COALESCE(survey.quit_reason, '') = ''
         ORDER BY survey.blockface_id, survey.created_at DESC
     )"""
 

--- a/src/nyc_trees/sass/partials/_legend.scss
+++ b/src/nyc_trees/sass/partials/_legend.scss
@@ -36,6 +36,9 @@
   .not-mapped {
     background-color: #85664B;
   }
+  .unmappable{
+    background-color: #888;
+  }
   // If you change this color, also change src/nyc_trees/js/lib/SelectableBlockfaceLayer.js
   .selected {
     background-color: #FFEB3B;

--- a/src/tiler/sql/borough_progress.sql
+++ b/src/tiler/sql/borough_progress.sql
@@ -14,8 +14,7 @@
     END AS is_mapped
     FROM survey_blockface AS block
     LEFT OUTER JOIN survey_survey AS survey
-      ON (block.id = survey.blockface_id
-          AND COALESCE(survey.quit_reason, '') = '')
+      ON block.id = survey.blockface_id
     ORDER BY block.id
   ) AS s
   GROUP BY borough_id

--- a/src/tiler/sql/event_pdf.sql
+++ b/src/tiler/sql/event_pdf.sql
@@ -11,8 +11,7 @@
   JOIN survey_territory AS turf
     ON block.id = turf.blockface_id
   LEFT OUTER JOIN survey_survey AS survey
-    ON (block.id = survey.blockface_id
-        AND COALESCE(survey.quit_reason, '') = '')
+    ON block.id = survey.blockface_id
   WHERE turf.group_id = <%= group_id %>
   ORDER BY block.id, survey.created_at DESC NULLS LAST
 ) AS query

--- a/src/tiler/sql/group_progress.sql
+++ b/src/tiler/sql/group_progress.sql
@@ -4,6 +4,7 @@
   DISTINCT ON (block.id)
   block.geom, block.id,
   CASE
+    WHEN COALESCE(survey.quit_reason, '') <> '' THEN 'Q'
     WHEN survey.user_id IS NOT NULL THEN 'T'
     ELSE 'F'
   END AS is_mapped
@@ -11,8 +12,7 @@
   JOIN survey_territory AS turf
     ON block.id = turf.blockface_id
   LEFT OUTER JOIN survey_survey AS survey
-    ON (block.id = survey.blockface_id
-        AND COALESCE(survey.quit_reason, '') = '')
+    ON block.id = survey.blockface_id
   WHERE turf.group_id = <%= group_id %>
   ORDER BY block.id, survey.created_at DESC NULLS LAST
 ) AS query

--- a/src/tiler/sql/nta_progress.sql
+++ b/src/tiler/sql/nta_progress.sql
@@ -14,8 +14,7 @@
     END AS is_mapped
     FROM survey_blockface AS block
     LEFT OUTER JOIN survey_survey AS survey
-      ON (block.id = survey.blockface_id
-          AND COALESCE(survey.quit_reason, '') = '')
+      ON block.id = survey.blockface_id
     ORDER BY block.id
   ) AS s
   GROUP BY nta_id

--- a/src/tiler/sql/progress.sql
+++ b/src/tiler/sql/progress.sql
@@ -4,12 +4,12 @@
   DISTINCT ON (block.id)
   block.geom, block.id,
   CASE
+    WHEN COALESCE(survey.quit_reason, '') <> '' THEN 'Q'
     WHEN survey.id IS NOT NULL THEN 'T'
     ELSE 'F'
   END AS is_mapped
   FROM survey_blockface AS block
   LEFT OUTER JOIN survey_survey AS survey
-    ON (block.id = survey.blockface_id
-        AND COALESCE(survey.quit_reason, '') = '')
+    ON block.id = survey.blockface_id
   ORDER BY block.id, survey.created_at DESC NULLS LAST
 ) AS query

--- a/src/tiler/sql/user_progress.sql
+++ b/src/tiler/sql/user_progress.sql
@@ -4,13 +4,14 @@
   DISTINCT ON (block.id)
   block.geom, block.id,
   CASE
+    WHEN (COALESCE(survey.quit_reason, '') <> '' AND
+          survey.user_id IS NOT DISTINCT FROM <%= user_id %>) THEN 'Q'
     WHEN survey.user_id IS NOT DISTINCT FROM <%= user_id %> THEN 'T'
     WHEN survey.teammate_id IS NOT DISTINCT FROM <%= user_id %> THEN 'T'
     ELSE 'F'
   END AS is_mapped
   FROM survey_blockface AS block
   LEFT OUTER JOIN survey_survey AS survey
-    ON (block.id = survey.blockface_id
-        AND COALESCE(survey.quit_reason, '') = '')
+    ON block.id = survey.blockface_id
   ORDER BY block.id, survey.created_at DESC NULLS LAST
 ) AS query

--- a/src/tiler/style/progress.mss
+++ b/src/tiler/style/progress.mss
@@ -1,7 +1,7 @@
 /* If you change these colors, also change src/nyc_trees/sass/partials/_legend.scss */
+@unmappable: #888;
 @mapped: #8BC34A;
 @not-mapped: #85664B;
-@not-mapped-zoomed-out: #85664B;
 
 #survey_blockface {
   line-join: round;
@@ -16,15 +16,15 @@
   [zoom = 18]{ line-width: 8; }
   [zoom = 19]{ line-width: 16; }
 
+  [is_mapped = 'Q'] {
+    line-color: @unmappable;
+  }
   [is_mapped = 'T'] {
     line-color: @mapped;
     [zoom <= 17]{ line-width: 6; }
   }
   [is_mapped = 'F'] {
     line-color: @not-mapped;
-    [zoom <= 15]{
-      line-color: @not-mapped-zoomed-out;
-    }
   }
 }
 


### PR DESCRIPTION
Surveys quit for a specific reason (intended for things which prevent
mapping the block edge, like construction) are now considered as
completed for the purposes of aggregate counts such as percent completed
on the home page and the block and neighborhood percentages on the
progress map.

For the more detailed view of the all progress layer, and for the user and
group progress layers, we show quit blocks as gray, and the legend shows
that they could not be mapped.

On the event detail map, I chose to show quit blocks the same color as mapped
blocks, since the more pertinent information there is what is available.

Connects to #1800