### PR TITLE
Add ability to preview survey before submitting it

### DIFF
--- a/src/nyc_trees/apps/survey/routes.py
+++ b/src/nyc_trees/apps/survey/routes.py
@@ -92,6 +92,9 @@ survey_detail = individual_mapper_do(
     route(GET=do(render_template('survey/survey_detail.html'),
                  v.survey_detail)))
 
+survey_preview = login_required(
+    route(POST=json_api_call(v.survey_preview)))
+
 confirm_survey = individual_mapper_do(
     route(GET=do(render_template('survey/survey_detail.html'),
                  update_with({'show_controls': True}),

--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -50,7 +50,7 @@
             </div>
             <div class="tree-form-block">
                 <div class="field" id="preview-survey-container">
-                    <button class="btn btn-secondary btn-block" id="preview-survey">Preview Block <span data-block-id></span></button>
+                    <button class="btn btn-secondary btn-block preview-btn" id="preview-survey">Preview Block <span data-block-id></span></button>
                 </div>
                 <div class="field">
                     <button class="btn btn-primary btn-block" id="another-tree">+ Another Tree</button>
@@ -77,6 +77,9 @@
                 <img src="{{ "img/logo-treekit.png"|static_url }}" alt="TreeKit" />
             </div>
         </div>
+        <div id="close-preview-section" class="hidden">
+            <button class="btn btn-secondary btn-block preview-btn" id="close-preview">Close Block Preview</button>
+        </div>
     </div>
 </div>
 
@@ -100,6 +103,7 @@
                 {% elif location %}data-location="{{ location }}" data-zoom="LOCATION"
                 {% endif %}>
             </div>
+            <div id="preview-map" class="map-survey preview-map hidden"></div>
         </div>
     </div>
 {% endblock main %}

--- a/src/nyc_trees/apps/survey/tests.py
+++ b/src/nyc_trees/apps/survey/tests.py
@@ -8,6 +8,7 @@ import json
 from datetime import timedelta
 
 from waffle.models import Flag
+from django_tinsel.exceptions import HttpBadRequestException
 
 from functools import partial
 
@@ -15,7 +16,6 @@ from django.contrib.gis.geos import LineString, MultiLineString
 from django.conf import settings
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db import connection
-from django.http import HttpResponseBadRequest
 from django.test import TestCase
 from django.utils.timezone import now
 
@@ -130,12 +130,12 @@ class SurveySubmitTests(SurveyTestCase):
         self.assertEqual(tree.problems, 'Stones,Sneakers')
 
     def test_missing_trees(self):
-        error = self.submit_survey({'has_trees': True}, [])
-        self.assertTrue(isinstance(error, HttpResponseBadRequest))
+        with self.assertRaises(HttpBadRequestException):
+            self.submit_survey({'has_trees': True}, [])
 
     def test_extra_trees(self):
-        error = self.submit_survey({'has_trees': False}, [tree_defaults()])
-        self.assertTrue(isinstance(error, HttpResponseBadRequest))
+        with self.assertRaises(HttpBadRequestException):
+            self.submit_survey({'has_trees': False}, [tree_defaults()])
 
     def test_missing_blockface(self):
         with self.assertRaises(ObjectDoesNotExist):

--- a/src/nyc_trees/apps/survey/urls/survey.py
+++ b/src/nyc_trees/apps/survey/urls/survey.py
@@ -6,7 +6,7 @@ from __future__ import division
 from django.conf.urls import patterns, url
 
 from apps.survey.routes import (survey, survey_from_event,
-                                flag_survey, survey_detail,
+                                flag_survey, survey_detail, survey_preview,
                                 confirm_survey, confirm_survey_from_event,
                                 restart_blockface, teammates_for_mapping)
 
@@ -37,5 +37,9 @@ urlpatterns = patterns(
 
     # Note: changes here must be kept in sync with
     # src/nyc_trees/js/src/surveyPage.js
-    url(r'^teammates/$', teammates_for_mapping)
+    url(r'^teammates/$', teammates_for_mapping),
+
+    # Note: changes here must be kept in sync with
+    # src/nyc_trees/js/src/surveyPage.js
+    url(r'^preview/$', survey_preview)
 )

--- a/src/nyc_trees/apps/survey/views.py
+++ b/src/nyc_trees/apps/survey/views.py
@@ -10,6 +10,8 @@ from pytz import timezone
 
 from celery import chain
 
+from django_tinsel.exceptions import HttpBadRequestException
+
 from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ValidationError, PermissionDenied
@@ -618,6 +620,21 @@ def restart_blockface(request, survey_id):
     return {'success': True}
 
 
+def _get_survey_data(request):
+    data = json.loads(request.body)
+    survey_data = data['survey']
+    tree_list = data.get('trees', [])
+
+    survey = Survey(user=request.user, **survey_data)
+
+    if survey.has_trees and len(tree_list) == 0:
+        raise HttpBadRequestException('Trees expected but absent')
+    if not survey.has_trees and len(tree_list) > 0:
+        raise HttpBadRequestException('Trees not expected but present')
+
+    return survey, tree_list
+
+
 @transaction.atomic
 def _create_survey_and_trees(request, event=None):
     """
@@ -630,17 +647,7 @@ def _create_survey_and_trees(request, event=None):
     }
     trees.problems should be a list of problem codes -- ["Stones", "Sneakers"]
     """
-    data = json.loads(request.body)
-    survey_data = data['survey']
-    tree_list = data.get('trees', [])
-
-    survey = Survey(user=request.user, **survey_data)
-
-    if survey.has_trees and len(tree_list) == 0:
-        return HttpResponseBadRequest('Trees expected but absent')
-    if not survey.has_trees and len(tree_list) > 0:
-        return HttpResponseBadRequest('Trees not expected but present')
-
+    survey, tree_list = _get_survey_data(request)
     blockface = survey.blockface
 
     if event:
@@ -691,15 +698,35 @@ def flag_survey(request, survey_id):
 
 def _survey_detail(request, survey_id):
     survey = Survey.objects.get(id=survey_id)
-    with connection.cursor() as cursor:
-        cursor.execute(_SURVEY_DETAIL_QUERY, [survey_id])
-        trees = [tree[0] for tree in cursor]
+    trees = survey.tree_set \
+        .values('distance_to_tree', 'curb_location') \
+        .order_by('id')
+
     return {
         'survey_id': survey_id,
         'blockface_id': survey.blockface_id,
-        'trees': json.dumps(trees),
+        'trees': json.dumps(_survey_geojson(survey, trees)),
         'bounds': list(survey.blockface.geom.extent),
     }
+
+
+def _survey_geojson(survey, trees):
+    tree_distances = [float(tree['distance_to_tree']) for tree in trees]
+    tree_offsets = [2.5 if tree['curb_location'] == 'OnCurb' else 12
+                    for tree in trees]
+
+    params = {
+        'blockface_id': survey.blockface_id,
+        'survey_dir': survey.is_mapped_in_blockface_polyline_direction,
+        'left_side': survey.is_left_side,
+        'tree_distances': tree_distances,
+        'tree_offsets': tree_offsets
+    }
+    with connection.cursor() as cursor:
+        cursor.execute(_SURVEY_DETAIL_QUERY, params)
+        trees = [tree[0] for tree in cursor]
+
+    return trees
 
 
 def survey_detail_from_event(request, event_slug, survey_id):
@@ -713,6 +740,11 @@ def survey_detail(request, survey_id):
         BlockfaceReservation.objects.remaining_for(request.user))
     ctx.update({'no_more_reservations': reservations_for_user == 0})
     return ctx
+
+
+def survey_preview(request):
+    survey, tree_list = _get_survey_data(request)
+    return [json.loads(tree) for tree in _survey_geojson(survey, tree_list)]
 
 
 def admin_territory_page(request):

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -21,7 +21,12 @@
     left: 0;
     right: 0;
     @media (max-width: $screen-sm - 1) {
-        bottom: 20rem;
+        #map {
+            bottom: 20rem;
+        }
+        #preview-map {
+            bottom: 4rem;
+        }
     }
     @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
         top: 4.5rem;
@@ -62,6 +67,9 @@
             @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
                 top: 4.5rem;
             }
+        }
+        &.skinny {
+            height: 4rem;
         }
     }
 
@@ -300,14 +308,16 @@
 #preview-survey-container {
     @media (max-width: $screen-sm - 1) {
         padding: 0;
+    }
+}
 
-        #preview-survey {
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            border-radius: 0;
-        }
+@media (max-width: $screen-sm - 1) {
+    .preview-btn {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        border-radius: 0;
     }
 }
 


### PR DESCRIPTION
Builds on top of 4a26f2f, which is not part of this PR.

Alters `survey_detail.sql` to operate based on passed in parameters,
allowing us to show a preview screen without having to save the survey to
the database.

To test:
 - Ensure there are no regressions in showing the survey detail page
 - Test that the survey preview looks correct
 - Test that the scroll position is correct and all elements are shwon/hidden appropriately after showing/hiding the preview

Connects to #1841