### PR TITLE
fix #1866. map no longer cut off or showing through on the survey for…

### DIFF
--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -68,6 +68,14 @@
             @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
                 top: 4.5rem;
             }
+            /**
+             * iPhone 5
+             * Fixes vh unit issue
+             */
+            @media screen and (device-aspect-ratio: 40/71) {
+              min-height: 540px;
+              background: #F3F3F3;
+            }
         }
         &.skinny {
             height: 4rem;
@@ -343,6 +351,11 @@
 
     @media (max-width: $screen-sm - 1) {
         min-height: 93vh;
+    }
+    
+    // Fixes vh unit issue
+    @media screen and (device-aspect-ratio: 40/71) {
+        min-height: 540px;
     }
 }
 

--- a/src/nyc_trees/sass/partials/_survey.scss
+++ b/src/nyc_trees/sass/partials/_survey.scss
@@ -20,16 +20,17 @@
     bottom: 0;
     left: 0;
     right: 0;
-    @media (max-width: $screen-sm - 1) {
-        #map {
-            bottom: 20rem;
-        }
-        #preview-map {
-            bottom: 4rem;
-        }
-    }
     @media (max-height: $screen-xs-height) and (max-width: $screen-sm) {
         top: 4.5rem;
+    }
+}
+
+@media (max-width: $screen-sm - 1) {
+    #map {
+        bottom: 20rem;
+    }
+    #preview-map {
+        bottom: 4rem;
     }
 }
 
@@ -339,6 +340,10 @@
     .tree-form .btn-group > input:first-child + .btn {
         border-radius: $border-radius-base 0 0 $border-radius-base;
     }
+
+    @media (max-width: $screen-sm - 1) {
+        min-height: 93vh;
+    }
 }
 
 .distance-end-form {
@@ -363,6 +368,10 @@
         left: -2rem;
         right: -2rem;
         margin-top: 30px;
+    }
+    @media (max-width: $screen-sm - 1) {
+        bottom: 0;
+        margin-bottom: -5rem;
     }
     span {
         font-size: $font-size-small;


### PR DESCRIPTION
@maurizi It turns out the sliver of map peaking through was there. On mobile, you needed to add a second tree and then collapse the trees. The sidebar wouldnt be tall enough to cover the screen.

This PR should fix that.