### PR TITLE
Survey preview improvements

### DIFF
--- a/src/nyc_trees/apps/survey/templates/survey/survey.html
+++ b/src/nyc_trees/apps/survey/templates/survey/survey.html
@@ -79,6 +79,7 @@
         </div>
         <div id="close-preview-section" class="hidden">
             <button class="btn btn-secondary btn-block preview-btn" id="close-preview">Close Block Preview</button>
+            <button class="btn btn-warning btn-block preview-btn" id="restart-survey">Restart Block</button>
         </div>
     </div>
 </div>

--- a/src/nyc_trees/js/src/map.js
+++ b/src/nyc_trees/js/src/map.js
@@ -33,8 +33,8 @@ function createAndGetControls(options) {
     }, options);
 
     var mapOptions = {
-        minZoom: zoom.MIN,
-        maxZoom: zoom.MAX,
+        minZoom: options.minZoom || zoom.MIN,
+        maxZoom: options.maxZoom || zoom.MAX,
         attributionControl: false,
         zoomControl: false,
         maxBounds: L.latLngBounds(config.bounds[0], config.bounds[1]).pad(4)

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -108,6 +108,7 @@ var dom = {
         previewButton: '#preview-survey',
         closePreviewSection: '#close-preview-section',
         closePreview: '#close-preview',
+        restartSurvey: '#restart-survey',
 
         blockfaceMapId: 'map',
         previewMapId: 'preview-map'
@@ -930,3 +931,8 @@ if (!helpShown) {
         $('.geolocate-help').hide();
     });
 }
+
+$(dom.restartSurvey).on('click', function() {
+    window.location.hash = blockfaceId;
+    window.location.reload();
+});

--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -506,13 +506,14 @@ function showPreview(trees) {
     $('#' + dom.blockfaceMapId).addClass('hidden');
     $('#' + dom.previewMapId).removeClass('hidden');
 
+    var bounds = selectedLayer.getBounds();
     if (previewMap === null) {
         previewMap = mapModule.create({
             domId: dom.previewMapId,
             legend: false,
             search: false,
             baseMap: mapModule.SATELLITE,
-            bounds: selectedLayer.getBounds()
+            minZoom: blockfaceMap.getBoundsZoom(bounds) - 1,
         });
         previewLayer = new L.geoJson(null, {
             pointToLayer: function(feature, latLng) {
@@ -521,6 +522,9 @@ function showPreview(trees) {
         });
         previewLayer.addTo(previewMap);
     }
+    previewMap.fitBounds(bounds);
+    previewMap.setMaxBounds(bounds);
+
     previewLayer.clearLayers();
     previewLayer.addData(selectedLayer.toGeoJSON());
     previewLayer.setStyle(mapUtil.styledStreetConfirmation);

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -354,7 +354,6 @@
 
 #treeform-sponsor {
     text-align: center;
-    margin-top: 30px;
     background: #f3f3f3;
     margin-bottom: -10px;
     position: absolute;
@@ -363,6 +362,7 @@
         width: auto;
         left: -2rem;
         right: -2rem;
+        margin-top: 30px;
     }
     span {
         font-size: $font-size-small;

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -315,9 +315,19 @@
     .preview-btn {
         position: fixed;
         bottom: 0;
+        border-radius: 0;
+        width: 50%;
+    }
+    #close-preview {
+        left: 0;
+    }
+    #restart-survey {
+        right: 0;
+    }
+    #preview-survey {
         left: 0;
         right: 0;
-        border-radius: 0;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
 - Add button to survey preview to restart survey.
 - Slight style fix to tree sponsor section on mobile
 - Improve setting bounds when showing preview map, and prevent zooming or panning away from the blockedge

Connects to #1858 
Connects to #1859