### PR TITLE
Add new achievements

### DIFF
--- a/src/nyc_trees/apps/home/tests.py
+++ b/src/nyc_trees/apps/home/tests.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from unittest import skip
+
 from waffle.models import Flag
 
 from django.test import TestCase
@@ -243,6 +245,7 @@ class HomeTestCase(UsersTestCase):
         response.assert_training_finished(False)
         response.assert_achievements_visible(False)
 
+    @skip("2015 achievements are now inactive")
     def test_online_trained_user_content(self):
         self._complete_user_online_training()
         response = self._render_homepage(self.user)

--- a/src/nyc_trees/apps/users/__init__.py
+++ b/src/nyc_trees/apps/users/__init__.py
@@ -103,9 +103,10 @@ def get_achievements_for_user(user):
         'achieved': [(key, achievements[key])
                      for key in achievements.iterkeys()
                      if key in user_achievements],
-        'remaining': [(key, achievements[key])
-                      for key in achievements.iterkeys()
-                      if key not in user_achievements],
+        'remaining': [
+            (key, achievements[key])
+            for key in achievements.iterkeys()
+            if key not in user_achievements and achievements[key].active],
         'all': achievements
     }
 

--- a/src/nyc_trees/apps/users/migrations/0008_auto_20160415_1550.py
+++ b/src/nyc_trees/apps/users/migrations/0008_auto_20160415_1550.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import apps.users.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0007_auto_20150505_1155'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='achievement',
+            name='achievement_id',
+            field=models.IntegerField(help_text=apps.users.models.achievement_help_text, choices=[(1, 'In Pursuit of Mappiness'), (0, 'Ready, Set, Roll'), (2, 'Treerifically Trained'), (3, 'Counter Cultured'), (4, 'Rolling Revolutionary'), (5, 'Mapping Machine'), (6, 'Sprout Mapper'), (7, 'Seedling Mapper'), (8, 'Sapling Mapper'), (9, 'Mayoral Mapper'), (10, 'Lavender Linden'), (11, 'Magenta Maple'), (12, 'Silver Sophora'), (13, 'Gold Gingko'), (14, 'Platinum Planetree'), (15, 'Four Season Mapper')]),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/users/migrations/0009_record_2015_achievements.py
+++ b/src/nyc_trees/apps/users/migrations/0009_record_2015_achievements.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from apps.core.models import User
+from apps.users.models import achievements, AchievementDefinition, Achievement
+
+
+untrained_achievements = {
+    AchievementDefinition.ONLINE_TRAINING, AchievementDefinition.FOLLOW_GROUPS}
+
+
+def update_inactive_achievements(user, is_untrained):
+    achieved_ids = set([a.achievement_id
+                        for a in user.achievement_set.all()])
+
+    for id, definition in achievements.iteritems():
+        if is_untrained and id not in untrained_achievements:
+            continue
+
+        if ((id not in achieved_ids and not definition.active and
+             definition.achieved(user))):
+            a = Achievement(user=user, achievement_id=id)
+            a.save()
+
+
+def record_achievements(apps, schema_editor):
+    # We use the real user model instead of the migration model in order to use
+    # its helper methods
+    users = User.objects.select_related('achievements')
+
+    untrained = users.filter(field_training_complete=False)
+    trained = users.filter(field_training_complete=True)
+
+    for user in untrained:
+        update_inactive_achievements(user, True)
+
+    for user in trained:
+        update_inactive_achievements(user, False)
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0008_auto_20160415_1550'),
+        ('core', '0031_auto_20150513_1536'),
+    ]
+
+    operations = [
+        migrations.RunPython(record_achievements, noop)
+    ]

--- a/src/nyc_trees/apps/users/tests.py
+++ b/src/nyc_trees/apps/users/tests.py
@@ -3,7 +3,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from datetime import timedelta
+from datetime import timedelta, datetime
+from unittest import skip
+
+from dateutil.relativedelta import relativedelta
 from waffle.models import Flag
 
 from django.contrib.auth.models import AnonymousUser
@@ -14,25 +17,25 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponseRedirect
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.timezone import now
+from django.utils.timezone import now, get_current_timezone
 
 from apps.core.models import User, Group
 from apps.core.test_utils import (make_request, make_event, make_tree,
-                                  make_survey, make_species,
+                                  make_survey, make_species, tree_defaults,
                                   complete_online_training, survey_defaults)
 
 from apps.event.models import EventRegistration
 from apps.event.routes import event_registration, check_in_user_to_event
 
-from apps.survey.models import Blockface, Territory, Survey
+from apps.home.routes import home_page
+
+from apps.survey.models import Blockface, Territory, Survey, Tree
 
 from apps.users.models import (Follow, Achievement, achievements,
                                AchievementDefinition, TrustedMapper,
                                update_achievements)
 from apps.users.views.user import user_detail as user_detail_view
 from apps.users.views.group import group_detail as group_detail_view
-
-from apps.home.routes import home_page
 from apps.users.routes.user import (user_detail as user_detail_route,
                                     request_individual_mapper_status)
 from apps.users.routes.group import (group_detail, group_edit,
@@ -570,6 +573,7 @@ class AchievementTests(UsersTestCase):
                             for a in self.user.achievement_set.all()])
         self.assertEqual(set(expected_ids), achieved_ids)
 
+    @skip("2015 achievements are now inactive")
     def testGroupFollows(self):
         self._assertAchievements([])
         for i in range(0, 5):
@@ -577,16 +581,19 @@ class AchievementTests(UsersTestCase):
             Follow.objects.create(group=group, user=self.user)
         self._assertAchievements([AchievementDefinition.FOLLOW_GROUPS])
 
+    @skip("2015 achievements are now inactive")
     def testOnlineTraining(self):
         self._assertAchievements([])
         complete_online_training(self.user)
         self._assertAchievements([AchievementDefinition.ONLINE_TRAINING])
 
+    @skip("2015 achievements are now inactive")
     def testTrainingEvent(self):
         self._assertAchievements([])
         self.user.field_training_complete = True
         self._assertAchievements([AchievementDefinition.TRAINING_EVENT])
 
+    @skip("2015 achievements are now inactive")
     def testMappingEvent(self):
         self._assertAchievements([])
         for title in {'Event 1', 'Event 2', 'Event 3'}:
@@ -595,6 +602,7 @@ class AchievementTests(UsersTestCase):
                                              did_attend=True)
         self._assertAchievements([AchievementDefinition.MAPPING_EVENT])
 
+    @skip("2015 achievements are now inactive")
     def test50Blocks(self):
         self._assertAchievements([])
         geom = MultiLineString(LineString(((0, 0), (1, 1))))
@@ -610,3 +618,43 @@ class AchievementTests(UsersTestCase):
 
         self._assertAchievements([AchievementDefinition.MAP_50,
                                   AchievementDefinition.MAP_100])
+
+    def test_600_trees(self):
+        self._assertAchievements([])
+        geom = MultiLineString(LineString(((0, 0), (1, 1))))
+        blockface = Blockface.objects.create(geom=geom)
+
+        survey = make_survey(self.user, blockface)
+
+        t = tree_defaults()
+        t['survey'] = survey
+
+        trees = [Tree(**t) for _ in xrange(0, 600)]
+        Tree.objects.bulk_create(trees)
+
+        self._assertAchievements([AchievementDefinition.TREES_100,
+                                  AchievementDefinition.TREES_300,
+                                  AchievementDefinition.TREES_500])
+
+    def test_four_seasons(self):
+        self._assertAchievements([])
+        tz = get_current_timezone()
+        july_2015 = datetime(2015, 7, 1, tzinfo=tz)
+
+        geom = MultiLineString(LineString(((0, 0), (1, 1))))
+        blocks = [Blockface(geom=geom) for i in range(0, 12)]
+        Blockface.objects.bulk_create(blocks)
+
+        surveys = []
+        s = survey_defaults()
+        for b in Blockface.objects.all():
+            s.update(user=self.user, blockface=b)
+            surveys.append(Survey(**s))
+        Survey.objects.bulk_create(surveys)
+
+        # Backdate created_at on each survey
+        for i, survey in enumerate(self.user.surveys):
+            survey.created_at = july_2015 + relativedelta(months=i)
+            survey.save()
+
+        self._assertAchievements([AchievementDefinition.FOUR_SEASONS])


### PR DESCRIPTION
New achievements are temporarily using the image for 'Mayoral Mapper'
until the final images are decided upon.

To enable showing what achievements a user already has, a data migration
will update achievements for all users to record their what their inactive
achievements are, since they are no longer active for 2016 and cannot be
unlocked with new surveys.

Connects to #1836