### PR TITLE
Show blockface ID on treecorder screen.

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -42,13 +42,16 @@
         </div>
         <div id="survey" class="hidden">
             <div id="tree-form-header">
-                <h4>Treecorder</h4>
+                <h4>Treecorder &ndash; Block <span data-block-id></span></h4>
             </div>
             <div id="tree-form-container" class="clearfix">
                 <a class="btn btn-warning btn-block" href="#no-trees-popup" data-toggle="modal" id="no-trees">No Trees On This Block</a>
                 {% include "survey/partials/tree_form.html" with tree_number=1 %}
             </div>
             <div class="tree-form-block">
+                <div class="field" id="preview-survey-container">
+                    <button class="btn btn-secondary btn-block" id="preview-survey">Preview Block <span data-block-id></span></button>
+                </div>
                 <div class="field">
                     <button class="btn btn-primary btn-block" id="another-tree">+ Another Tree</button>
                     <button class="btn btn-gray btn-block" id="no-further-trees">No Further Trees on Block</button>

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -100,7 +100,8 @@ var dom = {
         noTreesPopup: '#no-trees-popup',
         noTreesConfirm: '#no-trees-confirm',
 
-        treeHeading: '.sticky-title'
+        treeHeading: '.sticky-title',
+        blockId: '[data-block-id]'
     },
 
     showSelectStart = makeMutexShow([
@@ -198,6 +199,8 @@ function selectBlockface(data) {
     endPointLayers.addLayer(endCircle);
 
     showSelectStart();
+
+    $(dom.blockId).html(Number(blockfaceId).toLocaleString());
 }
 
 endPointLayers.setStyle(defaultStyle);

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -297,6 +297,20 @@
     top: -.75rem;
 }
 
+#preview-survey-container {
+    @media (max-width: $screen-sm - 1) {
+        padding: 0;
+
+        #preview-survey {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            border-radius: 0;
+        }
+    }
+}
+
 #survey {
     position: relative;  // for sticky titles
     background-color: #fff;


### PR DESCRIPTION
On mobile the ID is visible at all times on the preview button (previewing itself is not implemented yet).

I attempted to make the header "sticky" for the desktop view so that the blockface ID would always be visible for desktop users as well, but I ran into cross-browsers styling issues and decided to leave it as-is.

![treecorder1](https://cloud.githubusercontent.com/assets/4432106/14655302/abaceab6-064f-11e6-8cb4-0a5ecbeeec4c.png)

Connects to #1840