### PR TITLE
Add support for limiting access to the site after the census ends.

### DIFF
--- a/src/nyc_trees/apps/core/templates/core/partials/nav.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/nav.html
@@ -26,16 +26,18 @@
                     <a href="javascript:" data-toggle="modal" data-target="#treecorder-survey-modal">Treecorder</a>
                 {% endif %}
             </li>
-            <li{% if active_page == "dashboard" %} class="active"{% endif %}>
-                <a href="{% url 'home_page' %}">{% if user.is_authenticated %}Dashboard{% else %}Homepage{% endif %}</a>
-            </li>
-            <li{% if active_page == "progress_page" %} class="active"{% endif %}><a href="{% url 'progress_page' %}">Progress Map</a></li>
-            <li{% if active_page == "training" %} class="active"{% endif %}><a href="{% url 'training_summary_pure' %}">Training</a></li>
-            <li{% if active_page == "groups" %} class="active"{% endif %}><a href="{% url 'group_list_page' %}">Groups</a></li>
-            <li{% if active_page == "events" %} class="active"{% endif %}><a href="{% url 'events_list_page' %}">Events</a></li>
-            <li{% if active_page == "reservations" %} class="active"{% endif %}><a href="{% url 'reservations' %}">Reservations</a></li>
-            <li{% if active_page == "achievements" %} class="active"{% endif %}><a href="{% url 'achievements' %}">Rewards</a></li>
         {% endflag %}
+        <li{% if active_page == "dashboard" %} class="active"{% endif %}>
+            <a href="{% url 'home_page' %}">{% if user.is_authenticated %}Dashboard{% else %}Homepage{% endif %}</a>
+        </li>
+        <li{% if active_page == "progress_page" %} class="active"{% endif %}><a href="{% url 'progress_page' %}">Progress Map</a></li>
+        <li{% if active_page == "training" %} class="active"{% endif %}><a href="{% url 'training_summary_pure' %}">Training</a></li>
+        <li{% if active_page == "groups" %} class="active"{% endif %}><a href="{% url 'group_list_page' %}">Groups</a></li>
+        <li{% if active_page == "events" %} class="active"{% endif %}><a href="{% url 'events_list_page' %}">Events</a></li>
+        {% flag full_access %}
+            <li{% if active_page == "reservations" %} class="active"{% endif %}><a href="{% url 'reservations' %}">Reservations</a></li>
+        {% endflag %}
+        <li{% if active_page == "achievements" %} class="active"{% endif %}><a href="{% url 'achievements' %}">Rewards</a></li>
         <li{% if active_page == "about" %} class="active"{% endif %}><a href="{% url 'about_faq_page' %}">About &amp; FAQ</a></li>
         {% if request.user.is_authenticated %}
             <li><a href="{% url 'auth_logout' %}">Logout</a></li>

--- a/src/nyc_trees/apps/event/event_list.py
+++ b/src/nyc_trees/apps/event/event_list.py
@@ -9,6 +9,7 @@ from urllib import urlencode
 from django.db.models import Q
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response
+from django.template.context import RequestContext
 
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
@@ -242,13 +243,14 @@ class EventList(object):
     def url_name(self):
         return self.name + '_partial'
 
-    def endpoint(self, *args, **kwargs):
+    def endpoint(self, request, *args, **kwargs):
         """
         The endpoint used to render a partial.
         """
         return render_to_response(
             self.template_path,
-            {'event_list': self.as_context(*args, **kwargs)})
+            {'event_list': self.as_context(request, *args, **kwargs)},
+            context_instance=RequestContext(request))
 
     #########################################
     # event list control management

--- a/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
+++ b/src/nyc_trees/apps/event/templates/event/partials/rsvp.html
@@ -1,5 +1,6 @@
-{% comment %}
+{% load waffle_tags %}
 
+{% comment %}
 The following variables must be in scope:
 ===
   - user (object)      Model object
@@ -20,8 +21,10 @@ The following variables must be in scope:
         <a id="rsvp" href="#" class="btn btn-switch disabled">This event has ended.</a>
     {% else %}
         {% if is_admin %}
+            {% flag full_access %}
             <a href="{{ event_edit_url }}"
                class="btn btn-secondary"><i class="icon-cog"></i>Edit</a>
+            {% endflag %}
         {% endif %}
         {% if is_admin %}
            <a id="rsvp"

--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -47,7 +47,6 @@
         <div class="row">
             <main class="col-sm-12 main-dashboard">
                 {% flag full_access %}
-
                     {% if not user.online_training_complete %}
                         <div class="home-container">
                             <section class="trainings">
@@ -57,91 +56,84 @@
                             </section>
                         </div>
                     {% endif %}
+                {% endflag %}
 
-                    <section class="section-home">
-                        <div class="home-container clearfix">
-                            <h4 class="section-heading">Progress</h4>
-                            <p>See the progress you and other volun<b>treers</b> have made in helping us count our street trees!</p>
-                            <ul class="nav nav-tabs nav-tabs--filter">
-                                <li class="active">
-                                    <a data-toggle="tab" href="#all-time">All Time</a>
-                                </li>
-                                <li>
-                                    <a data-toggle="tab" href="#past-week">Past Week</a>
-                                </li>
-                                <li>
-                                    <a data-toggle="tab" href="#my-trees">My Trees</a>
-                                </li>
-                            </ul>
-                            <div class="tab-content">
-                                <div class="tab-pane active" id="all-time">
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="progress-circles">
-                                                {% include "home/partials/circle.html" with label="Blocks" n=counts_all.block color="primary" url=progress_page_url %}
-                                                {% include "home/partials/circle.html" with label="Complete" n=counts_all.block_percent color="primary" url=progress_page_url %}
-                                                {% include "home/partials/circle.html" with label="Users" n=counts_all.user color="primary" modal="#users-modal" %}
-                                            </div>
-                                        </div>
-                                        <div class="col-md-6">
-                                            {% include "home/partials/ticker.html" with n=counts_all.tree %}
+                <section class="section-home">
+                    <div class="home-container clearfix">
+                        <h4 class="section-heading">Progress</h4>
+                        <p>See the progress you and other volun<b>treers</b> have made in helping us count our street trees!</p>
+                        <ul class="nav nav-tabs nav-tabs--filter">
+                            <li class="active">
+                                <a data-toggle="tab" href="#all-time">All Time</a>
+                            </li>
+                            <li>
+                                <a data-toggle="tab" href="#past-week">Past Week</a>
+                            </li>
+                            <li>
+                                <a data-toggle="tab" href="#my-trees">My Trees</a>
+                            </li>
+                        </ul>
+                        <div class="tab-content">
+                            <div class="tab-pane active" id="all-time">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="progress-circles">
+                                            {% include "home/partials/circle.html" with label="Blocks" n=counts_all.block color="primary" url=progress_page_url %}
+                                            {% include "home/partials/circle.html" with label="Complete" n=counts_all.block_percent color="primary" url=progress_page_url %}
+                                            {% include "home/partials/circle.html" with label="Users" n=counts_all.user color="primary" modal="#users-modal" %}
                                         </div>
                                     </div>
-                                </div>
-                                <div class="tab-pane" id="past-week">
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="progress-circles">
-                                                {% include "home/partials/circle.html" with label="Blocks" n=counts_week.block color="primary" url=progress_page_url %}
-                                                {% include "home/partials/circle.html" with label="Complete" n=counts_week.block_percent color="primary" url=progress_page_url %}
-                                                {% include "home/partials/circle.html" with label="Events" n=counts_week.event color="primary" url=events_page_url %}
-                                            </div>
-                                        </div>
-                                        <div class="col-md-6">
-                                            {% include "home/partials/ticker.html" with n=counts_week.tree %}
-                                        </div>
+                                    <div class="col-md-6">
+                                        {% include "home/partials/ticker.html" with n=counts_all.tree %}
                                     </div>
                                 </div>
-                                <div class="tab-pane" id="my-trees">
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="progress-circles">
-                                                {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" url=progress_page_url %}
-                                                {% include "home/partials/circle.html" with label="Species" n=counts.species color="primary" modal="#species-modal" %}
-                                                {% include "home/partials/circle.html" with label="Events" n=counts.event color="primary" url=events_page_url %}
-                                            </div>
+                            </div>
+                            <div class="tab-pane" id="past-week">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="progress-circles">
+                                            {% include "home/partials/circle.html" with label="Blocks" n=counts_week.block color="primary" url=progress_page_url %}
+                                            {% include "home/partials/circle.html" with label="Complete" n=counts_week.block_percent color="primary" url=progress_page_url %}
+                                            {% include "home/partials/circle.html" with label="Events" n=counts_week.event color="primary" url=events_page_url %}
                                         </div>
-                                        <div class="col-md-6">
-                                            {% include "home/partials/ticker.html" with n=counts.tree_digits %}
+                                    </div>
+                                    <div class="col-md-6">
+                                        {% include "home/partials/ticker.html" with n=counts_week.tree %}
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane" id="my-trees">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="progress-circles">
+                                            {% include "home/partials/circle.html" with label="Blocks" n=counts.block color="primary" url=progress_page_url %}
+                                            {% include "home/partials/circle.html" with label="Species" n=counts.species color="primary" modal="#species-modal" %}
+                                            {% include "home/partials/circle.html" with label="Events" n=counts.event color="primary" url=events_page_url %}
                                         </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        {% include "home/partials/ticker.html" with n=counts.tree_digits %}
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    </section>
+                    </div>
+                </section>
 
-                    {% if user.online_training_complete %}
-                        <div class="dashboard-columns">
-                            <section class="events">
-                                <div class="home-container">
-                                    <h4 class="section-heading"><a href="{% url 'events_list_page' %}">Events</a></h4>
-                                    <p>Join other tree-loving citizens at street tree mapping events across the five boroughs! Sign up and help us make trees count!</p>
-                                    <div data-class="event-list-container">
-                                        {% include "event/partials/event_list.html" with event_list=all_events %}
-                                    </div>
+                {% if user.online_training_complete %}
+                    <div class="dashboard-columns">
+                        <section class="events">
+                            <div class="home-container">
+                                <h4 class="section-heading"><a href="{% url 'events_list_page' %}">Events</a></h4>
+                                <p>Join other tree-loving citizens at street tree mapping events across the five boroughs! Sign up and help us make trees count!</p>
+                                <div data-class="event-list-container">
+                                    {% include "event/partials/event_list.html" with event_list=all_events %}
                                 </div>
-                            </section>
-                            {% include "users/partials/activity.html" %}
-                        </div>
-                    {% endif %}
-
-                {% else %}
-                    <section class="soft-launch">
-                        {% with title="" section_id="soft-launch" public=False %}
-                            {% include "users/partials/profile/soft_launch.html"%}
-                        {% endwith %}
-                    </section>
-                {% endflag %}
+                            </div>
+                        </section>
+                        {% include "users/partials/activity.html" %}
+                    </div>
+                {% endif %}
             </main>
         </div>
     </div>

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -14,11 +14,9 @@
                     <div class="col-sm-8 col-sm-push-4 col-md-6 col-md-push-6">
                         <div class="hero-content">
                             <h1 class="hero-heading">We're mapping <span class="color--primary">every&nbsp;street&nbsp;tree</span> in&nbsp;New&nbsp;York&nbsp;City!</h1>
-                            {% flag full_access %}
-                                <div class="text-right">
-                                    <a class="hero-link hero-text text-center color--secondary h4" href="{% url 'progress_page' %}">Show me the map →</a>
-                                </div>
-                            {% endflag %}
+                            <div class="text-right">
+                                <a class="hero-link hero-text text-center color--secondary h4" href="{% url 'progress_page' %}">Show me the map →</a>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -50,7 +48,6 @@
                     </div>
                 </section>
 
-                {% flag full_access %}
                 <section class="section-ticker text-center">
                     <div class="home-container">
                         <h2>Help us count our <span class="color--primary">street&nbsp;trees</span>!</h2>
@@ -69,7 +66,6 @@
                         </div>
                     </div>
                 </section>
-                {% endflag %}
 
                 <section class="section-appeal">
                     <div class="row">

--- a/src/nyc_trees/apps/home/templates/home/partials/training.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/training.html
@@ -1,60 +1,65 @@
 {% load utils %}
+{% load waffle_tags %}
 
-{% if user.online_training_complete %}
-<h3>Online Training Complete!</h3>
-<p>Visit <a href="{% url 'home_page' %}">the dashboard</a> to explore the site and start mapping!</p>
+{% flag full_access %}
+    {% if user.online_training_complete %}
+    <h3>Online Training Complete!</h3>
+    <p>Visit <a href="{% url 'home_page' %}">the dashboard</a> to explore the site and start mapping!</p>
 
-<p>You can also visit the Groups page to learn more about mapping opportunities and follow groups for event information.</p>
+    <p>You can also visit the Groups page to learn more about mapping opportunities and follow groups for event information.</p>
 
-<p>The next step after completing online training is to sign up for a training event where you will practice what you've learned in the field! <a href="{% url 'events_list_page' %}?active_filter=training">Sign up for training events here.</a></p>
+    <p>The next step after completing online training is to sign up for a training event where you will practice what you've learned in the field! <a href="{% url 'events_list_page' %}?active_filter=training">Sign up for training events here.</a></p>
 
-{% elif is_started %}
-<h3>You're almost there!</h3>
-<p>Continue your training and help us make trees count!</p>
+    {% elif is_started %}
+    <h3>You're almost there!</h3>
+    <p>Continue your training and help us make trees count!</p>
 
-{% else %}
-<h3>Become a trained volun<span class="color--primary">treer</span> today!</h3>
+    {% else %}
+    <h3>Become a trained volun<span class="color--primary">treer</span> today!</h3>
 
-<p>Before you can RSVP to mapping events, you need to be trained to map trees as a volun<b>treer</b>!
-   Click Start below to continue and help make trees count!</p>
+    <p>Before you can RSVP to mapping events, you need to be trained to map trees as a volun<b>treer</b>!
+    Click Start below to continue and help make trees count!</p>
 
-{% endif %}
+    {% endif %}
 
-<p>You can also download a PDF of the training materials <a target="_blank" href="{{ STATIC_URL }}training/TreesCount2015Training.pdf">here.</a></p>
+    <p>You can also download a PDF of the training materials <a target="_blank" href="{{ STATIC_URL }}training/TreesCount2015Training.pdf">here.</a></p>
 
-{% for step_info in training_steps %}
-<div class="row training block item {% if not step_info.is_visitable %}inactive{% endif %}">
-    <div class="col-xs-8">
-        <h5>
-            <a {% if step_info.is_visitable %}href="{{ step_info.step.pure_url }}"{% endif %}>
-                {{ step_info.step.description }}</a>
-        </h5>
-    </div>
-    <div class="col-xs-4 text-right">
-        <a {% if step_info.is_visitable %}href="{{ step_info.step.pure_url }}"{% endif %}>
-            {% if step_info.is_complete %}
-            <i class="icon-check h4"></i>
-            {% elif step_info.is_next %}
-            <span class="btn-primary btn">Start</span>
-            {% endif %}
-        </a>
-    </div>
-</div>
-{% endfor %}
-{% if user.online_training_complete %}
-<a href="{% url 'groups_to_follow' %}"
-   class="training block item">
-    <div class="row">
+    {% for step_info in training_steps %}
+    <div class="row training block item {% if not step_info.is_visitable %}inactive{% endif %}">
         <div class="col-xs-8">
-            <h5>Groups to Follow</h5>
+            <h5>
+                <a {% if step_info.is_visitable %}href="{{ step_info.step.pure_url }}"{% endif %}>
+                    {{ step_info.step.description }}</a>
+            </h5>
         </div>
         <div class="col-xs-4 text-right">
-          {% if user.training_finished_groups_to_follow %}
-              <i class="icon-check h4"></i>
-          {% else %}
-              <button class="btn-primary btn">Go</button>
-          {% endif %}
+            <a {% if step_info.is_visitable %}href="{{ step_info.step.pure_url }}"{% endif %}>
+                {% if step_info.is_complete %}
+                <i class="icon-check h4"></i>
+                {% elif step_info.is_next %}
+                <span class="btn-primary btn">Start</span>
+                {% endif %}
+            </a>
         </div>
     </div>
-</a>
-{% endif %}
+    {% endfor %}
+    {% if user.online_training_complete %}
+    <a href="{% url 'groups_to_follow' %}"
+    class="training block item">
+        <div class="row">
+            <div class="col-xs-8">
+                <h5>Groups to Follow</h5>
+            </div>
+            <div class="col-xs-4 text-right">
+            {% if user.training_finished_groups_to_follow %}
+                <i class="icon-check h4"></i>
+            {% else %}
+                <button class="btn-primary btn">Go</button>
+            {% endif %}
+            </div>
+        </div>
+    </a>
+    {% endif %}
+{% else %}
+    <p>You can download a PDF of the training materials <a target="_blank" href="{{ STATIC_URL }}training/TreesCount2015Training.pdf">here.</a></p>
+{% endflag %}

--- a/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/event_section.html
@@ -1,3 +1,5 @@
+{% load waffle_tags %}
+
 {% with event=info.event %}
 {# If the user can edit the group, this section should be a div with hrefs, otherwise the whole thing should be an href #}
 {% if event_list.user_can_edit_group %}
@@ -70,15 +72,19 @@
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="group-detail-event-info-submenu-{{ event.id }}">
                     <li><a role="menuitem" tabindex="-1" href="{{ event.get_absolute_url }}">View event</a></li>
-                    {% if not event.is_past %}
-                    <li><a role="menuitem" tabindex="-1" href="{% url 'event_edit' group_slug=event.group.slug event_slug=event.slug %}">Edit details</a></li>
-                    {% endif %}
+                    {% flag full_access %}
+                        {% if not event.is_past %}
+                        <li><a role="menuitem" tabindex="-1" href="{% url 'event_edit' group_slug=event.group.slug event_slug=event.slug %}">Edit details</a></li>
+                        {% endif %}
+                    {% endflag %}
                     {% if event.can_send_email %}
                     <li><a role="menuitem" tabindex="-1" href="{% url 'event_email' group_slug=event.group.slug event_slug=event.slug %}">Email attendees</a></li>
                     {% endif %}
-                    {% if not event.is_past %}
-                    <li><a role="menuitem" tabindex="-1" href="{% url 'event_admin_check_in_page' group_slug=event.group.slug event_slug=event.slug %}">Event check-in</a></li>
-                    {% endif %}
+                    {% flag full_access %}
+                        {% if not event.is_past %}
+                        <li><a role="menuitem" tabindex="-1" href="{% url 'event_admin_check_in_page' group_slug=event.group.slug event_slug=event.slug %}">Event check-in</a></li>
+                        {% endif %}
+                    {% endflag %}
                     <li><a role="menuitem" tabindex="-1" href="javascript:;" class="js-copy-event-url"
                             data-event-url="{{ info.event_share_url }}">Get shareable link</a></li>
                 </ul>

--- a/src/nyc_trees/apps/users/templates/groups/partials/follow_button.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/follow_button.html
@@ -1,3 +1,5 @@
+{% load waffle_tags %}
+
 {% comment %}
 
 The following variables must be in scope:
@@ -7,17 +9,23 @@ The following variables must be in scope:
   - user_is_following (bool)  Is the current user following this group?
 
 {% endcomment %}
-{% if user_is_following %}
-<a href="javascript:void(0)"
-    class="btn btn-default btn-unfollow"
-    data-url="{% url 'unfollow_group' group_slug=group.slug %}"
-    data-verb="POST">Following</a>
-{% elif not user.is_authenticated %}
-<a href="{% url 'login' %}?next={% url 'follow_group' group_slug=group.slug  %}"
-    class="btn btn-switch btn-follow">Follow</a>
+{% flag full_access %}
+    {% if user_is_following %}
+    <a href="javascript:void(0)"
+        class="btn btn-default btn-unfollow"
+        data-url="{% url 'unfollow_group' group_slug=group.slug %}"
+        data-verb="POST">Following</a>
+    {% elif not user.is_authenticated %}
+    <a href="{% url 'login' %}?next={% url 'follow_group' group_slug=group.slug  %}"
+        class="btn btn-switch btn-follow">Follow</a>
+    {% else %}
+    <a href="javascript:void(0)"
+        class="btn btn-switch btn-follow"
+        data-url="{% url 'follow_group' group_slug=group.slug %}"
+        data-verb="POST">Follow</a>
+    {% endif %}
 {% else %}
-<a href="javascript:void(0)"
-    class="btn btn-switch btn-follow"
-    data-url="{% url 'follow_group' group_slug=group.slug %}"
-    data-verb="POST">Follow</a>
-{% endif %}
+    {% if user_is_following %}
+    <a class="btn btn-default btn-follow" href="javascript:void(0)">Following</a>
+    {% endif %}
+{% endflag %}

--- a/src/nyc_trees/apps/users/templates/groups/partials/follow_detail.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/follow_detail.html
@@ -1,3 +1,5 @@
+{% load waffle_tags %}
+
 {% if render_follow_button_without_count %}
     {% include 'groups/partials/follow_button.html' %}
 {% else %}
@@ -6,12 +8,18 @@
         <span class="h6">Follower{{ counts.follows|pluralize }}</span>
     </div>
     <div class="col-xs-6 text-right">
+    {% flag full_access %}
         {% if event_list.user_can_edit_group %}
             <a href="{{edit_url}}" class="btn btn-switch icon-cog">Admin</a>
         {% else %}
+            <div class="btn-follow-container">
+                {% include 'groups/partials/follow_button.html' %}
+            </div>
+        {% endif %}
+    {% else %}
         <div class="btn-follow-container">
             {% include 'groups/partials/follow_button.html' %}
         </div>
-        {% endif %}
+    {% endflag %}
     </div>
 {% endif  %}

--- a/src/nyc_trees/apps/users/templates/users/partials/activity.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/activity.html
@@ -10,26 +10,28 @@
         </form>
     </section>
     {% endif %}
+{% endflag %}
 
-    {% if show_contributions %}
-    <section class="contributions">
-        <div>
-            {% with title=contributions_title url="contributions" public=user.contributions_are_public %}
-                {% include "users/partials/profile/contributions.html"%}
-            {% endwith %}
-        </div>
-    </section>
-    {% endif %}
-
-    {% if show_groups and follows.follows %}
-    <section class="groups">
-        {% url 'group_list_page' as groups_url %}
-        {% with title="Groups" url=groups_url public=user.group_follows_are_public %}
-            {% include "users/partials/profile/groups.html" %}
+{% if show_contributions %}
+<section class="contributions">
+    <div>
+        {% with title=contributions_title url="contributions" public=user.contributions_are_public %}
+            {% include "users/partials/profile/contributions.html"%}
         {% endwith %}
-    </section>
-    {% endif %}
+    </div>
+</section>
+{% endif %}
 
+{% if show_groups and follows.follows %}
+<section class="groups">
+    {% url 'group_list_page' as groups_url %}
+    {% with title="Groups" url=groups_url public=user.group_follows_are_public %}
+        {% include "users/partials/profile/groups.html" %}
+    {% endwith %}
+</section>
+{% endif %}
+
+{% flag full_access %}
     {% if show_reservations %}
     <section class="reservations">
         {% url 'reservations' as reservations_url %}
@@ -38,19 +40,13 @@
         {% endwith %}
     </section>
     {% endif %}
-
-    {% if show_achievements %}
-    <section class="achievements">
-        {% url 'achievements' as achievements_url %}
-        {% with title="Rewards" url=achievements_url public=user.achievements_are_public %}
-            {% include "users/partials/profile/achievements.html" %}
-        {% endwith %}
-    </section>
-    {% endif %}
-{% else %}
-    <section class="soft-launch">
-        {% with title="Your Profile" url=softlaunch_url public=False %}
-            {% include "users/partials/profile/soft_launch.html"%}
-        {% endwith %}
-    </section>
 {% endflag %}
+
+{% if show_achievements %}
+<section class="achievements">
+    {% url 'achievements' as achievements_url %}
+    {% with title="Rewards" url=achievements_url public=user.achievements_are_public %}
+        {% include "users/partials/profile/achievements.html" %}
+    {% endwith %}
+</section>
+{% endif %}

--- a/src/nyc_trees/nyc_trees/middleware.py
+++ b/src/nyc_trees/nyc_trees/middleware.py
@@ -11,10 +11,10 @@ from django.contrib.auth import logout
 from django.shortcuts import redirect
 
 
-class SoftLaunchMiddleware(object):
+class FullAccessMiddleware(object):
     def __init__(self):
-        self.redirect_url = getattr(settings, 'SOFT_LAUNCH_REDIRECT_URL', '/')
-        regexes = getattr(settings, 'SOFT_LAUNCH_REGEXES', [])
+        self.redirect_url = settings.LIMITED_ACCESS_REDIRECT_URL
+        regexes = settings.LIMITED_ACCESS_REGEXES
         self.regexes = [re.compile(r) for r in regexes]
 
     def process_view(self, request, view_func, view_args, view_kwargs):

--- a/src/nyc_trees/nyc_trees/settings/base.py
+++ b/src/nyc_trees/nyc_trees/settings/base.py
@@ -263,7 +263,7 @@ MIDDLEWARE_CLASSES = (
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'waffle.middleware.WaffleMiddleware',
-    'nyc_trees.middleware.SoftLaunchMiddleware',
+    'nyc_trees.middleware.FullAccessMiddleware',
     'nyc_trees.middleware.BannedUserMiddleware',
 )
 # END MIDDLEWARE CONFIGURATION
@@ -367,14 +367,28 @@ TILER_URL = '//%s' % environ.get('TILER_HOST', 'localhost')
 
 MAX_GROUP_IMAGE_SIZE_IN_BYTES = 102400  # 100 KB
 
-SOFT_LAUNCH_REDIRECT_URL = "/"
-SOFT_LAUNCH_REGEXES = [
-    r'^/user/',
+LIMITED_ACCESS_REDIRECT_URL = "/"
+# The following regexes control what pages users are allowed to access
+LIMITED_ACCESS_REGEXES = [
+    r'^/$',
     r'^/accounts/',
-    r'^/login/',
-    r'^/faq/',
     r'^/admin/',
+    r'^/blockedge/(progress|printable-map|near|map-poll|group-popup)/',
+    r'^/blockedge/group-borders.json',
+    r'^/blockedge/\d+/',
+    r'^/event/',
+    r'^/faq/',
+    r'^/geocode/',
+    r'^/group/$',
+    r'^/group/[\w-]+/$',
+    r'^/group/[\w-]+/events/',
+    r'^/group/[\w-]+/event/[\w-]+/$',
+    r'^/group/[\w-]+/event/[\w-]+/(email|popup|printable-map|map-poll|unsubscribe)',  # NOQA
+    r'^/group/\d+/territory.json',
     r'^/health-check/',
+    r'^/login/',
+    r'^/training/$',
+    r'^/user/',
 ]
 
 RESERVATION_REMINDER_WINDOW = 3


### PR DESCRIPTION
Uses the existing soft launch infrastructure to support full access to
the site when the census is suspended to a limited group of people, and
allow some access for other users.

Users who do not have full access can get to the progress map, group and
event lists, group and event detail pages, the FAQ and the main training
page (but not the training subpages).

Access to editing groups and events is blocked off unless the user has
full site access, as is access to following groups.

Connects to #1814 

To test, configure the `full_access` waffle flag from the Django admin site.  You can set the value for `Everyone` to `No` to test how limited access works regardless of the logged in user, or set the flag to `Unknown` to allow configuring which users the flag does and does not apply to via the other options available.