### PR TITLE
Fix map not showing when switching between preview map and normal map

### DIFF
--- a/src/nyc_trees/js/src/surveyPage.js
+++ b/src/nyc_trees/js/src/surveyPage.js
@@ -522,6 +522,10 @@ function showPreview(trees) {
         });
         previewLayer.addTo(previewMap);
     }
+    // If the browser window is resized when the preview map is hidden
+    // (from the phone switching orientation for example), the map won't display properly
+    // Calling .invalidateSize() should fix that
+    previewMap.invalidateSize();
     previewMap.fitBounds(bounds);
     previewMap.setMaxBounds(bounds);
 
@@ -546,6 +550,11 @@ $(dom.closePreview).click(function () {
     } else {
         $(dom.mapSidebar).scrollTop(savedScrollPosition);
     }
+    //
+    // If the browser window is resized when the blockface map is hidden
+    // (from the phone switching orientation for example), the map won't display properly
+    // Calling .invalidateSize() should fix that
+    blockfaceMap.invalidateSize();
 });
 
 function getScrollToTopPosition($el) {


### PR DESCRIPTION
When changing the map element size (e.g if the phone orientation changes),
if the map is not currently visible it will get stuck in an invalid state.

Calling `.invalidateSize()` when switching between the preview map and the
normal survey map will cause Leaflet to requery the DOM for the map size,
fixing the issue.

I wasn't able to create issues with the normal survey map, but I put in a call to `invalidateSize()` for it when hiding the preview map, since it can't really hurt matters.

To test:
 - On the develop branch, show the preview map, close it, resize the browser window, and show the preview map again.  You should see the issue reported in #1867.
 - On this branch, repeat the same steps.  You should not experience the issue.

Connects to #1867