### PR TITLE
Hide calls to action on event page

### DIFF
--- a/src/nyc_trees/apps/event/templates/event/event_list_page.html
+++ b/src/nyc_trees/apps/event/templates/event/event_list_page.html
@@ -15,9 +15,13 @@
       Check out our upcoming TreesCount! events and sign up to map street trees with fellow volun<strong>treers</strong>!
 -->
     </p>
+<!--
     <p class="pageheading-description-detail">Click to view as a list or find an event nearby using the map.</p>
+-->
     <div id="action-bar" class="action-bar">
+<!--
       Select an event to view additional details
+-->
     </div>
     <div class="row">
       <ul class="nav nav-tabs nav-tabs-event" id="nav-tabs-event">


### PR DESCRIPTION
There will be no events over the winter so this instructive text could
be misleading.

### Before

<img width="804" alt="screen shot 2015-11-02 at 2 13 13 pm" src="https://cloud.githubusercontent.com/assets/17363/10894831/f69ccb66-816d-11e5-85b4-b8de84030c3e.png">

### After

<img width="802" alt="screen shot 2015-11-02 at 2 21 27 pm" src="https://cloud.githubusercontent.com/assets/17363/10894841/fe206d02-816d-11e5-9a38-53fc48d66ef9.png">


Connects to #1825 