### PR TITLE
Use AliasTarget keyword arguments for parameters

### DIFF
--- a/deployment/deployment-helper.sh
+++ b/deployment/deployment-helper.sh
@@ -70,8 +70,8 @@ toggle_app_server_stack() {
   AWS_STACKS=$(aws cloudformation describe-stacks | grep STACKS | cut -f7)
   AWS_APP_STACK_OUTPUTS=$(get_stack_outputs "NYCTrees${1}AppServers")
 
-  AWS_ELB_APP_ENDPOINT=$(echo $AWS_APP_STACK_OUTPUTS | grep "AppServerLoadBalancerEndpoint" | cut -d' ' -f2)
-  AWS_ELB_APP_HOSTED_ZONE_ID=$(echo $AWS_APP_STACK_OUTPUTS | grep "AppServerLoadBalancerHostedZoneNameID" | cut -d' ' -f4)
+  AWS_ELB_APP_ENDPOINT=$(echo $AWS_APP_STACK_OUTPUTS | grep "AppServerLoadBalancerEndpoint" | awk '{ print $4 }')
+  AWS_ELB_APP_HOSTED_ZONE_ID=$(echo $AWS_APP_STACK_OUTPUTS | grep "AppServerLoadBalancerHostedZoneNameID" | awk '{ print $2 }')
 
   # Build parameters argument
   AWS_STACK_PARAMS="ParameterKey=PublicHostedZone,ParameterValue=${AWS_PUBLIC_HOSTED_ZONE}"
@@ -99,8 +99,8 @@ toggle_tile_server_stack() {
   AWS_TILE_STACK_OUTPUTS=$(get_stack_outputs "NYCTrees${1}TileServers")
 
   AWS_VPC_ID=$(echo "${AWS_VPC_STACK_OUTPUTS}" | grep "VpcId" | cut -f2)
-  AWS_ELB_TILE_ENDPOINT=$(echo $AWS_TILE_STACK_OUTPUTS | grep "TileServerLoadBalancerEndpoint" | cut -d' ' -f2)
-  AWS_ELB_TILE_HOSTED_ZONE_ID=$(echo $AWS_TILE_STACK_OUTPUTS | grep "TileServerLoadBalancerHostedZoneNameID" | cut -d' ' -f4)
+  AWS_ELB_TILE_ENDPOINT=$(echo $AWS_TILE_STACK_OUTPUTS | grep "TileServerLoadBalancerEndpoint" | awk '{ print $4 }')
+  AWS_ELB_TILE_HOSTED_ZONE_ID=$(echo $AWS_TILE_STACK_OUTPUTS | grep "TileServerLoadBalancerHostedZoneNameID" | awk '{ print $2 }')
   AWS_PRIVATE_HOSTED_ZONE_ID=$(aws route53 list-hosted-zones | grep -B1 "${AWS_VPC_ID}" | grep -v "${AWS_VPC_ID}" | cut -f3 | cut -d'/' -f3)
 
   # Build parameters argument

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,4 +1,4 @@
 ansible==2.0.1.0
-awscli==1.10.16
+awscli==1.10.51
 boto==2.39.0
-troposphere==1.5.0
+troposphere==1.7.0

--- a/deployment/troposphere/app_hosted_zone_template.py
+++ b/deployment/troposphere/app_hosted_zone_template.py
@@ -40,12 +40,12 @@ public_dns_records_sets = t.add_resource(r53.RecordSetGroup(
         r53.RecordSet(
             'dnsAppServers',
             AliasTarget=r53.AliasTarget(
-                Ref(app_server_load_balancer_hosted_zone_id_param),
-                Join(
+                HostedZoneId=Ref(
+                    app_server_load_balancer_hosted_zone_id_param),
+                DNSName=Join(
                     '',
-                    [Ref(app_server_hosted_zone_alias_target_param), '.']
-                ),
-                True
+                    [Ref(app_server_hosted_zone_alias_target_param), '.']),
+                EvaluateTargetHealth=True
             ),
             Failover='PRIMARY',
             Name=Ref(hosted_zone_name_param),

--- a/deployment/troposphere/tiler_hosted_zone_template.py
+++ b/deployment/troposphere/tiler_hosted_zone_template.py
@@ -51,12 +51,12 @@ public_dns_records_sets = t.add_resource(r53.RecordSetGroup(
         r53.RecordSet(
             'dnsTileServers',
             AliasTarget=r53.AliasTarget(
-                Ref(tile_server_load_balancer_hosted_zone_id_param),
-                Join(
+                HostedZoneId=Ref(
+                    tile_server_load_balancer_hosted_zone_id_param),
+                DNSName=Join(
                     '',
-                    [Ref(tile_server_hosted_zone_alias_target_param), '.']
-                ),
-                True
+                    [Ref(tile_server_hosted_zone_alias_target_param), '.']),
+                EvaluateTargetHealth=True
             ),
             Name=Join('', ['tiles.', Ref(hosted_zone_name_param), '.']),
             Type='A'


### PR DESCRIPTION
Ensure that we are supplying arguments to the `AliasTarget` resource in the correct way. Previously, keyword arguments were not available, so the order of constructor arguments meant something. That meaning was altered along the way, which led to silent parameter swapping.

---

**Testing**

The [`nyc-trees-staging-deployment`](http://civicci01.internal.azavea.com/view/nyc-trees/job/nyc-trees-staging-deployment/497/console) job in Jenkins already executed a deployment to staging with the changes in this PR. Ensure that the application is working correctly with whatever new changes were introduced.