### PR TITLE
Add management command to calculate tree locations from CSV

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -22,5 +22,5 @@ elasticsearch_cluster_name: "logstash"
 
 nodejs_npm_version: 2.1.14
 
-java_version: "7u111-*"
+java_version: "7u*"
 relp_version: "7.4.4-*"

--- a/deployment/ansible/roles/nyc-trees.app/tasks/dev-and-test-dependencies.yml
+++ b/deployment/ansible/roles/nyc-trees.app/tasks/dev-and-test-dependencies.yml
@@ -8,7 +8,7 @@
     - Restart nyc-trees-app
 
 - name: Install Firefox for UI tests
-  apt: pkg="firefox=4*" state=present
+  apt: pkg="firefox" state=present
 
 - name: Install Xvfb for JavaScript tests
   apt: pkg="xvfb=2:1.15.1*" state=present

--- a/src/nyc_trees/apps/survey/management/commands/treecorder.py
+++ b/src/nyc_trees/apps/survey/management/commands/treecorder.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import sys
+import csv
+import json
+import fileinput
+import itertools
+
+from collections import namedtuple
+
+from django.core.management.base import BaseCommand
+
+from apps.survey.models import Survey
+from apps.survey.views import _survey_geojson
+
+
+Record = namedtuple('Record', ['report_id',
+                               'plot_number',
+                               'block_face_number',
+                               'tree_id_number',
+                               'distance_along_curb',
+                               'distance_along_curb_units',
+                               'street_side_numbers',
+                               'on_st',
+                               'from_st',
+                               'to_st',
+                               'address_order',
+                               'side_of_centerline'])
+
+
+class Command(BaseCommand):
+    """
+    Execute the Treekit geometry constructor for each row of tree data
+    in a CSV file. The output CSV should match the original input with
+    additional columns for lat/lng.
+    """
+
+    def handle(self, *args, **options):
+        fp = fileinput.input('-')
+        reader = csv.reader(fp)
+        writer = csv.writer(sys.stdout)
+
+        headers = reader.next()
+        headers = headers + ['LAT', 'LNG']
+        writer.writerow(headers)
+
+        records = (Record(*line) for line in reader)
+
+        # Group rows in chunks by block_face_number. Assumes that the CSV
+        # is sorted by block_face_number.
+        grouped_records = itertools.groupby(records,
+                                            lambda r: r.block_face_number)
+
+        for blockface_id, rows in grouped_records:
+            rows = list(rows)
+            survey = self.create_survey(rows[0])
+
+            if not survey.blockface_id:
+                continue
+
+            trees = list(self.create_trees(rows))
+
+            # Execute Treekit geometry constructor to determine
+            # tree locations.
+            points = _survey_geojson(survey, trees)
+
+            # Parse GeoJSON result.
+            points = (json.loads(p) for p in points)
+
+            # Combine tree location with original CSV row.
+            for row, point in itertools.izip(rows, points):
+                lat, lng = point['coordinates']
+                writer.writerow(row + (lat, lng))
+
+    def create_survey(self, row):
+        """
+        Return fake survey with the minimum amount of information
+        necessary to generate tree locations.
+        """
+        survey = Survey()
+        survey.blockface_id = row.block_face_number
+        survey.is_left_side = row.side_of_centerline == 'Left'
+
+        # TODO: How to determine if they started at the beginning
+        # or end of blockface?
+        survey.is_mapped_in_blockface_polyline_direction = True
+
+        return survey
+
+    def create_trees(self, rows):
+        """
+        Return survey formatted data to calculate tree locations.
+        Assumes all rows belong to the same blockface.
+        """
+        rows = list(rows)
+        for row in rows:
+            distance_to_tree = float(row.distance_along_curb or 0)
+
+            # Add distances from trees behind current tree.
+            for other in rows:
+                if other.tree_id_number < row.tree_id_number:
+                    distance_to_tree += float(other.distance_along_curb or 0)
+
+            yield {
+                'distance_to_tree': distance_to_tree,
+                'curb_location': 'OnCurb',
+            }

--- a/src/nyc_trees/requirements/development.txt
+++ b/src/nyc_trees/requirements/development.txt
@@ -2,5 +2,6 @@
 
 coverage==3.6
 django-debug-toolbar==1.2
+sqlparse==0.1
 Sphinx==1.2b1
 ipdb==0.8


### PR DESCRIPTION
This command scans a CSV file of survey data and executes the Treekit geometry construction algorithm to calculate tree locations.
Lat/lng fields are appended to each row of the original CSV.

This builds on top of work done by @kdeloach, and adds the ability to determine which end of the blockface the survey was started at by comparing the distance from the newly provided X/Y points to both the start and ends of the blockface geometry.

I also corrected a bug in the original command: the command was making the `distance_to_tree` field be from the start of the blockface for each tree, but the geometry constructor expects `distance_to_tree` to be the distance from the previous tree (or the start of the blockface) which is conveniently what the spreadsheet provides.

There were a number of duplicate rows in the provided spreadsheet, as well as several rows with no blockface ID. I decided to drop any rows with no Blockface ID, as well as drop any duplicate rows.

This is the input CSV I used (it is the `WITH_XY` sheet of the provided spreadsheet, sorted by Blockface ID and Tree ID).
[2016_11_23_NYC_Parks_Data_for_Treecorder.txt](https://github.com/azavea/nyc-trees/files/714938/2016_11_23_NYC_Parks_Data_for_Treecorder.txt)

This is the output I received.
[output.txt](https://github.com/azavea/nyc-trees/files/720508/output.txt)

I verified my results by manually running through the Treecorder for Blockface `203652`, and verified that the Lat/Lng provided by the Geometry Constructor when used via the UI matched the Lat/Lng provided by this command.

Connects to #1879 