### PR TITLE
Fix loading tiles on progress map when logged out

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/progress.html
+++ b/src/nyc_trees/apps/survey/templates/survey/progress.html
@@ -10,8 +10,7 @@
     <div class="map-sidebar">
         <div class="map-sidebar-context block">
             <h2 class="pull-left">Progress</h2>
-            {% if request.user.is_authenticated %}
-                <div class="dropdown pull-right">
+            <div class="dropdown pull-right {% if not request.user.is_authenticated %}hidden{% endif %}">
                     <button type="button" class="btn btn-default dropdown-toggle progress-toggle" data-toggle="dropdown">
                         All Users
                     </button>
@@ -45,7 +44,6 @@
     {#                    </li>#}
                     </ul>
                 </div>
-            {% endif %}
             <div class="clear">
                 {% include 'survey/partials/progress_legend.html' %}
             </div>


### PR DESCRIPTION
We omitted the dropdown from the progress map when logged out, because
after removing the group view in 83aa2242 there was only a single mode
when not logged in.

This broke loading the tiles on the page, as JS reads the DOM to know
which mode is currently active.  Hiding the element instead of omitting it
fixes the issue while still leaving it not shown for logged out users.

Connects to #1845