### PR TITLE
Meet Paramiko dependency before installing Ansible

### DIFF
--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -77,6 +77,7 @@
         "sleep 5",
         "sudo apt-get update -qq",
         "sudo apt-get install python-pip python-dev -y",
+        "sudo pip install paramiko==1.16.0",
         "sudo pip install ansible==2.0.1.0"
       ]
     },


### PR DESCRIPTION
The loose dependency on Paramiko is pulling in a version with a backwards incompatible change, which is causing the Ansible install to fail. Until Ansible addresses this issue, I'd rather explicitly install an older version of Paramiko that satisfies Ansible dependency requirements.

See also: ansible/ansible#15665

---

**Testing**

See if http://civicci01.internal.azavea.com/view/nyc-trees/job/nyc-trees-packer/647/ succeeds.