### PR TITLE
Reduce access to events

### DIFF
--- a/src/nyc_trees/apps/core/templates/core/partials/nav.html
+++ b/src/nyc_trees/apps/core/templates/core/partials/nav.html
@@ -33,7 +33,7 @@
         <li{% if active_page == "progress_page" %} class="active"{% endif %}><a href="{% url 'progress_page' %}">Progress Map</a></li>
         <li{% if active_page == "training" %} class="active"{% endif %}><a href="{% url 'training_summary_pure' %}">Training</a></li>
         <li{% if active_page == "groups" %} class="active"{% endif %}><a href="{% url 'group_list_page' %}">Groups</a></li>
-        <li{% if active_page == "events" %} class="active"{% endif %}><a href="{% url 'events_list_page' %}">Events</a></li>
+{#        <li{% if active_page == "events" %} class="active"{% endif %}><a href="{% url 'events_list_page' %}">Events</a></li>#}
         {% flag full_access %}
             <li{% if active_page == "reservations" %} class="active"{% endif %}><a href="{% url 'reservations' %}">Reservations</a></li>
         {% endflag %}

--- a/src/nyc_trees/apps/event/event_list.py
+++ b/src/nyc_trees/apps/event/event_list.py
@@ -133,9 +133,10 @@ class EventList(object):
                     is_private=False, includes_training=False)),
             ]),
             EventList.chronoFilters: OrderedDict([
-                (_CURRENT, lambda qs: (qs
-                                       .filter(ends_at__gte=right_now)
-                                       .order_by('begins_at'))),
+                # Hiding the "current" category for the 2016 season
+                # (_CURRENT, lambda qs: (qs
+                #                        .filter(ends_at__gte=right_now)
+                #                        .order_by('begins_at'))),
                 (_PAST, lambda qs: (qs
                                     .filter(ends_at__lt=right_now)
                                     .order_by('-begins_at'))),

--- a/src/nyc_trees/apps/users/templates/groups/partials/edit_event_list.html
+++ b/src/nyc_trees/apps/users/templates/groups/partials/edit_event_list.html
@@ -1,9 +1,9 @@
 {% extends "event/partials/event_list.html" %}
 
-
-{% block filter_ul_extra_controls %}
-<li><a href="{% url 'add_event' group_slug=event_list.group_slug %}">+ New</a></li>
-{% endblock filter_ul_extra_controls %}
+{# Removing the ability to add an event for the 2016 season #}
+{#{% block filter_ul_extra_controls %}#}
+{#<li><a href="{% url 'add_event' group_slug=event_list.group_slug %}">+ New</a></li>#}
+{#{% endblock filter_ul_extra_controls %}#}
 
 {% block event_list_loop %}
     {% for info in event_list.event_infos %}

--- a/src/nyc_trees/apps/users/views/group.py
+++ b/src/nyc_trees/apps/users/views/group.py
@@ -92,7 +92,7 @@ def group_detail(request):
 
     event_list = (group_detail_events
                   .configure(chunk_size=3,
-                             active_filter=EventList.Filters.CURRENT,
+                             active_filter=EventList.Filters.PAST,
                              filterset_name=EventList.chronoFilters)
                   .as_context(request, group_slug=group.slug))
     user_is_following = Follow.objects.filter(user_id=request.user.id,
@@ -161,7 +161,7 @@ def edit_group(request, form=None):
         form = GroupSettingsForm(instance=request.group, label_suffix='')
     event_list = (group_edit_events
                   .configure(chunk_size=3,
-                             active_filter=EventList.Filters.CURRENT,
+                             active_filter=EventList.Filters.PAST,
                              filterset_name=EventList.chronoFilters)
                   .as_context(request, group_slug=group.slug))
     pending_mappers = TrustedMapper.objects.filter(group=request.group,


### PR DESCRIPTION
* Remove "Events" page from menu
* Remove "Current" section from group events
* Remove "+ New" option when editing a group

To allow possible future use of the code I chose to comment out rather than delete.

Connects #1837