### PR TITLE
Show preview button help popup when first visiting the treecorder

### DIFF
--- a/src/nyc_trees/apps/core/admin.py
+++ b/src/nyc_trees/apps/core/admin.py
@@ -93,7 +93,8 @@ class NycUserAdmin(UserAdmin):
 
         ('Help', {'fields': ('progress_page_help_shown',
                              'reservations_page_help_shown',
-                             'survey_geolocate_help_shown')})
+                             'survey_geolocate_help_shown',
+                             'survey_preview_help_shown')})
     )
 
     add_fieldsets = UserAdmin.add_fieldsets + (

--- a/src/nyc_trees/apps/core/migrations/0032_user_survey_preview_help_shown.py
+++ b/src/nyc_trees/apps/core/migrations/0032_user_survey_preview_help_shown.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0031_auto_20150513_1536'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='survey_preview_help_shown',
+            field=models.BooleanField(default=False, help_text='Seen preview button help text on Survey page?'),
+            preserve_default=True,
+        ),
+    ]

--- a/src/nyc_trees/apps/core/models.py
+++ b/src/nyc_trees/apps/core/models.py
@@ -137,6 +137,9 @@ class User(NycModel, AbstractUser):
     reservations_page_help_shown = models.BooleanField(
         default=False,
         help_text='Seen help text on Reservations page?')
+    survey_preview_help_shown = models.BooleanField(
+        default=False,
+        help_text='Seen preview button help text on Survey page?')
 
     reservation_ids_in_map_pdf = models.TextField(
         default='', blank=True,

--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -165,6 +165,28 @@
     </div>
 </div>
 
+{% if not preview_help_shown %}
+<div class="modal fade" id="preview-button-help" tabindex="-1" role="dialog" aria-labelledby="preview-button-help-title" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close btn btn-link pull-right" data-dismiss="modal">
+                    <span aria-hidden="true">×</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title" id="preview-button-help-title">Treecorder</h4>
+            </div>
+            <div class="modal-body">
+                <p>Welcome to the Treecorder!</p>
+                <h5>Block Preview</h5>
+                <p>Click on the "<i>Preview Block</i>" button at any time during your Treecorder session to
+                   get an overall glimpse of your progress on the current block.</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 {% include "survey/partials/map_another_popup.html" %}
 
 {% endblock extra_content %}

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -489,6 +489,8 @@ def start_survey(request):
         'no_more_reservations': reservations_for_user <= 1,
         'geolocate_help_shown': _was_help_shown(request,
                                                 'survey_geolocate_help_shown'),
+        'preview_help_shown': _was_help_shown(request,
+                                              'survey_preview_help_shown'),
     }
 
 
@@ -512,6 +514,8 @@ def start_survey_from_event(request, event_slug):
         'choices': _get_survey_choices(),
         'geolocate_help_shown': _was_help_shown(request,
                                                 'survey_geolocate_help_shown'),
+        'preview_help_shown': _was_help_shown(request,
+                                              'survey_preview_help_shown'),
     }
 
 

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -91,6 +91,8 @@ var dom = {
         quitReason: '#quit-reason',
         quit: '#quit',
 
+        previewHelpPopup: '#preview-button-help',
+
         btnGroupToTeammate: '#btn-group-to-teammate',
         btnToTeammate: '#btn-to-teammate',
         selectTeammate: '#select-teammate',
@@ -405,6 +407,10 @@ $(dom.btnNext).click(function(e) {
     blockfaceMap.removeLayer(grid);
     mapModule.hideCrosshairs();
     mapModule.stopTrackingUserPosition(blockfaceMap);
+
+    if ($(dom.previewHelpPopup).length > 0) {
+        $(dom.previewHelpPopup).modal('show');
+    }
 });
 
 $(dom.addTree).click(function (){


### PR DESCRIPTION
To test, log in, reserve a block edge, and visit the treecorder.
Upon first getting to the data entry part of the treecorder you should see
a modal.  On later uses of the treecorder you should not see a modal.

Connects to #1842