### PR TITLE
Update the azavea.beaver ansible role to the latest version

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -23,7 +23,7 @@ azavea.java,0.1.1
 azavea.curator,0.1.0
 azavea.ruby,0.3.0
 azavea.sauce-connect,0.2.0
-azavea.beaver,0.1.2
+azavea.beaver,1.0.0
 azavea.swapfile,0.1.0
 azavea.build-essential,0.1.0
 azavea.tasseo,0.1.1

--- a/deployment/ansible/roles/nyc-trees.beaver/vars/main.yml
+++ b/deployment/ansible/roles/nyc-trees.beaver/vars/main.yml
@@ -1,3 +1,2 @@
 ---
-beaver_version: "33.0.0"
 beaver_redis_url: "redis://{{ redis_host }}:{{ redis_port }}/0"


### PR DESCRIPTION
The latest version of azavea.beaver uses 36.2.0 for the beaver version.

Only the most recent version of Beaver can be installed, as one of its
dependencies was renamed and old versions were pulled from PyPi.