### PR TITLE
Show street label layer on survey detail page

### DIFF
--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -155,7 +155,7 @@ function initBaseMap(map, options) {
 
     map.addLayer(new L.TileLayer(url, layerOptions));
 
-    if (options.baseMap !== SATELLITE && !options.withLabels) {
+    if (!options.withLabels) {
         labelLayer = new L.TileLayer(protocol + labelsOnlyUrl + suffix, layerOptions);
         labelLayer.setOpacity(0.75);
         map.addLayer(labelLayer);


### PR DESCRIPTION
This works well, except that I'm getting 503 errors on Stamen label tiles
at zoom 19 (our default zoom for many block edges) and on some tiles at zoom 18.
I don't think it's our problem since I also see these errors at their site, e.g.
http://maps.stamen.com/toner-labels/#18/40.71925/-73.99044
I reported the problem using their "report a bug" form.

Connects #1813