### PR TITLE
Make survey migration 0029 backward compatible

### DIFF
--- a/src/nyc_trees/apps/survey/migrations/0029_survey_submit_comment.py
+++ b/src/nyc_trees/apps/survey/migrations/0029_survey_submit_comment.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='survey',
             name='submit_comment',
-            field=models.TextField(help_text='Description of why survey was remapped or submitted for review', blank=True),
+            field=models.TextField(help_text='Description of why survey was remapped or submitted for review', null=True, blank=True),
             preserve_default=True,
         ),
     ]

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -119,6 +119,7 @@ class Survey(models.Model):
         blank=True,
         help_text='Description of why survey was abandoned')
     submit_comment = models.TextField(
+        null=True,
         blank=True,
         help_text='Description of why survey was remapped or submitted for '
                   'review')


### PR DESCRIPTION
Temporarily allowing null values allows the migrated database to be shared between old and new versions of the running application, making blue/green deployments easier to manage.

Connects to #1808 