### PR TITLE
Apply "winter" text changes from Parks

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/event_list_page.html
+++ b/src/nyc_trees/apps/event/templates/event/event_list_page.html
@@ -10,7 +10,10 @@
   <div class="map-sidebar">
     <h2>Events</h2>
     <p class="pageheading-description-detail">
+      NYC Parks and TreesCount! partner groups hosted more than 900 events in 2015.
+<!--
       Check out our upcoming TreesCount! events and sign up to map street trees with fellow volun<strong>treers</strong>!
+-->
     </p>
     <p class="pageheading-description-detail">Click to view as a list or find an event nearby using the map.</p>
     <div id="action-bar" class="action-bar">

--- a/src/nyc_trees/apps/home/templates/home/about_faq.html
+++ b/src/nyc_trees/apps/home/templates/home/about_faq.html
@@ -29,7 +29,7 @@
 <p>
     New volun<b>treer</b> training and data collection has ended, but there are opportunities year
     round to get involved in caring for the urban forest. Check out NYC Parks
-    <a href="http://www.nycgovparks.org/reg/stewardship%22">stewardship page</a>
+    <a href="http://www.nycgovparks.org/reg/stewardship">stewardship page</a>
     to find out more.
 <!--
     Getting involved is easy! To get started, <a href="{% url 'registration_register' %}">register</a> on our
@@ -73,7 +73,7 @@
 <p>
     If you missed voluntreer training for TreesCount! don’t worry – there are still other
     opportunities to get involved! Check out NYC Parks
-    <a href="http://www.nycgovparks.org/reg/stewardship%22">stewardship page</a>
+    <a href="http://www.nycgovparks.org/reg/stewardship">stewardship page</a>
     to find out how you can help care for our urban forest year-round.
 </p>
 <!--

--- a/src/nyc_trees/apps/home/templates/home/about_faq.html
+++ b/src/nyc_trees/apps/home/templates/home/about_faq.html
@@ -12,22 +12,33 @@
 
 <h4>What is TreesCount! 2015?</h4>
 <p>
-    TreesCount! 2015 is NYC Parks&rsquo; initiative to map and assess every street tree on every block in New York City.
+    TreesCount! is NYC Parks&rsquo; initiative to map and assess every street tree on every block in New York City.
+<!--
     <a href="{% url 'registration_register' %}">Register</a> to become a volun<b>treer</b> today!
+-->
 </p>
 
+<!--
 <h4>Do I need to know a lot about trees to get involved?</h4>
 <p>
     No prior experience is required! We will help you learn everything you need to know to participate.
 </p>
+-->
 
 <h4>How do I become a voluntreer?</h4>
 <p>
+    New volun<b>treer</b> training and data collection has ended, but there are opportunities year
+    round to get involved in caring for the urban forest. Check out NYC Parks
+    <a href="http://www.nycgovparks.org/reg/stewardship%22">stewardship page</a>
+    to find out more.
+<!--
     Getting involved is easy! To get started, <a href="{% url 'registration_register' %}">register</a> on our
     website and take our brief online training course. Then, RSVP to and attend a training event with NYC Parks
     or one of our Census partner groups to gain hands-on knowledge about how to assess and map street trees.
+-->
 </p>
 
+<!--
 <h4>What happens at a TreesCount! 2015 event?</h4>
 <p>
     There are two kinds of events: training and mapping.
@@ -45,15 +56,36 @@
     and spend the entire event collecting data and mapping. You can
     also check out a wheel directly from any NYC Parks’ mapping event in order to map on your own!
 </p>
+-->
 
 <h4>Where can I volunteer to map street trees?</h4>
+<p>
+    Data collection in many neighborhoods was completed in 2015. If you’re a trained mapper,
+    check out our <a href="{% url "progress_page" %}">progress map</a> to find out which neighborhoods are complete, and learn where
+    we still need your help!.
+</p>
+<p>
+    Volun<b>treer</b> data collection will begin again in spring of 2016. If you are an experienced
+    independent mapper, and are interested in volun<b>treering</b> over the winter, please email
+    <a href="mailto:Treescount@parks.nyc.gov">Treescount@parks.nyc.gov</a>
+    to find out how.
+</p>
+<p>
+    If you missed voluntreer training for TreesCount! don’t worry – there are still other
+    opportunities to get involved! Check out NYC Parks
+    <a href="http://www.nycgovparks.org/reg/stewardship%22">stewardship page</a>
+    to find out how you can help care for our urban forest year-round.
+</p>
+<!--
 <p>
     We are hosting events in neighborhoods throughout all five boroughs of New York City.
     Many local organizations are contributing to the mapping effort, and you will be able to
     participate in events hosted by TreesCount! partner groups and by NYC Parks.
     After you’ve completed your online training, find training and mapping events near you <a href="{% url "events_list_page" %}">here</a>.
 </p>
+-->
 
+<!--
 <h4>Do I need to bring anything to a training event?</h4>
 <p>
     Just a love of trees and a willingness to learn! You will need your TreesCount! username and
@@ -112,16 +144,22 @@
     a current list of loaning hubs, and always call the loaning hub contact number to confirm that wheels are available
     before visiting! Loaning hub locations will be updated periodically throughout the summer.
 </p>
+-->
 
-<h4>When will TreesCount! 2015 end?</h4>
+<h4>When will TreesCount! end?</h4>
 <p>
+    As with our past censuses in 1995-96 and 2005-06, this data collection effort will take two
+    seasons. Volunteers, community groups, and expert staff members are all vital contributors
+    to this effort, and working together we can make sure every tree counts!
+<!--
     Our goal is to complete data collection this fall, with the end
     date depending on variables such as weather and participation
     rates. Volunteers, community groups and expert staff are all vital
     contributors to this effort.
+-->
 </p>
 
-<h5>For additional information on NYC Parks, TreesCount! 2015 and past
+<h5>For additional information on NYC Parks, TreesCount! and past
     TreesCount! Censuses from 1995 and 2005 visit the
     <a href="http://www.nycgovparks.org/trees/treescount">NYC&nbsp;Parks&nbsp;website</a>.</h5>
 

--- a/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/dashboard.html
@@ -35,7 +35,12 @@
                         <div class="hero-content">
                             <h1 class="hero-heading">Welcome back,
                             volun<span class="color--primary">treer!</span></h1>
+                            <p>Thank you for playing a key role in the future of our urban forest!
+                                Volun<b>treer</b> data collection will begin again in spring 2016
+                                and you&rsquo;ll be able to make block edge reservations to map more trees across NYC.</p>
+                            <!--
                             <p>Play a key role in the future of our urban forest! Sign up for a mapping event or make a block edge reservation to map more trees across NYC!</p>
+                            -->
                         </div>
                     </div>
                 </div>
@@ -122,16 +127,20 @@
 
                 {% if user.online_training_complete %}
                     <div class="dashboard-columns">
+                        {% include "users/partials/activity.html" %}
                         <section class="events">
                             <div class="home-container">
                                 <h4 class="section-heading"><a href="{% url 'events_list_page' %}">Events</a></h4>
+                                <p>Check back in spring 2016 for more opportunities to join other tree-loving citizens
+                                    at street tree mapping events across the five boroughs!</p>
+                                <!--
                                 <p>Join other tree-loving citizens at street tree mapping events across the five boroughs! Sign up and help us make trees count!</p>
                                 <div data-class="event-list-container">
                                     {% include "event/partials/event_list.html" with event_list=all_events %}
                                 </div>
+                                -->
                             </div>
                         </section>
-                        {% include "users/partials/activity.html" %}
                     </div>
                 {% endif %}
             </main>

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -35,9 +35,15 @@
                                      srcset="{{ "img/logo-nycparks@2x.png"|static_url }} 2x" alt="NYC Parks Logo" />
                             </div>
                             <div class="col-xs-9 col-sm-8">
+                                Join the Counter Culture! NYC Parks, partner groups and trained
+                                volun<b>treers</b> are counting and mapping all the beautiful street trees that
+                                grace our city. Sign up to find out more about how you too can play a
+                                key role in the future of our urban forest!
+<!--
                                 Join the Counter Culture!
                                 This year, NYC Parks is counting and mapping all the beautiful street trees that grace our city, and we need your help!
                                 Sign up to become a volun<b>treer</b> for TreesCount! 2015 and play a key role in the future of our urban forest!
+-->
                             </div>
                         </div>
 
@@ -74,9 +80,22 @@
                         </div>
                         <div class="section-appeal-text col-sm-6">
                             <h2>Collecting data on street trees leads to a greener and greater NYC!</h2>
+                            <p>Our street trees make our city cooler, our air cleaner, and our neighborhoods more
+                                beautiful. <b>TreesCount!</b> is New York City’s third census of our urban forest, and tree-loving
+                                citizens like you are helping us collect data.</p>
+                            <p>New volunteer training and data collection has now ended for 2015. Expert staff and
+                                independent mappers trained in winter data collection are continuing to map, and all trained
+                                volun<b>treers</b> will be able to help us finish mapping in 2016.</p>
+                            <p>Once the census is complete, NYC Parks will launch a new Street Tree Map using
+                                TreesCount! data. You will be able to see and explore the forest, and record tree
+                                stewardship like weeding, watering and mulching.</p>
+                            <p>There are also opportunities year round to get involved in caring for the urban forest. Check
+                                out NYC Parks <a href="http://www.nycgovparks.org/reg/stewardship%22">stewardship page</a>
+                                to find out more!</p>
+ <!--
                             <p>
                                 Our street trees make our city cooler, our air cleaner, and our neighborhoods more beautiful.
-                                <b>TreesCount!&nbsp;2015</b> is New York City&rsquo;s third decadal effort to inventory our urban forest,
+                                <b>TreesCount!&nbsp;2015</b> is New York City&rsquo;s third decadal effort to inventory our urban forest,
                                 and we need tree-loving citizens like you to help us collect data.
                                 Volunteers will be trained on how to identify and assess street trees,
                                 using simple site surveying tools and software to map them block by block.
@@ -88,6 +107,7 @@
                                 For more information on the volunteer experience check out our <a href="{% url 'about_faq_page' %}">FAQ</a>!
                             </p>
                             <p>Can we count on you? Create an account to become a volun<b>treer</b> today!</p>
+-->
                         </div>
                     </div>
                 </section>

--- a/src/nyc_trees/apps/home/templates/home/partials/home_public.html
+++ b/src/nyc_trees/apps/home/templates/home/partials/home_public.html
@@ -90,7 +90,7 @@
                                 TreesCount! data. You will be able to see and explore the forest, and record tree
                                 stewardship like weeding, watering and mulching.</p>
                             <p>There are also opportunities year round to get involved in caring for the urban forest. Check
-                                out NYC Parks <a href="http://www.nycgovparks.org/reg/stewardship%22">stewardship page</a>
+                                out NYC Parks <a href="http://www.nycgovparks.org/reg/stewardship">stewardship page</a>
                                 to find out more!</p>
  <!--
                             <p>

--- a/src/nyc_trees/apps/survey/templates/survey/partials/reservations_legend.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/reservations_legend.html
@@ -5,6 +5,12 @@ Reservations
 {% endblock %}
 
 {% block legend_text %}
+    Ready to map on your own? If you’re interested in mapping over the winter, please email
+    <a href="mailto:Treescount@parks.nyc.gov">Treescount@parks.nyc.gov</a>
+    to sign up for a winter data collection course and learn how to
+    keep rolling. You can also check back in the spring to find out where we still need your help,
+    and reserve more available block edges for mapping.
+<!--
     Ready to map on your own?
     Reserve available block edges for mapping!
     Select the blocks you want to map, add them to the cart,
@@ -13,4 +19,5 @@ Reservations
     <br><br>
     Checking out a wheel is easy! You can either visit one of our loaning hubs,
     or check out a wheel at the end of any NYC Parks’ mapping event.
+-->
 {% endblock %}

--- a/src/nyc_trees/apps/survey/templates/survey/partials/reservations_legend.html
+++ b/src/nyc_trees/apps/survey/templates/survey/partials/reservations_legend.html
@@ -5,12 +5,6 @@ Reservations
 {% endblock %}
 
 {% block legend_text %}
-    Ready to map on your own? If you’re interested in mapping over the winter, please email
-    <a href="mailto:Treescount@parks.nyc.gov">Treescount@parks.nyc.gov</a>
-    to sign up for a winter data collection course and learn how to
-    keep rolling. You can also check back in the spring to find out where we still need your help,
-    and reserve more available block edges for mapping.
-<!--
     Ready to map on your own?
     Reserve available block edges for mapping!
     Select the blocks you want to map, add them to the cart,
@@ -19,5 +13,4 @@ Reservations
     <br><br>
     Checking out a wheel is easy! You can either visit one of our loaning hubs,
     or check out a wheel at the end of any NYC Parks’ mapping event.
--->
 {% endblock %}

--- a/src/nyc_trees/apps/users/templates/groups/list.html
+++ b/src/nyc_trees/apps/users/templates/groups/list.html
@@ -7,6 +7,15 @@
 
 {% block aside %}
   <h2>Groups</h2>
+    <p class="pageheading-description-detail">
+        NYC Parks and TreesCount! partner groups hosted training and mapping events across the
+        five boroughs throughout the summer and fall of 2015.
+    </p>
+    <p class="pageheading-description-detail">
+        Interested in being a TreesCount! partner group again in 2016? Please email
+        <a href="mailto:Treescount@parks.nyc.gov">Treescount@parks.nyc.gov</a> and let us know.
+    </p>
+<!--
   <p class="pageheading-description-detail">
     NYC Parks and TreesCount! Partner groups will be hosting training and mapping events
     across the five boroughs.
@@ -18,6 +27,7 @@
     Interested in being a TreesCount! group? Learn more about registering your group
     <a href="http://www.nycgovparks.org/trees/treescount/register-your-group">here</a>!
   </p>
+-->
   {% block extra_description %}
  	{% endblock %}
 {% endblock aside %}

--- a/src/nyc_trees/apps/users/templates/users/achievement.html
+++ b/src/nyc_trees/apps/users/templates/users/achievement.html
@@ -8,10 +8,15 @@
 <div class="pageheading-description block">
     <h2>Rewards</h2>
     <p class="pageheading-description-detail">
+        A new year of mapping brings new rewards. Check back in spring 2016 to see our new set
+        of prizes and track your progress in becoming a master mapper! Earn badges and become
+        eligible for prizes the more block edges you map. Service letters available on request.
+<!--
       Track your progress in becoming a master
       mapper! Earn badges and become eligible for
       prizes the more block edges you map!
       Service letters available on request.
+-->
     </p>
 </div>
 {% endblock aside %}

--- a/src/nyc_trees/apps/users/templates/users/partials/activity.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/activity.html
@@ -22,15 +22,6 @@
 </section>
 {% endif %}
 
-{% if show_groups and follows.follows %}
-<section class="groups">
-    {% url 'group_list_page' as groups_url %}
-    {% with title="Groups" url=groups_url public=user.group_follows_are_public %}
-        {% include "users/partials/profile/groups.html" %}
-    {% endwith %}
-</section>
-{% endif %}
-
 {% flag full_access %}
     {% if show_reservations %}
     <section class="reservations">
@@ -47,6 +38,15 @@
     {% url 'achievements' as achievements_url %}
     {% with title="Rewards" url=achievements_url public=user.achievements_are_public %}
         {% include "users/partials/profile/achievements.html" %}
+    {% endwith %}
+</section>
+{% endif %}
+
+{% if show_groups and follows.follows %}
+<section class="groups">
+    {% url 'group_list_page' as groups_url %}
+    {% with title="Groups" url=groups_url public=user.group_follows_are_public %}
+        {% include "users/partials/profile/groups.html" %}
     {% endwith %}
 </section>
 {% endif %}

--- a/src/nyc_trees/apps/users/templates/users/partials/profile/reservations.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/reservations.html
@@ -24,13 +24,10 @@
 {% if reservations.count > 0 %}
     {% include "core/partials/polling_download_section.html" with poll_url=reservations.map_poll_url %}
 {% else %}
-    <p>Ready to map on your own? If you&rsquo;re interested in mapping over the winter, please email
-        <a href="mailto:Treescount@parks.nyc.gov">Treescount@parks.nyc.gov</a>
-        to sign up for a winter data collection course and learn how to
-        keep rolling.</p>
-    <p>You can also check back in the spring to see where we still need your help, and
-        <a href="{{ reservations_url }}">reserve more available block edges for mapping</a>.
-    </p>
+    Ready to map on your own? If you&rsquo;re interested in mapping over the winter, please email
+    <a href="mailto:Treescount@parks.nyc.gov">Treescount@parks.nyc.gov</a>
+    to sign up for a winter data collection course and learn how to
+    keep rolling.
 <!--
     Ready to map on your own? <a href="{{ reservations_url }}">Reserve available block edges</a> for mapping!
 -->

--- a/src/nyc_trees/apps/users/templates/users/partials/profile/reservations.html
+++ b/src/nyc_trees/apps/users/templates/users/partials/profile/reservations.html
@@ -24,7 +24,16 @@
 {% if reservations.count > 0 %}
     {% include "core/partials/polling_download_section.html" with poll_url=reservations.map_poll_url %}
 {% else %}
+    <p>Ready to map on your own? If you&rsquo;re interested in mapping over the winter, please email
+        <a href="mailto:Treescount@parks.nyc.gov">Treescount@parks.nyc.gov</a>
+        to sign up for a winter data collection course and learn how to
+        keep rolling.</p>
+    <p>You can also check back in the spring to see where we still need your help, and
+        <a href="{{ reservations_url }}">reserve more available block edges for mapping</a>.
+    </p>
+<!--
     Ready to map on your own? <a href="{{ reservations_url }}">Reserve available block edges</a> for mapping!
+-->
 {% endif %}
 
 {% endblock section_content %}

--- a/src/nyc_trees/templates/registration/activation_email.html
+++ b/src/nyc_trees/templates/registration/activation_email.html
@@ -22,9 +22,13 @@
     </a>
 </p>
 <p>
-    Please contact us at
-    <a href="mailto:TreesCount.Help@parks.nyc.gov">TreesCount.Help@parks.nyc.gov</a>
-    for technical assistance or any questions related to the TreesCount! 2015 website.
+    Your email address has now been added to our list for updates on TreesCount! progress.
+    If you have questions about the project, please email us at treescount@parks.nyc.gov.
+    <a href="mailto:treescount@parks.nyc.gov">treescount@parks.nyc.gov</a>
+</p>
+<p>
+    If you&rsquo;re interested in immediate opportunities to volunteer, please visit the NYC Parks
+    <a href="http://www.nycgovparks.org/reg/stewardship">stewardship page</a>.
 </p>
 </body>
 

--- a/src/nyc_trees/templates/registration/registration_form.html
+++ b/src/nyc_trees/templates/registration/registration_form.html
@@ -6,10 +6,21 @@
 
 {% block registration_content %}
 <p>
+    Training for new TreesCount! volun<b>treers</b> has ended for 2015, but there are still
+    many opportunities to get involved in the urban forest. For immediate volunteer
+    opportunities, please visit the NYC Parks
+    <a href="http://www.nycgovparks.org/reg/stewardship">stewardship page</a>.
+    If you&rsquo;d like updates on TreesCount! progress and the future Street Tree Map,
+    please create a username and choose a password.
+    If you are already a trained volun<b>treer</b>, you can
+    <a href="{% url "auth_login" %}">log in</a> to your dashboard
+    using the link in the top right corner.
+<!--
     TreesCount! 2015 volunteers will use equipment and materials provided by NYC Parks and Partner Groups
     to inventory street trees throughout New York City. Create a username and choose a password to get started
     or <a href="{% url "auth_login" %}">log in</a> using the link in the top right corner to participate
     if you have already created an account.
+-->
 </p>
 <form method="post" action="{{ request.path }}">
     {% csrf_token %}


### PR DESCRIPTION
* Leave existing text commented-out for easy restoration in spring
* On the logged-in dashboard I gave them a slightly different order than they requested. (It would be a lot harder to have events in the middle because of how this content is shared with the user profile.):
  * Currently: events, groups, reservations, rewards
  * They wanted: reservations, rewards, events, groups
  * I gave them: reservations, rewards, groups, events

Connects #1825