### PR TITLE
Bump Apache and JVM versions

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -22,5 +22,5 @@ elasticsearch_cluster_name: "logstash"
 
 nodejs_npm_version: 2.1.14
 
-java_version: "7u95-*"
+java_version: "7u101-*"
 relp_version: "7.4.4-*"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,5 +1,5 @@
 - src: azavea.apache2
-  version: 0.2.2
+  version: 0.2.4
 
 - src: azavea.ntp
   version: 0.1.1


### PR DESCRIPTION
Version 7u95 of the OpenJDK JVM is no longer available.

See also: azavea/ansible-apache2#5