### PR TITLE
Make Survey.submit_comment non-nullable again.

### DIFF
--- a/src/nyc_trees/apps/survey/migrations/0030_auto_20150901_1244.py
+++ b/src/nyc_trees/apps/survey/migrations/0030_auto_20150901_1244.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0029_survey_submit_comment'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='survey',
+            name='submit_comment',
+            field=models.TextField(default='', help_text='Description of why survey was remapped or submitted for review', blank=True),
+            preserve_default=False,
+        ),
+    ]

--- a/src/nyc_trees/apps/survey/models.py
+++ b/src/nyc_trees/apps/survey/models.py
@@ -119,7 +119,6 @@ class Survey(models.Model):
         blank=True,
         help_text='Description of why survey was abandoned')
     submit_comment = models.TextField(
-        null=True,
         blank=True,
         help_text='Description of why survey was remapped or submitted for '
                   'review')


### PR DESCRIPTION
Now that we have pushed release 12 into production, it should be safe
to remove the `null=True` from this field.

Connects to #1810