### PR TITLE
Change census end FAQ text.

### DIFF
--- a/src/nyc_trees/apps/home/templates/home/about_faq.html
+++ b/src/nyc_trees/apps/home/templates/home/about_faq.html
@@ -115,8 +115,10 @@
 
 <h4>When will TreesCount! 2015 end?</h4>
 <p>
-    Volunteer data collection will end on October 15th. Parks staff data collection will continue
-    into the winter, if all of the blocks have not yet been counted.
+    Our goal is to complete data collection this fall, with the end
+    date depending on variables such as weather and participation
+    rates. Volunteers, community groups and expert staff are all vital
+    contributors to this effort.
 </p>
 
 <h5>For additional information on NYC Parks, TreesCount! 2015 and past


### PR DESCRIPTION
A new answer for "When will TreesCount! 2015 end?" provides by Parks.

<img width="481" alt="screen shot 2015-10-01 at 5 30 27 pm" src="https://cloud.githubusercontent.com/assets/17363/10237127/b1f1d228-6862-11e5-9547-2aea389fe4f6.png">

Connects to #1818