### PR TITLE
Hide RSVP button unless user has full_access

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/event_detail.html
+++ b/src/nyc_trees/apps/event/templates/event/event_detail.html
@@ -1,6 +1,7 @@
 {% extends "base_two_frames.html" %}
 
 {% load utils %}
+{% load waffle_tags %}
 
 {% block top %}
 
@@ -113,11 +114,13 @@
         </div>
     </div>
 
+    {% flag full_access %}
     <div class="pageheading-controls block">
         <div id="rsvp-section" class="row">
             {% include "event/partials/rsvp.html" %}
         </div>
     </div>
+    {% endflag %}
 
 {% endblock aside %}
 


### PR DESCRIPTION
Regular users cannot RSVP to events after the census officially ends.

Connects to #1826 